### PR TITLE
Control Center: restart itself after a successful install/update run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project are documented in this file. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+- Control Center: after a successful Install/Update run, the Control Center now restarts itself
+  automatically so it serves whatever code the run just landed on. Previously only the setup
+  script's own logic picked up a branch switch/self-update live (via `self_update.sh`'s existing
+  re-exec) - the long-lived Control Center web server process itself (`gui_installer/server.py`)
+  stayed on stale code until manually restarted or the Pi rebooted, even though the files on disk
+  were already updated. The frontend shows a lock overlay ("Restarting the Control Center to load
+  the new version...") for the duration, then reconnects and reloads automatically once the new
+  process answers - no more silent staleness, and no confusing a deliberate restart with a crash.
+  Note: a device's *first* update through this feature won't show it yet (the still-running old
+  server doesn't know to restart itself) - it applies from the following update onward.
+
 ## [1.3.0] - 2026-07-29
 
 ### Added

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -154,6 +154,17 @@ _phase_index = -1  # furthest phase reached so far, -1 = none yet
 _reboot_needed = None  # None = unknown yet, True/False once the run reports it
 _last_action = None  # "fresh" | "reinstall" | "update"
 _last_mode = "full"  # "full" | "indi_only" - selects PHASES vs PHASES_INDI_ONLY
+# True from the moment a successful setup-script run finishes until this
+# process itself gets killed by _restart_control_center() below - exposed via
+# /state and /log so the frontend can show a "restarting..." lock overlay
+# instead of the normal success screen. A successful run may have landed on
+# different PiFinder_Stellarmate code (branch switch/self-update always run
+# first, any action/mode) - this process is a long-lived import of that code,
+# so it stays stale until the systemd service itself restarts, unlike the
+# setup script subprocess, which already gets fresh code via self_update.sh's
+# own re-exec. Found live (2026-07-29): editing the code on disk did nothing
+# for the still-running Control Center until it was manually restarted.
+_cc_restart_pending = False
 
 _mode_action_running = False  # True while fake_mode.sh start/stop is in flight
 _mode_lines = []  # fake_mode.sh's own stdout/stderr, shown in the shared Terminal tile
@@ -972,8 +983,21 @@ def _get_all_ips():
     return ips
 
 
+def _restart_control_center():
+    """Kills and relaunches this process via systemd, so it picks up
+    whatever PiFinder_Stellarmate code a just-finished run landed on - see
+    _cc_restart_pending's own comment for why this process doesn't already
+    pick that up on its own. The sleep gives the frontend one more /log or
+    /state poll to observe _cc_restart_pending before this process dies -
+    without it, a fast enough restart could kill the process before the
+    browser ever learns a restart was coming, and it'd just look like a
+    crash instead of the deliberate, communicated restart it actually is."""
+    time.sleep(2)
+    subprocess.run(["sudo", "systemctl", "restart", "pifinder-control-center.service"])
+
+
 def _reader_thread(proc):
-    global _running, _exit_code, _phase_index, _reboot_needed
+    global _running, _exit_code, _phase_index, _reboot_needed, _cc_restart_pending
     # _last_mode is set by _start_run() before this thread starts and never
     # changes for the lifetime of this run - safe to read once, unlocked.
     phases = PHASES_INDI_ONLY if _last_mode == "indi_only" else PHASES
@@ -998,6 +1022,15 @@ def _reader_thread(proc):
     with _lock:
         _running = False
         _exit_code = proc.returncode
+        # Any successful run (fresh/reinstall/update, any mode) already ran
+        # switch_branch.sh + self_update.sh at its very start, so it may have
+        # landed on different PiFinder_Stellarmate code regardless of which
+        # action was picked - always restart on success, not just for
+        # specific actions.
+        if _exit_code == 0:
+            _cc_restart_pending = True
+    if _exit_code == 0:
+        threading.Thread(target=_restart_control_center, daemon=True).start()
 
 
 def _current_pifinder_stellarmate_branch():
@@ -1215,6 +1248,7 @@ class Handler(BaseHTTPRequestHandler):
                 phase_index = _phase_index
                 reboot_needed = _reboot_needed
                 last_action = _last_action
+                restarting = _cc_restart_pending
                 phases = PHASES_INDI_ONLY if _last_mode == "indi_only" else PHASES
             self._send_json(
                 {
@@ -1231,6 +1265,7 @@ class Handler(BaseHTTPRequestHandler):
                     "reboot_needed": reboot_needed,
                     "action": last_action,
                     "current_branch": _current_pifinder_stellarmate_branch(),
+                    "restarting": restarting,
                 }
             )
             return
@@ -1464,6 +1499,7 @@ class Handler(BaseHTTPRequestHandler):
                 phase_index = _phase_index
                 reboot_needed = _reboot_needed
                 last_action = _last_action
+                restarting = _cc_restart_pending
                 phases = PHASES_INDI_ONLY if _last_mode == "indi_only" else PHASES
             self._send_json(
                 {
@@ -1476,6 +1512,7 @@ class Handler(BaseHTTPRequestHandler):
                     "phase_label": phases[phase_index] if phase_index >= 0 else None,
                     "reboot_needed": reboot_needed,
                     "action": last_action,
+                    "restarting": restarting,
                 }
             )
             return

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -794,6 +794,38 @@
     margin-bottom: 1rem;
     font-size: 0.9rem;
   }
+  /* Full-page lock shown while the Control Center restarts itself after a
+     successful setup run (see enterCcRestartingState() below) - covers and
+     visually disables the whole page rather than individually disabling
+     every scattered button, since the server itself is about to die and
+     come back, not just one action being mid-flight. */
+  #cc-restart-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    background: rgba(10, 10, 10, 0.88);
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 2rem;
+  }
+  #cc-restart-overlay-box {
+    max-width: 26rem;
+    color: #ddd;
+  }
+  #cc-restart-overlay-box .spinner {
+    width: 2rem;
+    height: 2rem;
+    margin: 0 auto 1rem;
+    border: 3px solid #444;
+    border-top-color: #2a6fdb;
+    border-radius: 50%;
+    animation: cc-restart-spin 0.9s linear infinite;
+  }
+  @keyframes cc-restart-spin { to { transform: rotate(360deg); } }
+  #cc-restart-overlay-box p { margin: 0.3rem 0; }
+  #cc-restart-overlay-box .cc-restart-detail { color: #888; font-size: 0.85rem; }
   /* R-ROLE1 (docs/concepts/remote_indi_coupling_split_host.md): what the
      SELECTED PROFILE makes this device do - a colored, always-visible chip
      near the tile top (per direct feedback: a plain grey text line under
@@ -818,6 +850,15 @@
 <h1>PiFinder on Stellarmate Control Center</h1>
 
 <div id="conn-lost-banner" style="display:none;"></div>
+
+<div id="cc-restart-overlay">
+  <div id="cc-restart-overlay-box">
+    <div class="spinner"></div>
+    <p><strong>Update complete.</strong></p>
+    <p>Restarting the Control Center to load the new version&hellip;</p>
+    <p class="cc-restart-detail">This page will reload automatically once it's back.</p>
+  </div>
+</div>
 
 <div class="page">
   <div class="left-col">
@@ -1815,6 +1856,35 @@ async function watchForServerLoss() {
   }
 }
 
+// Server-triggered self-restart after a successful setup run (see
+// _cc_restart_pending in server.py) - unlike watchForServerLoss() above,
+// this is a KNOWN, deliberate restart the server told us is coming, so
+// instead of just freezing with a "reload it yourself" banner, this locks
+// the page, waits it out, and reloads automatically once the new process
+// actually answers.
+let ccRestarting = false;
+
+function enterCcRestartingState() {
+  if (ccRestarting) return;
+  ccRestarting = true;
+  document.getElementById('cc-restart-overlay').style.display = 'flex';
+  waitForControlCenterRestart();
+}
+
+async function waitForControlCenterRestart() {
+  const maxAttempts = 30;  // 30 * 500ms = 15s ceiling before giving up and reloading anyway
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    try {
+      await fetch('/', { cache: 'no-store' });
+      break;  // new process answered - reload below, whether this was the loop that found it or the ceiling
+    } catch (e) {
+      // still restarting (or mid-kill from the old process) - keep waiting
+    }
+  }
+  location.reload();
+}
+
 // Runs continuously whenever this tab isn't actively polling a run (i.e.
 // whenever pollLog()'s loop has stopped - idle, cancelled, succeeded, or
 // failed). Catches the case where a run gets started some other way (a
@@ -1825,11 +1895,20 @@ async function watchForServerLoss() {
 // elsewhere. Harmless either way (the server refuses to shut down mid-run),
 // but confusing, so resume live tracking instead of leaving it stale.
 async function watchForNewRun() {
-  if (serverConnectionLost) return;
+  if (serverConnectionLost || ccRestarting) return;
   if (!polling) {
     try {
       const resp = await fetch('/state', { cache: 'no-store' });
       const data = await resp.json();
+      if (data.restarting) {
+        // Same run-just-finished handoff as pollLog() - this tab wasn't
+        // the one actively polling the run (started elsewhere, or this
+        // tab was idle when it finished), but the restart is happening
+        // regardless, so hand off here too instead of leaving the idle
+        // watcher to just keep silently failing against a dead process.
+        enterCcRestartingState();
+        return;
+      }
       if (data.running) {
         document.getElementById('reboot-wrap').style.display = 'none';
         document.getElementById('reset-wrap').style.display = 'none';
@@ -1986,6 +2065,16 @@ async function pollLog() {
     // stop polling and tell the user this view is now frozen.
     polling = false;
     showServerLostBanner();
+    return;
+  }
+  if (data.restarting) {
+    // The run just finished successfully and the server already committed
+    // to restarting itself (see _cc_restart_pending) - stop polling and
+    // hand off to the lock-overlay/reconnect flow instead of the normal
+    // success screen, which would be showing stale-by-the-time-you-read-it
+    // buttons for a process that's about to die anyway.
+    polling = false;
+    enterCcRestartingState();
     return;
   }
   if (data.lines.length > 0) {


### PR DESCRIPTION
## Summary
- The setup script subprocess already gets fresh code live after a branch switch/self-update (`self_update.sh`'s own `exec "$0"` re-exec) - but the long-lived Control Center web server process (`gui_installer/server.py`) was never restarted, so it kept serving stale code until manually restarted or the Pi rebooted.
- `_reader_thread` now sets `_cc_restart_pending` as soon as a run finishes successfully (any action/mode), exposed via `/state` and `/log`. A background thread waits 2s then restarts `pifinder-control-center.service`.
- Frontend shows a full-page lock overlay for the duration instead of the normal success screen, then retry-polls `/` every 500ms (15s ceiling) until the new process answers, then reloads.

## Caveat
A device's *first* update through this feature won't show it yet - the still-running old server doesn't know to restart itself. Applies from the following update onward. Documented in CHANGELOG.

## Test plan
- [x] `node --check` on the extracted `<script>` block, HTML div-balance, `python3 -m py_compile`
- [x] Service restarted locally with the new code (dormant path - not yet exercised via a real run)
- [ ] Live verification of the actual restart-and-reload flow (needs a real successful install/update run on a device already carrying this code)