### PR TITLE
Make branch refresh button visually distinct from help icons

### DIFF
--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -162,21 +162,20 @@
   .refresh-link {
     display: inline-block;
     margin-left: 0.4rem;
-    width: 1rem;
-    height: 1rem;
-    line-height: 0.9rem;
+    width: 1.3rem;
+    height: 1.3rem;
+    line-height: 1.2rem;
     border-radius: 50%;
-    border: 1px solid #555;
-    color: #777;
-    font-size: 0.75rem;
+    border: none;
+    background: #2a6fdb;
+    color: white;
+    font-size: 0.85rem;
     text-align: center;
-    text-decoration: none;
     vertical-align: middle;
     cursor: pointer;
-    background: none;
     padding: 0;
   }
-  .refresh-link:hover { color: #ccc; border-color: #999; }
+  .refresh-link:hover { filter: brightness(1.15); }
   #choices p { margin: 0 0 0.8rem; color: #aaa; font-size: 0.9rem; line-height: 1.4; }
   #install-tile {
     background: #1a1a1a;

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -176,6 +176,9 @@
     padding: 0;
   }
   .refresh-link:hover { filter: brightness(1.15); }
+  .refresh-link:disabled { cursor: default; filter: brightness(0.8); }
+  .refresh-link.spinning { animation: refresh-spin 0.6s linear; }
+  @keyframes refresh-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
   #choices p { margin: 0 0 0.8rem; color: #aaa; font-size: 0.9rem; line-height: 1.4; }
   #install-tile {
     background: #1a1a1a;
@@ -766,7 +769,7 @@ sudo systemctl start pifinder</pre>
       </select>
       <input type="text" id="branch-other-input" placeholder="branch name" style="display:none;" oninput="branchTouched = true;">
       <span id="branch-current-hint"></span>
-      <button type="button" class="refresh-link" onclick="refreshBranchInfo()" title="Re-check which branch is actually on disk right now - useful if it was switched elsewhere (another tab, a terminal, a merged PR) since this page loaded.">&#8635;</button>
+      <button type="button" id="branch-refresh-btn" class="refresh-link" onclick="manualRefreshBranchInfo(this)" title="Re-check which branch is actually on disk right now - useful if it was switched elsewhere (another tab, a terminal, a merged PR) since this page loaded.">&#8635;</button>
     </div>
 
     <div id="choices" style="display:none;"></div>
@@ -1228,6 +1231,34 @@ async function refreshBranchInfo() {
   }
 }
 setInterval(refreshBranchInfo, 30000);
+
+// A click needs its own visible acknowledgment, distinct from
+// refreshBranchInfo()'s silent periodic use - the result (the hint text)
+// often won't visibly change at all (nothing switched elsewhere, the common
+// case), which would otherwise make a click look like it did nothing. Also
+// bypasses refreshBranchInfo()'s own `if (polling) return` guard's silence -
+// mid-run, a manual click should still say so rather than just not respond.
+async function manualRefreshBranchInfo(btn) {
+  if (polling) {
+    const originalTitle = btn.title;
+    btn.title = "Can't check right now - a run is in progress.";
+    setTimeout(() => { btn.title = originalTitle; }, 3000);
+    return;
+  }
+  btn.disabled = true;
+  btn.classList.add('spinning');
+  try {
+    const resp = await fetch('/state', { cache: 'no-store' });
+    const data = await resp.json();
+    applyBranchInfo(data);
+  } catch (e) {
+    // leave whatever was already shown
+  }
+  setTimeout(() => {
+    btn.classList.remove('spinning');
+    btn.disabled = false;
+  }, 400);
+}
 
 async function start(action) {
   if (action === 'reinstall' &&


### PR DESCRIPTION
## Summary

Small visual fix: the refresh button next to the Branch picker's "(currently on: ...)" hint was
styled as an outlined gray circle, identical at a glance to the neighboring help-link "i" icons -
confusing since one is an action (re-checks state) and the other is passive (opens help). Now a
solid blue circular button matching the app's other actionable buttons, so it reads as clickable.

## Test plan

- [x] `<div>`-balance check + clean `systemctl restart`.
