### PR TITLE
Installer branch picker: choose which branch to install from

### DIFF
--- a/bin/switch_branch.sh
+++ b/bin/switch_branch.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Switch PiFinder_Stellarmate to a different branch before self_update.sh
+# runs - a distinct, deliberate step from self-update's own job (fast-
+# forwarding whichever branch is ALREADY checked out). A pure no-op unless
+# a branch is explicitly requested, so every existing entry point is
+# unaffected when this isn't used.
+#
+# Usage: source this near the very top of an entry-point script (before
+# self_update.sh runs), then call
+#   switch_pifinder_stellarmate_branch "$SCRIPT_DIR" "$TARGET_BRANCH"
+# TARGET_BRANCH may be empty (no-op) - this is what makes the --branch=
+# flag optional everywhere it's accepted.
+#
+# Safety model (mirrors self_update.sh): a dirty working tree aborts loudly
+# rather than risking losing local changes on a checkout - this is meant to
+# be an explicit, occasional action, not something that silently discards
+# work in progress.
+
+switch_pifinder_stellarmate_branch() {
+    local repo_dir="$1"
+    local target_branch="$2"
+
+    if [ -z "$target_branch" ]; then
+        return 0
+    fi
+
+    if ! git -C "$repo_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "❌ Branch switch FAILED: ${repo_dir} is not a git checkout." >&2
+        exit 1
+    fi
+
+    local current_branch
+    current_branch="$(git -C "$repo_dir" symbolic-ref --short -q HEAD)"
+    if [ "$current_branch" = "$target_branch" ]; then
+        echo "✅ Branch: already on '${target_branch}'."
+        return 0
+    fi
+
+    if [ -n "$(git -C "$repo_dir" status --porcelain 2>/dev/null)" ]; then
+        echo "❌ Branch switch FAILED: local changes present in ${repo_dir} - commit, stash, or" >&2
+        echo "   discard them first (same dev-mode safety as self_update.sh)." >&2
+        exit 1
+    fi
+
+    echo "🔄 Switching ${repo_dir} from '${current_branch:-detached HEAD}' to '${target_branch}' ..."
+    if ! git -C "$repo_dir" fetch --quiet origin "$target_branch"; then
+        echo "❌ Branch switch FAILED: 'git fetch origin ${target_branch}' did not succeed" >&2
+        echo "   (branch doesn't exist on origin? no network?)." >&2
+        exit 1
+    fi
+
+    if git -C "$repo_dir" show-ref --verify --quiet "refs/heads/${target_branch}"; then
+        # Local branch already exists (e.g. switching back to one used
+        # before) - just fast-forward it, same guarantee self_update.sh
+        # gives for the branch you started on.
+        if ! git -C "$repo_dir" checkout --quiet "$target_branch"; then
+            echo "❌ Branch switch FAILED: 'git checkout ${target_branch}' did not succeed." >&2
+            exit 1
+        fi
+        if ! git -C "$repo_dir" merge --ff-only --quiet "origin/${target_branch}"; then
+            echo "❌ Branch switch FAILED: local '${target_branch}' has diverged from" >&2
+            echo "   'origin/${target_branch}' (not a fast-forward). Resolve manually:" >&2
+            echo "   cd ${repo_dir} && git status" >&2
+            exit 1
+        fi
+    else
+        if ! git -C "$repo_dir" checkout --quiet -t "origin/${target_branch}"; then
+            echo "❌ Branch switch FAILED: 'git checkout -t origin/${target_branch}' did not" >&2
+            echo "   succeed - does that branch exist on origin? Check the name and try again." >&2
+            exit 1
+        fi
+    fi
+
+    echo "✅ Branch: now on '${target_branch}' (up to date with origin)."
+}

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -33,7 +33,7 @@ PORT = 8765
 # Same account + mechanism PiFinder's own Remote login checks
 # (sys_utils.verify_password("stellarmate", password)) - one password to
 # remember for both. Only the page and state-changing actions require it;
-# /state and /log stay open so PiFinder's INDI Drivers page can cross-origin
+# /state and /log stay open so PiFinder's PFSM page can cross-origin
 # poll status and show "Setup Wizard is running" without a login prompt.
 AUTH_USER = "stellarmate"
 AUTH_REALM = "PiFinder Setup"
@@ -985,7 +985,21 @@ def _reader_thread(proc):
         _exit_code = proc.returncode
 
 
-def _start_run(action):
+def _current_pifinder_stellarmate_branch():
+    """Best-effort - None if this isn't a git checkout or the command fails,
+    which the branch-picker UI treats as "can't tell, show nothing"."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "symbolic-ref", "--short", "-q", "HEAD"],
+            capture_output=True, text=True, timeout=5,
+        )
+        branch = result.stdout.strip()
+        return branch if result.returncode == 0 and branch else None
+    except Exception:
+        return None
+
+
+def _start_run(action, branch=None):
     global _running, _exit_code, _process, _lines, _phase_index, _reboot_needed, _last_action
     with _lock:
         if _running:
@@ -1001,6 +1015,8 @@ def _start_run(action):
         _reboot_needed = None
         _last_action = action
         cmd = ["bash", str(SETUP_SCRIPT), f"--action={action}"]
+        if branch:
+            cmd.append(f"--branch={branch}")
         _process = subprocess.Popen(
             cmd,
             cwd=str(REPO_ROOT),
@@ -1116,7 +1132,7 @@ class Handler(BaseHTTPRequestHandler):
         # /state and /log (the only _send_json callers reachable without
         # auth, see _require_auth()) are meant to be freely reachable on the
         # LAN - CORS headers don't change that, they just let PiFinder's own
-        # "INDI Drivers" page (served from a different port, hence a
+        # "PFSM" page (served from a different port, hence a
         # different origin) read the response via fetch().
         self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
@@ -1195,6 +1211,7 @@ class Handler(BaseHTTPRequestHandler):
                     "port": PORT,
                     "reboot_needed": reboot_needed,
                     "action": last_action,
+                    "current_branch": _current_pifinder_stellarmate_branch(),
                 }
             )
             return
@@ -1413,7 +1430,7 @@ class Handler(BaseHTTPRequestHandler):
         global _hwtest_running
         parsed = urlparse(self.path)
 
-        # /shutdown stays open: PiFinder's INDI Drivers page (a different
+        # /shutdown stays open: PiFinder's PFSM page (a different
         # origin/port) cross-origin-POSTs here to stop the installer, and
         # cross-origin requests never carry this page's cached Basic Auth
         # credentials. Shutting the installer down isn't destructive, unlike
@@ -1427,7 +1444,16 @@ class Handler(BaseHTTPRequestHandler):
             if action not in ("fresh", "reinstall", "update", "cancel"):
                 self._send_json({"started": False, "error": f"invalid action '{action}'"}, status=400)
                 return
-            started, error = _start_run(action)
+            # branch is optional (see bin/switch_branch.sh) - only a plain
+            # branch-name shape is accepted here, since this becomes a shell
+            # argument; git's own naming rules already rule out most of the
+            # dangerous characters, but this is a defense-in-depth check, not
+            # a git-refname validator.
+            branch = qs.get("branch", [""])[0].strip()
+            if branch and not re.fullmatch(r"[A-Za-z0-9._/-]+", branch):
+                self._send_json({"started": False, "error": f"invalid branch name '{branch}'"}, status=400)
+                return
+            started, error = _start_run(action, branch or None)
             self._send_json({"started": started, "error": error})
             return
 

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -166,6 +166,9 @@
     border-radius: 8px;
     padding: 0.7rem 0.9rem;
   }
+  #branch-picker-row { margin-bottom: 0.8rem; font-size: 0.82rem; }
+  #branch-current-hint { color: #777; margin-left: 0.5rem; font-size: 0.78rem; }
+  #branch-other-input { margin-left: 0.4rem; }
   #choices button, #start-fresh {
     background: #2a6fdb;
     color: white;
@@ -737,6 +740,17 @@ sudo systemctl start pifinder</pre>
 
     <ul id="phase-checklist" style="display:none;"></ul>
 
+    <div id="branch-picker-row">
+      <span class="mb-row-label">Branch:</span>
+      <select id="branch-select" onchange="onBranchSelectChange()">
+        <option value="main">main (stable)</option>
+        <option value="dev">dev (beta)</option>
+        <option value="__other__">Other&hellip;</option>
+      </select>
+      <input type="text" id="branch-other-input" placeholder="branch name" style="display:none;">
+      <span id="branch-current-hint"></span>
+    </div>
+
     <div id="choices" style="display:none;"></div>
 
     <div id="status-row">
@@ -858,7 +872,7 @@ function renderRemoteLinks(ips, port) {
 }
 
 // Reflects whether PiFinder itself is currently reachable (same probe that
-// drives the OLED-screen mirror) and links to its "INDI Drivers" nav page
+// drives the OLED-screen mirror) and links to its "PFSM" nav page
 // (the "INDI driver setup on PiFinder" quick-links row) once it is. Called
 // whenever that probe's result changes, not just once.
 // This is the only place PiFinder's own reachability/link is shown now (the
@@ -1119,6 +1133,25 @@ function showChoices(existingInstall) {
   }
 }
 
+// Branch picker (see bin/switch_branch.sh, pifinder_stellarmate_setup.sh's
+// --branch= flag): main/dev cover the common case as named options, "Other"
+// exposes the general case (any feature branch) without needing its own
+// UI real estate for what's an advanced/rare path. Threaded through as the
+// same --branch= flag on whatever install/update run the user actually
+// starts below - no separate "switch now" action needed.
+function onBranchSelectChange() {
+  const isOther = document.getElementById('branch-select').value === '__other__';
+  document.getElementById('branch-other-input').style.display = isOther ? '' : 'none';
+}
+
+function getSelectedBranch() {
+  const select = document.getElementById('branch-select');
+  if (select.value === '__other__') {
+    return document.getElementById('branch-other-input').value.trim();
+  }
+  return select.value;
+}
+
 async function start(action) {
   if (action === 'reinstall' &&
       !confirm('Reinstall from scratch? This permanently deletes the existing ~/PiFinder directory and everything in it.')) {
@@ -1132,7 +1165,10 @@ async function start(action) {
   document.getElementById('reboot-wrap').style.display = 'none';
   document.getElementById('close-wrap').style.display = 'none';
   setStatus('Starting…', 'status-running');
-  const resp = await fetch('/start?action=' + encodeURIComponent(action), { method: 'POST' });
+  const branch = getSelectedBranch();
+  let url = '/start?action=' + encodeURIComponent(action);
+  if (branch && branch !== 'main') url += '&branch=' + encodeURIComponent(branch);
+  const resp = await fetch(url, { method: 'POST' });
   const data = await resp.json();
   if (!data.started) {
     setStatus('Failed to start: ' + (data.error || 'unknown error'), 'status-failed');
@@ -1475,6 +1511,18 @@ async function init() {
   knownIps = data.ips || [];
   existingInstallKnown = data.existing_install;
   renderRemoteLinks(data.ips, data.port);
+  if (data.current_branch) {
+    const branchSelect = document.getElementById('branch-select');
+    const knownValues = Array.from(branchSelect.options).map((o) => o.value);
+    if (knownValues.includes(data.current_branch)) {
+      branchSelect.value = data.current_branch;
+    } else {
+      branchSelect.value = '__other__';
+      document.getElementById('branch-other-input').value = data.current_branch;
+      onBranchSelectChange();
+    }
+    document.getElementById('branch-current-hint').textContent = `(currently on: ${data.current_branch})`;
+  }
   updateProgress(data.phase_index, data.phase_total, data.phase_label);
   updateChecklist(data.phase_index, data.running, data.exit_code);
   setModeTileVisible(!data.running);

--- a/pifinder_stellarmate_setup.sh
+++ b/pifinder_stellarmate_setup.sh
@@ -21,11 +21,19 @@ smos_version_testing="2.2.1"
 # --action=reinstall|update|cancel: drive the existing-install menu and the
 # venv bootstrap non-interactively (used by gui_installer/server.py). Without
 # it, behavior is unchanged — the script still prompts on a terminal.
+# --branch=<name>: switch this repo (PiFinder_Stellarmate itself, not the
+# PiFinder checkout) to a different branch (e.g. "dev") before anything else
+# runs - see bin/switch_branch.sh. Optional; a no-op when omitted, same as
+# --action.
 ACTION=""
+BRANCH=""
 for arg in "$@"; do
     case "$arg" in
         --action=*)
             ACTION="${arg#--action=}"
+            ;;
+        --branch=*)
+            BRANCH="${arg#--branch=}"
             ;;
     esac
 done
@@ -35,6 +43,14 @@ done
 # re-execs below rely on `$(pwd)` (via `source $(pwd)/bin/functions.sh`) being
 # the repo root again, so they must `cd` back here first.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Branch switch (if requested) runs before self-update, which only ever
+# fast-forwards whichever branch is already checked out - it has no notion
+# of switching to a different one. See bin/switch_branch.sh for the safety
+# model (mirrors self_update.sh: skip cleanly when there's nothing to do,
+# abort loudly rather than risk a dirty tree).
+source "${SCRIPT_DIR}/bin/switch_branch.sh"
+switch_pifinder_stellarmate_branch "$SCRIPT_DIR" "$BRANCH"
 
 # Pull the latest PiFinder_Stellarmate before anything else runs - see
 # bin/self_update.sh for the safety model (skips cleanly during active


### PR DESCRIPTION
## Summary

Implements the branch-choice feature from #46 (concept issue - see it for the full history of
the open UX questions and how each was resolved, and the earlier comment on this PR's own branch
for the resolved design before implementation started).

- New `bin/switch_branch.sh` - same structure/safety model as `bin/self_update.sh` (skip cleanly
  on no-op, abort loudly on a dirty tree or a real git error), but does the thing self-update
  deliberately doesn't: switch to a *different* branch before self-update's own fast-forward runs.
- `pifinder_stellarmate_setup.sh` gets a new `--branch=<name>` flag, parallel to the existing
  `--action=` flag - a no-op unless passed, so every existing invocation (terminal or GUI-driven)
  is unaffected.
- **No interactive terminal prompt** - `self_update.sh` never prompts either, it silently stays on
  and updates whatever branch is already checked out; forcing a branch choice on every run would
  contradict that for the common case of just updating in place. `--branch=` covers the explicit,
  occasional case instead.
- Control Center: a Branch selector (`main` / `dev` / `Other...`) in the Install/Update tile,
  defaulting to whatever's actually checked out (new `current_branch` in `/state`). Threaded
  through as the same `--branch=` flag on whatever install/update run the user actually starts -
  no separate "switch now" action or endpoint. Server-side validates the branch name (conservative
  charset) before it becomes a shell argument.

## Test plan

- [x] `bin/switch_branch.sh`'s actual git behavior verified against a scratch clone (not the live
      checkout): no-op on empty branch, fresh checkout of a new local branch, no-op when already
      on the target, fast-forward of an existing local branch, loud failure on a nonexistent
      branch, loud failure on a dirty tree.
- [x] `py_compile` + `<div>`-balance check + clean `systemctl restart` on every change.
- [ ] **End-to-end through the live GUI itself** - clicking Update with a branch selected and
      watching `--branch=` actually take effect. Deliberately not run yet: doing that against the
      live checkout *before* this merges into `dev` would switch the very checkout serving this
      Control Center away from the code being tested. Planned as the next step once this merges.
