### PR TITLE
Fix branch-picker main bug + harden clone/update against silent failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project are documented in this file. Format loosely 
 
 ## [Unreleased]
 
+### Fixed
+
+- Auto-correct (Goto & Track) repeatedly aborted the mount mid-slew: the Mount Bridge INDI driver
+  re-issued a fresh Goto every 2s poll tick even while the mount was still slewing from the
+  previous one, causing jerky movement and continuous "aborted" alerts/sound in KStars/SMOS.
+- Control Center's "Install from: main" branch picker was silently ignored on an existing checkout
+  sitting on another branch - the switch never happened, and whatever branch was already checked
+  out stayed checked out regardless of the picker's selection.
+- `pifinder_stellarmate_setup.sh`'s `git clone` (Reinstall) and `git reset --hard`+`git pull`
+  (Update) had no exit-code check, so a failed/interrupted clone or update silently left a broken
+  installation behind instead of aborting with a clear error.
+
 ## [1.1.0] - 2026-07-26
 
 ### Added

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -1464,7 +1464,15 @@ async function start(action) {
   // time (see applyBranchInfo()'s own docstring), and sending that blindly
   // could ask to switch to a branch that no longer even exists. Untouched
   // just means "don't ask for a switch", not "resend the old default".
-  if (branchTouched && branch && branch !== 'main') url += '&branch=' + encodeURIComponent(branch);
+  //
+  // Bug fixed live during #53's reinstall/update test round: this used to
+  // also skip sending when branch === 'main', on the mistaken assumption
+  // that main never needs an explicit switch. That's only true for a FRESH
+  // clone (which starts on main anyway) - for an EXISTING checkout sitting
+  // on some other branch, explicitly picking "main" needs main sent through
+  // just like any other choice, or the switch silently never happens and
+  // whatever branch was already checked out stays checked out.
+  if (branchTouched && branch) url += '&branch=' + encodeURIComponent(branch);
   const resp = await fetch(url, { method: 'POST' });
   const data = await resp.json();
   if (!data.started) {

--- a/pifinder_stellarmate_setup.sh
+++ b/pifinder_stellarmate_setup.sh
@@ -252,7 +252,23 @@ if [ -d "${pifinder_home}/PiFinder" ]; then
                 fi
                 echo "Installation from scratch ..."
                 cd "${pifinder_home}"
-                git clone --recursive --branch release https://github.com/brickbots/PiFinder.git
+                if ! git clone --recursive --branch release https://github.com/brickbots/PiFinder.git; then
+                    echo "❌ ERROR: 'git clone' of PiFinder failed (network issue or GitHub unreachable?)."
+                    echo "❌ Aborting setup rather than patching/building against an incomplete checkout."
+                    exit 1
+                fi
+                if [ ! -f "${pifinder_home}/PiFinder/version.txt" ]; then
+                    # Belt-and-suspenders: seen live where the clone command
+                    # itself returned success but still left an incomplete
+                    # checkout behind (missing files, no error surfaced) -
+                    # every later step (patching, building, chown) silently
+                    # operated on that partial tree instead of catching it,
+                    # so the run "finished" looking mostly fine while
+                    # PiFinder itself was actually broken.
+                    echo "❌ ERROR: git clone did not produce a usable PiFinder checkout (no version.txt)."
+                    echo "❌ Aborting setup rather than patching/building against an incomplete checkout."
+                    exit 1
+                fi
                 sudo chown -R ${USER}:${USER} "${pifinder_home}/PiFinder"
                 echo "python/.venv/" >> "${pifinder_home}/PiFinder/.gitignore"
                 bash ${pifinder_stellarmate_bin}/patch_PiFinder_installation_files.sh
@@ -275,8 +291,16 @@ if [ -d "${pifinder_home}/PiFinder" ]; then
                 sudo systemctl stop pifinder
                 echo "🔄 Updating the existing installation with 'git reset --hard origin/release'..."
                 cd "${pifinder_home}/PiFinder"
-                git reset --hard origin/release
-                git pull
+                if ! git reset --hard origin/release; then
+                    echo "❌ ERROR: 'git reset --hard origin/release' failed - aborting rather than"
+                    echo "❌ patching/building against a checkout left in an unknown state."
+                    exit 1
+                fi
+                if ! git pull; then
+                    echo "❌ ERROR: 'git pull' failed - aborting rather than patching/building against"
+                    echo "❌ a possibly-stale checkout."
+                    exit 1
+                fi
                 sudo chown -R ${USER}:${USER} "${pifinder_home}/PiFinder"
                 echo "python/.venv/" >> "${pifinder_home}/PiFinder/.gitignore"
                 bash ${pifinder_stellarmate_bin}/patch_PiFinder_installation_files.sh


### PR DESCRIPTION
## Summary
Two real bugs found and fixed during the reinstall/update test round tracked in #53:

- Control Center's "Install from: main" was silently ignored on an existing checkout sitting on another branch - the switch never happened.
- `pifinder_stellarmate_setup.sh`'s `git clone` (Reinstall) and `git reset --hard`+`git pull` (Update) had no exit-code check, so a failed/interrupted operation silently left a broken installation behind instead of aborting loudly.

Also logs both fixes in `CHANGELOG.md`'s `Unreleased` section (new convention going forward - see basic-memory 00027).

## Test plan
- [x] Install from: `test/reinstall-update-verification` (via "Other…") - Reinstall from scratch - completed cleanly.
- [x] Install from: `test/reinstall-update-verification` (via "Other…") - Update - completed cleanly.
- [x] Branch-switch mechanism independently verified (not just trusting printed output).
- [x] Driver binary freshness confirmed via checksum match against a fresh build.

Full test plan and history: #53.