### PR TITLE
Set up bats-core test suite: extract and test version_gt/version_eq

### DIFF
--- a/bin/tests/run_all.sh
+++ b/bin/tests/run_all.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Runs this project's bats-core unit-test suite for its own shell scripts -
+# pure logic only (version comparison, argument parsing, OS detection), no
+# real filesystem/network/package-manager side effects. See
+# docs/concepts/setup_script_test_suite.md for what's deliberately NOT
+# covered here (that stays live-tested, same as the rest of this project).
+#
+# Requires bats-core (https://github.com/bats-core/bats-core) on PATH.
+# Not vendored/installed by this project's own setup script - a contributor/
+# CI dependency, not an end-user one.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if ! command -v bats >/dev/null 2>&1; then
+    echo "❌ 'bats' not found on PATH - install bats-core first:" >&2
+    echo "   https://github.com/bats-core/bats-core#installation" >&2
+    exit 1
+fi
+
+bats "${SCRIPT_DIR}"/*.bats

--- a/bin/tests/test_version_compare.bats
+++ b/bin/tests/test_version_compare.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+# Unit tests for bin/version_compare.sh - pure logic, no filesystem/network/
+# root access needed. See docs/concepts/setup_script_test_suite.md.
+
+setup() {
+    source "${BATS_TEST_DIRNAME}/../version_compare.sh"
+}
+
+@test "version_eq: identical versions are equal" {
+    run version_eq "1.1.0" "1.1.0"
+    [ "$status" -eq 0 ]
+}
+
+@test "version_eq: different versions are not equal" {
+    run version_eq "1.1.0" "1.2.0"
+    [ "$status" -ne 0 ]
+}
+
+@test "version_gt: newer major version is greater" {
+    run version_gt "2.0.0" "1.9.9"
+    [ "$status" -eq 0 ]
+}
+
+@test "version_gt: newer minor version is greater" {
+    run version_gt "1.2.0" "1.1.9"
+    [ "$status" -eq 0 ]
+}
+
+@test "version_gt: newer patch version is greater" {
+    run version_gt "1.1.1" "1.1.0"
+    [ "$status" -eq 0 ]
+}
+
+@test "version_gt: older version is not greater" {
+    run version_gt "1.1.0" "1.2.0"
+    [ "$status" -ne 0 ]
+}
+
+@test "version_gt: equal versions are not greater" {
+    run version_gt "1.1.0" "1.1.0"
+    [ "$status" -ne 0 ]
+}
+
+@test "version_gt: two-digit version segments sort numerically, not lexically" {
+    # A naive string/lexical sort would put "1.9.0" after "1.10.0" (since "9" >
+    # "1" as the first character) - sort -V (the mechanism version_gt relies
+    # on) must get this right, or the driver's own STABLE/TESTING version
+    # gates in pifinder_stellarmate_setup.sh would misfire on any project
+    # that reaches double-digit minor/patch numbers.
+    run version_gt "1.10.0" "1.9.0"
+    [ "$status" -eq 0 ]
+}
+
+@test "version_gt: regression case - the exact args from a real setup.sh call" {
+    # Guards the actual call site in pifinder_stellarmate_setup.sh:
+    # version_gt "$github_version" "$pifinder_stellarmate_version_stable"
+    run version_gt "2.6.0" "2.6.0"
+    [ "$status" -ne 0 ]
+    run version_gt "2.7.0" "2.6.0"
+    [ "$status" -eq 0 ]
+}

--- a/bin/version_compare.sh
+++ b/bin/version_compare.sh
@@ -1,0 +1,15 @@
+# Pure version-comparison helpers used by pifinder_stellarmate_setup.sh's
+# version checks. Extracted into their own sourceable file (no side effects,
+# no dependency on any other script state) so they can be unit-tested in
+# isolation - see bin/tests/test_version_compare.bats and
+# docs/concepts/setup_script_test_suite.md for why.
+
+# Returns 1 (bash false) if $1 > $2, sorting version strings the way `sort -V` does.
+version_gt() {
+    [ "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1" ]
+}
+
+# Returns 0 (bash true) if $1 and $2 are exactly equal strings.
+version_eq() {
+    [ "$1" = "$2" ]
+}

--- a/pifinder_stellarmate_setup.sh
+++ b/pifinder_stellarmate_setup.sh
@@ -102,15 +102,10 @@ github_version=$(curl -s https://raw.githubusercontent.com/brickbots/PiFinder/re
 echo "ℹ️  Local PiFinder version: $pifinder_local_version"
 echo "ℹ️  GitHub PiFinder version: $github_version"
 
-# Function to compare versions (returns 1 if $1 > $2)
-version_gt() {
-    [ "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1" ]
-}
-
-# Function to compare versions (returns 0 if equal)
-version_eq() {
-    [ "$1" = "$2" ]
-}
+# version_gt()/version_eq() - see bin/version_compare.sh for why these live
+# in their own sourceable file (unit-testable in isolation, see
+# bin/tests/test_version_compare.bats).
+source "${SCRIPT_DIR}/bin/version_compare.sh"
 
 # Main check
 if version_eq "$github_version" "$pifinder_stellarmate_version_stable"; then


### PR DESCRIPTION
## Summary
First slice of `docs/concepts/setup_script_test_suite.md` - a zero-risk warm-up before writing any new logic (the INDI-only install mode, next up) with tests from the start.

- Extracted `version_gt()`/`version_eq()` from `pifinder_stellarmate_setup.sh` into their own sourceable `bin/version_compare.sh` (pure logic, no other script state) - the main script now sources it instead of defining the functions inline. Behavior-identical, not a rewrite.
- `bin/tests/test_version_compare.bats` - 9 cases including a numeric-vs-lexical sort regression case and the exact real call-site arguments.
- `bin/tests/run_all.sh` as the single documented entry point. Requires `bats-core` on PATH - a contributor/CI dependency, not vendored or required by the setup script itself.

## Test plan
- [x] `bash -n` syntax check on the modified setup script
- [x] Manual function-call comparison before/after the extraction (identical results)
- [x] Real invocation (`pifinder_stellarmate_setup.sh --action=cancel`) still correctly prints "PiFinder version 2.6.0 matches STABLE version" via the sourced functions
- [x] All 9 bats tests pass (`bin/tests/run_all.sh`)