### PR TITLE
Wire --mode=indi_only into gui_installer (R1, GUI side)

### DIFF
--- a/gui_installer/help.html
+++ b/gui_installer/help.html
@@ -97,6 +97,10 @@
   <li><strong>Run Again</strong> (shown after a run finishes): resets this page back to the choice buttons above, without shutting anything down - use this if there's another install/update to do next. This webserver is meant to just keep running; restart it via PiFinder's own "Start Setup Wizard" button on the PFSM page if it's ever off, and stop it deliberately via <code>launch_setup_gui.sh --shutdown-webserver</code> from a terminal if you actually want to.</li>
 </ul>
 
+<h2 id="indi-only-mode">INDI-only</h2>
+<p>For running just the INDI drivers and Control Center on a host with no PiFinder hardware attached at all - e.g. a separate StellarMate/Astroberry "control host" coupled to a real PiFinder elsewhere over the network (see <code>docs/concepts/remote_indi_coupling_split_host.md</code>). Check the box, then click <strong>Install INDI-only</strong>.</p>
+<p>Installs the INDI build dependencies (<code>cmake</code>, build tools, <code>libindi-dev</code>, <code>git</code>) and builds/installs both INDI drivers - nothing else. Your existing <code>~/PiFinder</code> installation (if any) is never touched: no clone/patch, no Python environment, no star catalog, no GPIO/udev setup. On StellarMate, package installation briefly and automatically disables StellarMate's own Atomic Updates protection (voids the warranty while running) and restores it immediately afterward, success or failure - you'll see StellarMate's own warning text scroll past in the log; that's expected, not an error.</p>
+
 <h2 id="mount-bridge">Mount Bridge</h2>
 <p>Couples PiFinder's own solved sky position with a real telescope mount, via the <strong>PiFinder Mount Bridge</strong> INDI driver - so you don't need to open the separate INDI Control Panel for the common cases. The tile is organized as a numbered setup checklist (below the divider line) plus a live status/operate area (above it): connection diagram, Coupling presets, and the drift readout.</p>
 <p>Each numbered step shows a green checkmark once it's actually satisfied, and a yellow spinning symbol while its own action is running.</p>

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -100,6 +100,19 @@ PHASES = [
     "Building INDI drivers",
     "Setup complete",
 ]
+# --mode=indi_only's own, much shorter phase() call sequence - a completely
+# separate list, not a subset of PHASES, since "Building INDI drivers" also
+# appears there: matching by name against the full list (see _reader_thread()
+# below) would otherwise land on that entry's position in PHASES (index 8 of
+# 10) and mark everything before it - hardware access, cloning, venv, star
+# catalog, none of which indi_only mode ever runs - as falsely "done". Found
+# live (2026-07-28) via the Control Center's own checklist showing exactly
+# that.
+PHASES_INDI_ONLY = [
+    "Installing INDI build dependencies",
+    "Building INDI drivers",
+    "Setup complete",
+]
 PHASE_MARKER = "###PHASE### "
 REBOOT_MARKER = "###REBOOT_NEEDED### "
 
@@ -140,6 +153,7 @@ _process = None
 _phase_index = -1  # furthest phase reached so far, -1 = none yet
 _reboot_needed = None  # None = unknown yet, True/False once the run reports it
 _last_action = None  # "fresh" | "reinstall" | "update"
+_last_mode = "full"  # "full" | "indi_only" - selects PHASES vs PHASES_INDI_ONLY
 
 _mode_action_running = False  # True while fake_mode.sh start/stop is in flight
 _mode_lines = []  # fake_mode.sh's own stdout/stderr, shown in the shared Terminal tile
@@ -960,6 +974,9 @@ def _get_all_ips():
 
 def _reader_thread(proc):
     global _running, _exit_code, _phase_index, _reboot_needed
+    # _last_mode is set by _start_run() before this thread starts and never
+    # changes for the lifetime of this run - safe to read once, unlocked.
+    phases = PHASES_INDI_ONLY if _last_mode == "indi_only" else PHASES
     with open(LOG_FILE, "w") as log_f:
         for line in iter(proc.stdout.readline, ""):
             log_f.write(line)
@@ -967,9 +984,9 @@ def _reader_thread(proc):
             stripped = line.rstrip("\n")
             if stripped.startswith(PHASE_MARKER):
                 label = stripped[len(PHASE_MARKER):]
-                if label in PHASES:
+                if label in phases:
                     with _lock:
-                        _phase_index = max(_phase_index, PHASES.index(label))
+                        _phase_index = max(_phase_index, phases.index(label))
                 continue  # phase markers are for the progress bar, not the log panel
             if stripped.startswith(REBOOT_MARKER):
                 with _lock:
@@ -998,7 +1015,7 @@ def _current_pifinder_stellarmate_branch():
 
 
 def _start_run(action, branch=None, mode=None):
-    global _running, _exit_code, _process, _lines, _phase_index, _reboot_needed, _last_action
+    global _running, _exit_code, _process, _lines, _phase_index, _reboot_needed, _last_action, _last_mode
     with _lock:
         if _running:
             return False, "A run is already in progress."
@@ -1012,6 +1029,7 @@ def _start_run(action, branch=None, mode=None):
         _phase_index = -1
         _reboot_needed = None
         _last_action = action
+        _last_mode = mode or "full"
         cmd = ["bash", str(SETUP_SCRIPT), f"--action={action}"]
         if branch:
             cmd.append(f"--branch={branch}")
@@ -1197,15 +1215,16 @@ class Handler(BaseHTTPRequestHandler):
                 phase_index = _phase_index
                 reboot_needed = _reboot_needed
                 last_action = _last_action
+                phases = PHASES_INDI_ONLY if _last_mode == "indi_only" else PHASES
             self._send_json(
                 {
                     "existing_install": PIFINDER_DIR.is_dir(),
                     "running": running,
                     "exit_code": exit_code,
                     "phase_index": phase_index,
-                    "phase_total": len(PHASES),
-                    "phase_label": PHASES[phase_index] if phase_index >= 0 else None,
-                    "phases": PHASES,
+                    "phase_total": len(phases),
+                    "phase_label": phases[phase_index] if phase_index >= 0 else None,
+                    "phases": phases,
                     "setup_script_path": str(SETUP_SCRIPT),
                     "ips": _get_all_ips(),
                     "port": PORT,
@@ -1409,6 +1428,7 @@ class Handler(BaseHTTPRequestHandler):
                 phase_index = _phase_index
                 reboot_needed = _reboot_needed
                 last_action = _last_action
+                phases = PHASES_INDI_ONLY if _last_mode == "indi_only" else PHASES
             self._send_json(
                 {
                     "lines": new_lines,
@@ -1416,8 +1436,8 @@ class Handler(BaseHTTPRequestHandler):
                     "running": running,
                     "exit_code": exit_code,
                     "phase_index": phase_index,
-                    "phase_total": len(PHASES),
-                    "phase_label": PHASES[phase_index] if phase_index >= 0 else None,
+                    "phase_total": len(phases),
+                    "phase_label": phases[phase_index] if phase_index >= 0 else None,
                     "reboot_needed": reboot_needed,
                     "action": last_action,
                 }

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -997,7 +997,7 @@ def _current_pifinder_stellarmate_branch():
         return None
 
 
-def _start_run(action, branch=None):
+def _start_run(action, branch=None, mode=None):
     global _running, _exit_code, _process, _lines, _phase_index, _reboot_needed, _last_action
     with _lock:
         if _running:
@@ -1015,6 +1015,8 @@ def _start_run(action, branch=None):
         cmd = ["bash", str(SETUP_SCRIPT), f"--action={action}"]
         if branch:
             cmd.append(f"--branch={branch}")
+        if mode and mode != "full":
+            cmd.append(f"--mode={mode}")
         _process = subprocess.Popen(
             cmd,
             cwd=str(REPO_ROOT),
@@ -1457,7 +1459,14 @@ class Handler(BaseHTTPRequestHandler):
             if branch and not re.fullmatch(r"[A-Za-z0-9._/-]+", branch):
                 self._send_json({"started": False, "error": f"invalid branch name '{branch}'"}, status=400)
                 return
-            started, error = _start_run(action, branch or None)
+            # --mode=indi_only (see docs/concepts/setup_indi_only_install_mode.md,
+            # R1) - installs just the INDI stack, no PiFinder hardware/
+            # application. Optional; omitted/"full" is today's unchanged behavior.
+            mode = qs.get("mode", ["full"])[0].strip()
+            if mode not in ("full", "indi_only"):
+                self._send_json({"started": False, "error": f"invalid mode '{mode}'"}, status=400)
+                return
+            started, error = _start_run(action, branch or None, mode)
             self._send_json({"started": started, "error": error})
             return
 

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -191,6 +191,7 @@
     padding: 0.7rem 0.9rem;
   }
   #branch-picker-row { margin-bottom: 0.8rem; font-size: 0.82rem; }
+  #mode-picker-row { margin-bottom: 0.8rem; font-size: 0.82rem; }
   #branch-current-hint { color: #777; margin-left: 0.5rem; font-size: 0.78rem; }
   #branch-other-input { margin-left: 0.4rem; }
   #choices button, #start-fresh {
@@ -974,6 +975,14 @@ sudo systemctl start pifinder</pre>
       <button type="button" id="branch-refresh-btn" class="refresh-link" onclick="manualRefreshBranchInfo(this)" title="Re-check which branch is actually on disk right now - useful if it was switched elsewhere (another tab, a terminal, a merged PR) since this page loaded.">&#8635;</button>
     </div>
 
+    <div id="mode-picker-row">
+      <label>
+        <input type="checkbox" id="indi-only-checkbox" onchange="onIndiOnlyToggle(this.checked)">
+        INDI-only (no PiFinder hardware - for control-host setups)
+      </label>
+      <a class="help-link" href="/help.html#indi-only-mode" target="_blank" rel="noopener" title="Help">i</a>
+    </div>
+
     <div id="choices" style="display:none;"></div>
 
     <div id="status-row">
@@ -1336,9 +1345,33 @@ async function toggleKeyboardBridge() {
   refreshKeyboardBridge();
 }
 
+// --mode=indi_only (see docs/concepts/setup_indi_only_install_mode.md, R1):
+// installs just the INDI drivers + build deps, no PiFinder hardware/
+// application - irrelevant whether an existing ~/PiFinder install exists, so
+// it gets its own single button instead of reusing the reinstall/update
+// choices (whose confirm text and "delete ~/PiFinder" semantics don't apply
+// here at all). lastExistingInstall is remembered so the checkbox's own
+// onchange can re-render the same choices it was last given, without
+// needing a fresh /state round-trip just to toggle a checkbox.
+let indiOnlyMode = false;
+let lastExistingInstall = false;
+
+function onIndiOnlyToggle(checked) {
+  indiOnlyMode = checked;
+  showChoices(lastExistingInstall);
+}
+
 function showChoices(existingInstall) {
+  lastExistingInstall = existingInstall;
   const el = document.getElementById('choices');
   el.style.display = 'block';
+  if (indiOnlyMode) {
+    el.innerHTML = `
+      <p>Installs the INDI build dependencies and drivers only - no PiFinder hardware, clone, or Python environment is touched.</p>
+      <button class="choice-btn" onclick="start('fresh')">Install INDI-only</button>
+    `;
+    return;
+  }
   // No "Cancel"/"Close Setup" choice here - this webserver is meant to just
   // keep running (matching /smos's own "Start" without a "Stop"), and
   // restarting it when needed is already covered there. The old Cancel
@@ -1502,6 +1535,7 @@ async function start(action) {
   // just like any other choice, or the switch silently never happens and
   // whatever branch was already checked out stays checked out.
   if (branchTouched && branch) url += '&branch=' + encodeURIComponent(branch);
+  if (indiOnlyMode) url += '&mode=indi_only';
   const resp = await fetch(url, { method: 'POST' });
   const data = await resp.json();
   if (!data.started) {

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -1367,7 +1367,12 @@ function showChoices(existingInstall) {
   el.style.display = 'block';
   if (indiOnlyMode) {
     el.innerHTML = `
-      <p>Installs the INDI build dependencies and drivers only - no PiFinder hardware, clone, or Python environment is touched.</p>
+      <p>Use this if this machine has <strong>no PiFinder hardware attached at all</strong> - for example a separate StellarMate/Astroberry
+      "control host" on your network that couples to a real PiFinder running elsewhere, via its INDI driver over the network
+      (see the info icon above for details on that setup). Only the INDI build dependencies and the two PiFinder INDI drivers
+      get installed here. Your existing <code>~/PiFinder</code> installation, if any, is left completely untouched: no clone or patch,
+      no Python virtual environment, no star catalog download, no GPIO/udev hardware setup - none of that applies when there's
+      no PiFinder hardware for this machine to actually run.</p>
       <button class="choice-btn" onclick="start('fresh')">Install INDI-only</button>
     `;
     return;


### PR DESCRIPTION
## Summary
- New "INDI-only" checkbox next to the branch picker; gets its own "Install INDI-only" button (not the Reinstall/Update buttons, whose semantics don't apply).
- `server.py`'s `/start` accepts an optional `mode=` query param (full|indi_only), threaded into the setup script the same way `branch=` already is.
- Fixed a real bug caught via live browser testing: the phase checklist matched phase markers by name against the "full" mode's hardcoded phase list, so indi_only's "Building INDI drivers" phase landed on that name's position in the full list (9 of 10) and showed all earlier full-mode steps as falsely done. Added a separate phase list for indi_only mode, server-tracked per-run.
- Expanded the checkbox's description text into full sentences (use case + what's touched/untouched), per direct feedback that the short version was unclear.

## Test plan
- [x] `python3 -m py_compile server.py`, div-tag balance unchanged
- [x] Live end-to-end via the actual browser UI on real StellarMate hardware (stellarmate-pi5): checkbox renders correctly, toggling swaps in the single button with correct description, clicking it runs to Success with the correct log output
- [x] Live-confirmed the checklist bug and its fix: before the fix, all 8 full-mode steps before "Building INDI drivers" showed as done despite never running; after the fix, only the actual indi_only phases show