### PR TITLE
Add CONTRIBUTING.md: submodule setup, running the test suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+## After cloning: initialize submodules
+
+This repo vendors some dev/test tooling as git submodules (e.g. `bin/tests/vendor/bats-core`)
+instead of requiring a global install on every machine that works on it. A plain `git clone` does
+**not** pull submodule contents - run this once per fresh clone or worktree:
+
+```bash
+git submodule update --init --recursive
+```
+
+Skipping this step is the most common reason something that "should just work" (like the test
+suite below) instead fails with a missing-file or command-not-found error.
+
+## Running the shell-script test suite
+
+`pifinder_stellarmate_setup.sh` and its `bin/*.sh` helpers have a `bats-core` unit-test suite
+covering their pure logic (version comparison, argument parsing, OS detection) - not real
+side effects like an actual `git clone`, package install, or systemd service, which stay
+live-tested instead.
+
+```bash
+./bin/tests/run_all.sh
+```
+
+Runs in a couple of seconds, no root/network/real Pi required. Output is standard TAP format
+(`ok`/`not ok` per test case) - a failure points at the exact assertion that didn't hold.
+
+To run a single test file directly instead of the whole suite:
+
+```bash
+bin/tests/vendor/bats-core/bin/bats bin/tests/test_version_compare.bats
+```
+
+If `run_all.sh` reports the vendored `bats` binary is missing, you skipped the submodule-init step
+above - it prints the exact command to fix it.
+
+## Adding new tests
+
+New pure-logic functions extracted from the setup script (or its `bin/*.sh` helpers) should come
+with `.bats` tests in the same change, not as a follow-up.

--- a/README.md
+++ b/README.md
@@ -324,3 +324,4 @@ the script prints what those are and why, in case you want to remove them by han
 *   **[Readme_design_decisions.md](Readme_design_decisions.md)** — condensed summary of the key design decisions.
 *   **[CHANGELOG.md](CHANGELOG.md)** — release history.
 *   **[bin/README_compile_indi.md](bin/README_compile_indi.md)** — quick build reference for the PiFinder LX200 driver.
+*   **[CONTRIBUTING.md](CONTRIBUTING.md)** — submodule setup after cloning, running the shell-script test suite.

--- a/README_de.md
+++ b/README_de.md
@@ -326,3 +326,4 @@ und warum, falls man auch diese von Hand entfernen möchte.
 *   **[Readme_design_decisions_de.md](Readme_design_decisions_de.md)** — Zusammenfassung der wichtigsten Design-Entscheidungen.
 *   **[CHANGELOG.md](CHANGELOG.md)** — Versionshistorie.
 *   **[bin/README_compile_indi.md](bin/README_compile_indi.md)** — kurze Build-Referenz für den PiFinder-LX200-Treiber.
+*   **[CONTRIBUTING.md](CONTRIBUTING.md)** — Submodul-Einrichtung nach dem Klonen, Ausführen der Shell-Skript-Testsuite (Englisch).


### PR DESCRIPTION
## Summary
Closes the actual documentation gap flagged live during the bats-core test suite work (#63/#64): "how do I test this myself, what do I need to know, where is this written down" had no real answer beyond a code comment inside `run_all.sh`. `CONTRIBUTING.md` now spells out:

- The one-time `git submodule update --init --recursive` step after cloning (the most common reason a "should just work" test suite instead fails with a missing-file error).
- The exact commands to run the full suite or a single test file.

Linked from both `README.md` and `README_de.md`'s See Also sections for discoverability.

## Test plan
- [x] `./bin/tests/run_all.sh` runs clean (all 9 tests)
- [x] `bin/tests/vendor/bats-core/bin/bats bin/tests/test_version_compare.bats` (the documented single-file command) verified directly