### PR TITLE
Release v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project are documented in this file. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+- Control Center: after a successful Install/Update run, the Control Center now restarts itself
+  automatically so it serves whatever code the run just landed on. Previously only the setup
+  script's own logic picked up a branch switch/self-update live (via `self_update.sh`'s existing
+  re-exec) - the long-lived Control Center web server process itself (`gui_installer/server.py`)
+  stayed on stale code until manually restarted or the Pi rebooted, even though the files on disk
+  were already updated. The frontend shows a lock overlay ("Restarting the Control Center to load
+  the new version...") for the duration, then reconnects and reloads automatically once the new
+  process answers - no more silent staleness, and no confusing a deliberate restart with a crash.
+  Note: a device's *first* update through this feature won't show it yet (the still-running old
+  server doesn't know to restart itself) - it applies from the following update onward.
+
 ## [1.3.0] - 2026-07-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented in this file. Format loosely 
 
 ### Added
 
+- Control Center: after a successful Install/Update run, the Control Center now restarts itself
   automatically so it serves whatever code the run just landed on. Previously only the setup
   script's own logic picked up a branch switch/self-update live (via `self_update.sh`'s existing
   re-exec) - the long-lived Control Center web server process itself (`gui_installer/server.py`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,39 @@
 All notable changes to this project are documented in this file. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+- Control Center: after a successful Install/Update run, the Control Center now restarts itself
+  automatically so it serves whatever code the run just landed on, instead of staying on stale
+  code until manually restarted or the Pi rebooted. The frontend shows a lock overlay for the
+  duration, then reconnects and reloads automatically once the new process answers.
+- Mount Bridge: a compact hardware status strip and the PiFinder Mode tile now distinguish "still
+  starting" (pulsing yellow, within a 45s grace window) from a genuine "not detected" - PiFinder's
+  multi-process design can show its live OLED UI before its own web server process is actually
+  reachable yet, and a flat white "not detected" during that window read as broken.
+- The static OLED-mirror placeholder (shown before the live `/image` probe succeeds) is now a
+  pre-converted red version of PiFinder's own splash image, matching the warm red glow real
+  hardware is always seen in, instead of the full-color/blue original.
+
+### Changed
+
+- **Consolidated every "still checking / result pending" indicator in the Control Center onto one
+  pattern**: a forced-yellow pulsing dot (`.dot-unconfirmed`), extended to every place that
+  previously used a different, uncoupled visual - a static white "checking…" dot (Mode status,
+  Hardware Test rows, external Numpad/LCD rows), a dedicated one-time loading progress bar
+  (`#mb-initial-load-banner`, now removed entirely), and button-text-only feedback with no dot/icon
+  change (Coupling presets, Manual Sync, Link/Unlink Mount, Connect/Disconnect, external hardware
+  toggles). The compact hardware ampel badges pulse in sync with their detail-row dot via the same
+  mechanism. One implementation, one design rule, instead of several independently-grown ones for
+  the same underlying situation.
+- Mount Bridge status polling is now gated on the device's actual role (`deriveProfileRole()`) -
+  only roles that use Mount Bridge poll and show "checking... (unconfirmed)"; a PiFinder-host
+  device shows a calm "not used in this role" instead, and the whole diagram/caption (entirely
+  derived from Mount Bridge's own state, unobtainable in this role) is hidden rather than showing a
+  permanently red, misleading "not coupled" diagram.
+
 ## [1.3.0] - 2026-07-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project are documented in this file. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [1.3.1] - 2026-07-29
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ The primary goal is to allow users to leverage the powerful plate-solving and ob
 > * Use these scripts at your own risk. The author is not responsible for any damage to your hardware or software.
 > * This process has been tested with the PiFinder version specified in `version.txt`.
 
-> ### ✅ **Current Version — v1.3.0**
+> ### ✅ **Current Version — v1.3.1**
 >
 > * Built and verified for **PiFinder software 2.6.0** on **StellarMate OS 2.2.1** (Arch Linux).
 > * **Raspberry Pi 4**: Fully supported — camera ✅, plate solve ✅, IMU ✅, GPS ✅. Tested under real night sky (2026-07-12).
 > * **Raspberry Pi 5**: Supported — GPS ✅, Web UI ✅, OLED ✅. (A months-long "OLED stays dark" issue was traced to a defective HAT unit, not a Pi5/software limitation — resolved 2026-07-17 by swapping the physical HAT board.) **Keyboard ⚠️**: on the test unit, a Geekworm X1203 UPS shield shares GPIO 16 with the keypad matrix's column 0 (keys 7/4/1/LEFT), permanently disabling that whole column — a real hardware resource conflict between the two add-on boards, not a Pi5 or software limitation, and specific to setups with that UPS shield attached. Camera requires a 15-pin FFC CSI adapter cable (Pi4 uses 22-pin) — not yet installed on the test unit.
 > * **INDI integration**: standalone LX200 driver + optional real-mount coupling ("Mount Bridge"), verified end-to-end against a real Skywatcher EQ5/OnStepX mount, all four Coupling presets — see [Readme_PiFinder_LX200.md](Readme_PiFinder_LX200.md) and [CHANGELOG.md](CHANGELOG.md).
-> * **New in this release**: PiFinder can now run split across two devices — pick a **role** (All-in-one / PiFinder host / Control host) via role cards in the Mount Bridge tile; a Control host couples to a PiFinder running on a separate machine over the network, and a new `--mode=indi_only` install skips the full PiFinder setup for that role. The Mount Bridge status tile no longer flashes a misleading "not coupled" during brief status-check timing gaps — it shows the last confirmed state marked "unconfirmed" instead, with a live-updating drift readout throughout, and the Threshold field now takes effect immediately instead of needing a Coupling preset re-click. See [CHANGELOG.md](CHANGELOG.md) for the full list.
+> * **New in this release**: the Control Center now restarts itself automatically after a successful Install/Update run, so it always serves the code that run just landed on. Every "still checking" indicator across the Control Center (Mode status, hardware tests, Mount Bridge, external hardware toggles) now shares one consistent pulsing-yellow-dot pattern instead of several different ad-hoc ones, and the Mount Bridge tile is now role-aware — a PiFinder-host device no longer shows a misleading "not coupled" diagram for a driver it was never meant to have. See [CHANGELOG.md](CHANGELOG.md) for the full list.
 
 ---
 

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -154,6 +154,17 @@ _phase_index = -1  # furthest phase reached so far, -1 = none yet
 _reboot_needed = None  # None = unknown yet, True/False once the run reports it
 _last_action = None  # "fresh" | "reinstall" | "update"
 _last_mode = "full"  # "full" | "indi_only" - selects PHASES vs PHASES_INDI_ONLY
+# True from the moment a successful setup-script run finishes until this
+# process itself gets killed by _restart_control_center() below - exposed via
+# /state and /log so the frontend can show a "restarting..." lock overlay
+# instead of the normal success screen. A successful run may have landed on
+# different PiFinder_Stellarmate code (branch switch/self-update always run
+# first, any action/mode) - this process is a long-lived import of that code,
+# so it stays stale until the systemd service itself restarts, unlike the
+# setup script subprocess, which already gets fresh code via self_update.sh's
+# own re-exec. Found live (2026-07-29): editing the code on disk did nothing
+# for the still-running Control Center until it was manually restarted.
+_cc_restart_pending = False
 
 _mode_action_running = False  # True while fake_mode.sh start/stop is in flight
 _mode_lines = []  # fake_mode.sh's own stdout/stderr, shown in the shared Terminal tile
@@ -972,8 +983,21 @@ def _get_all_ips():
     return ips
 
 
+def _restart_control_center():
+    """Kills and relaunches this process via systemd, so it picks up
+    whatever PiFinder_Stellarmate code a just-finished run landed on - see
+    _cc_restart_pending's own comment for why this process doesn't already
+    pick that up on its own. The sleep gives the frontend one more /log or
+    /state poll to observe _cc_restart_pending before this process dies -
+    without it, a fast enough restart could kill the process before the
+    browser ever learns a restart was coming, and it'd just look like a
+    crash instead of the deliberate, communicated restart it actually is."""
+    time.sleep(2)
+    subprocess.run(["sudo", "systemctl", "restart", "pifinder-control-center.service"])
+
+
 def _reader_thread(proc):
-    global _running, _exit_code, _phase_index, _reboot_needed
+    global _running, _exit_code, _phase_index, _reboot_needed, _cc_restart_pending
     # _last_mode is set by _start_run() before this thread starts and never
     # changes for the lifetime of this run - safe to read once, unlocked.
     phases = PHASES_INDI_ONLY if _last_mode == "indi_only" else PHASES
@@ -998,6 +1022,15 @@ def _reader_thread(proc):
     with _lock:
         _running = False
         _exit_code = proc.returncode
+        # Any successful run (fresh/reinstall/update, any mode) already ran
+        # switch_branch.sh + self_update.sh at its very start, so it may have
+        # landed on different PiFinder_Stellarmate code regardless of which
+        # action was picked - always restart on success, not just for
+        # specific actions.
+        if _exit_code == 0:
+            _cc_restart_pending = True
+    if _exit_code == 0:
+        threading.Thread(target=_restart_control_center, daemon=True).start()
 
 
 def _current_pifinder_stellarmate_branch():
@@ -1215,6 +1248,7 @@ class Handler(BaseHTTPRequestHandler):
                 phase_index = _phase_index
                 reboot_needed = _reboot_needed
                 last_action = _last_action
+                restarting = _cc_restart_pending
                 phases = PHASES_INDI_ONLY if _last_mode == "indi_only" else PHASES
             self._send_json(
                 {
@@ -1231,6 +1265,7 @@ class Handler(BaseHTTPRequestHandler):
                     "reboot_needed": reboot_needed,
                     "action": last_action,
                     "current_branch": _current_pifinder_stellarmate_branch(),
+                    "restarting": restarting,
                 }
             )
             return
@@ -1464,6 +1499,7 @@ class Handler(BaseHTTPRequestHandler):
                 phase_index = _phase_index
                 reboot_needed = _reboot_needed
                 last_action = _last_action
+                restarting = _cc_restart_pending
                 phases = PHASES_INDI_ONLY if _last_mode == "indi_only" else PHASES
             self._send_json(
                 {
@@ -1476,6 +1512,7 @@ class Handler(BaseHTTPRequestHandler):
                     "phase_label": phases[phase_index] if phase_index >= 0 else None,
                     "reboot_needed": reboot_needed,
                     "action": last_action,
+                    "restarting": restarting,
                 }
             )
             return

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -1432,9 +1432,16 @@ async function toggleDebugSolve() {
   const port = new URL(pifinderScreenUrl).port || '80';
   const btn = document.getElementById('debug-solve-btn');
   const textEl = document.getElementById('debug-solve-text');
+  const dotEl = document.getElementById('debug-solve-dot');
   const before = lastDebugSolve;
   btn.disabled = true;
   textEl.textContent = 'Toggling…';
+  // Pulsing yellow on both the detail-row dot and its ampel badge (see
+  // setHwDot()) - per direct feedback (2026-07-29), the text-only change
+  // above was easy to miss ("the toggle doesn't react"), especially with
+  // the detail row tucked inside the collapsed "Hardware test and
+  // details" section while the ampel row above it stayed static.
+  setHwDot(dotEl, 'status-dot dot-yellow dot-unconfirmed');
   try {
     await fetch(`/api/debug_solve?port=${port}`, { method: 'POST' });
   } catch (e) {
@@ -2616,8 +2623,47 @@ function setMbStatusUnconfirmed(unconfirmed) {
   }
 }
 
+// Roles that actually involve a Mount Bridge driver - only for these does
+// polling/pulsing "checking... (unconfirmed)" mean anything. Found live
+// (2026-07-29): a PiFinder-host device (no Mount Bridge, by design) still
+// showed an endlessly pulsing "checking..." - there's nothing to check,
+// the status poll was just repeatedly hitting "connection refused" against
+// an indiserver nobody ever asked to load Mount Bridge. Same idea applies
+// to a fresh/no-role-yet profile.
+const MB_BRIDGE_RELEVANT_ROLES = ['aio', 'ctrl', 'ctrl-incomplete', 'bridge-only'];
+
+// Clears the tile to a calm, static, non-pulsing state with a reason -
+// shared by both "this role doesn't use Mount Bridge" and "the profile
+// isn't even running yet" below, since both are cases where polling
+// wouldn't tell the user anything they don't already know.
+function setMbStatusInapplicable(text) {
+  mbStatusMissStreak = 0;
+  setMbStatusUnconfirmed(false);
+  document.getElementById('mount-bridge-dot').className = 'status-dot dot-white';
+  document.getElementById('mount-bridge-text').textContent = text;
+  updateWmCouplingGate();
+  refreshWmActiveButton();
+  refreshConnectButtons();
+}
+
 async function refreshMountBridgeStatus() {
   const dotEl = document.getElementById('mount-bridge-dot');
+  const role = deriveProfileRole();
+  if (!MB_BRIDGE_RELEVANT_ROLES.includes(role)) {
+    setMbStatusInapplicable(
+      role === 'host' ? 'not used in this role' : 'no Mount Bridge in this profile yet'
+    );
+    return;
+  }
+  if (!wmServerRunning) {
+    // Mount Bridge SHOULD be here once the profile starts, but polling for
+    // it while the profile itself isn't even running yet would just pulse
+    // "checking..." indefinitely for a reason the user can already see
+    // for themselves in the checklist above (Step 1: Profile, not started) -
+    // point at the actual next step instead of making them guess.
+    setMbStatusInapplicable('not running - start the profile below');
+    return;
+  }
   try {
     const resp = await fetch('/api/mount_bridge_status', { cache: 'no-store' });
     const data = await resp.json();

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -91,35 +91,6 @@
     font-size: 0.85rem;
     margin-top: 0.4rem;
   }
-  /* Mount Bridge's own status is assembled from four independent async
-     checks (bridge/status, profile+drivers, KStars link, Ekos status) -
-     shown only once, during the tile's first load, until all four have
-     reported at least once. Deliberately NOT a persistent bar that
-     reappears on every later background refresh - each element already
-     has its own "checking..." state for that, this is just for the one
-     moment where the whole tile is still empty/misleading. */
-  #mb-initial-load-banner {
-    margin-bottom: 0.6rem;
-    opacity: 1;
-    transition: opacity 0.2s ease;
-  }
-  #mb-initial-load-track {
-    background: #262626;
-    border-radius: 5px;
-    height: 6px;
-    overflow: hidden;
-  }
-  #mb-initial-load-fill {
-    background: #2a6fdb;
-    height: 100%;
-    width: 0%;
-    transition: width 0.4s ease;
-  }
-  #mb-initial-load-label {
-    color: #999;
-    font-size: 0.74rem;
-    margin: 0.3rem 0 0.6rem 0;
-  }
   #phase-checklist {
     list-style: none;
     margin: 0 0 1.2rem;
@@ -495,6 +466,10 @@
     height: 18px;
     color: #666;
   }
+  /* Mirrors .dot-unconfirmed's pulse on the ampel badge (see setHwDot()) -
+     color itself is set inline (currentColor is already #f5a623 by then),
+     this only adds the animation. */
+  .mode-ampel-icon.mode-ampel-icon-unconfirmed { animation: mb-status-pulse 1.1s ease-in-out infinite; }
   /* Its own divider/spacing now comes from the .collapsible-toggle header
      right above it, not from this rule directly. */
   #ext-hw-status {
@@ -535,25 +510,6 @@
   .mb-role-card-title { font-weight: bold; color: #ddd; font-size: 0.8rem; }
   .mb-role-card.mb-role-active .mb-role-card-title { color: #4caf50; }
   .mb-role-card-sub { color: #999; font-size: 0.72rem; margin-top: 2px; line-height: 1.35; }
-  /* The one-time loading banner used to sit in its own full-width row below
-     the heading, leaving the wide empty area to the right of "Mount Bridge"
-     unused - per live feedback, moved into that corner instead. The status
-     line + action-status hint stay in their OWN row below (per live
-     feedback correction: only the loading banner and the action-status hint
-     were meant to move - the status line/drift caption stays put, just
-     paired on its row with the action-status hint on the right). */
-  #mb-tile-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 0.6rem;
-  }
-  #mb-tile-header .tile-heading { margin-bottom: 0; }
-  #mb-tile-header #mb-initial-load-banner {
-    flex-shrink: 0;
-    max-width: 55%;
-    text-align: right;
-  }
   #mb-status-row {
     display: flex;
     justify-content: space-between;
@@ -839,7 +795,7 @@
       </div>
       <div id="mode-tile">
         <h3 class="tile-heading" title="Real Mode uses actual PiFinder hardware (camera/IMU/GPS). Fake Mode runs a separate headless instance with everything simulated, for testing without hardware.">PiFinder Mode, Test and Power<a class="help-link" href="/help.html#mode-power" target="_blank" rel="noopener" title="Help">i</a></h3>
-        <div id="mode-status-line"><span class="status-dot dot-white" id="mode-status-dot"></span><span id="mode-status-text">Checking mode&hellip;</span></div>
+        <div id="mode-status-line"><span class="status-dot dot-unconfirmed" id="mode-status-dot"></span><span id="mode-status-text">Checking mode&hellip;</span></div>
         <div id="mode-power-groups">
           <div class="mode-power-group" title="Mode switch and pifinder.service start/stop/restart - all software-level, all the same PiFinder instance.">
             <div class="group-label">PiFinder</div>
@@ -869,21 +825,21 @@
              doesn't compete with the mode/power controls above it. -->
         <div id="mode-ampel-row" title="Quick hardware status - see Hardware test and details below for the full picture">
           <div class="mode-ampel-badge" title="Camera">
-            <svg class="mode-ampel-icon" id="mode-ampel-camera-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <svg class="mode-ampel-icon mode-ampel-icon-unconfirmed" id="mode-ampel-camera-icon" style="color:#f5a623;" viewBox="0 0 24 24" aria-hidden="true">
               <path d="M4 8.5h3l1.3-2h7.4l1.3 2h3v11H4z" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/>
               <circle cx="12" cy="14" r="3.4" fill="none" stroke="currentColor" stroke-width="1.3"/>
             </svg>
             <span>Cam</span>
           </div>
           <div class="mode-ampel-badge" title="Solve Simulation">
-            <svg class="mode-ampel-icon" id="mode-ampel-solve-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <svg class="mode-ampel-icon mode-ampel-icon-unconfirmed" id="mode-ampel-solve-icon" style="color:#f5a623;" viewBox="0 0 24 24" aria-hidden="true">
               <circle cx="12" cy="12" r="8" fill="none" stroke="currentColor" stroke-width="1.3"/>
               <path d="M12 2.5v4M12 17.5v4M2.5 12h4M17.5 12h4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
             </svg>
             <span>Solve</span>
           </div>
           <div class="mode-ampel-badge" title="IMU">
-            <svg class="mode-ampel-icon" id="mode-ampel-imu-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <svg class="mode-ampel-icon mode-ampel-icon-unconfirmed" id="mode-ampel-imu-icon" style="color:#f5a623;" viewBox="0 0 24 24" aria-hidden="true">
               <circle cx="12" cy="12" r="8" fill="none" stroke="currentColor" stroke-width="1.3"/>
               <path d="M12 5.5a6.5 6.5 0 0 1 6.5 6.5" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
               <path d="M18.5 12 L16 10 M18.5 12 L16.3 14.2" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
@@ -891,7 +847,7 @@
             <span>IMU</span>
           </div>
           <div class="mode-ampel-badge" title="GPS">
-            <svg class="mode-ampel-icon" id="mode-ampel-gps-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <svg class="mode-ampel-icon mode-ampel-icon-unconfirmed" id="mode-ampel-gps-icon" style="color:#f5a623;" viewBox="0 0 24 24" aria-hidden="true">
               <path d="M12 21.5S5 14.6 5 9.8a7 7 0 0 1 14 0c0 4.8-7 11.7-7 11.7z" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/>
               <circle cx="12" cy="9.6" r="2.4" fill="none" stroke="currentColor" stroke-width="1.3"/>
             </svg>
@@ -908,15 +864,15 @@
               <button id="hwtest-btn" class="ql-small-btn" onclick="runHardwareTest()" style="margin-left:0;">Test Hardware</button>
               <span id="hwtest-status-text"></span>
             </div>
-            <div class="hw-row"><span class="status-dot dot-white" id="hw-camera-dot"></span>Camera: <span id="hw-camera-text">checking&hellip;</span></div>
+            <div class="hw-row"><span class="status-dot dot-unconfirmed" id="hw-camera-dot"></span>Camera: <span id="hw-camera-text">checking&hellip;</span></div>
             <div class="hw-detail" id="hw-camera-detail"></div>
             <div class="hw-row" title="PiFinder's own &quot;Tools -> Test Mode&quot; feature - substitutes canned test images for the camera so plate-solving can be exercised without sky access, while IMU/keyboard/GPS stay live. Not the same as this tile's Fake Mode switch above (which runs a whole separate headless instance with no hardware at all).">
-              <span class="status-dot dot-white" id="debug-solve-dot"></span>Solve Simulation: <span id="debug-solve-text">unknown</span>
+              <span class="status-dot dot-unconfirmed" id="debug-solve-dot"></span>Solve Simulation: <span id="debug-solve-text">unknown</span>
               <button id="debug-solve-btn" class="ql-small-btn" onclick="toggleDebugSolve()" disabled>Toggle</button>
             </div>
-            <div class="hw-row"><span class="status-dot dot-white" id="hw-imu-dot"></span>IMU: <span id="hw-imu-text">checking&hellip;</span></div>
+            <div class="hw-row"><span class="status-dot dot-unconfirmed" id="hw-imu-dot"></span>IMU: <span id="hw-imu-text">checking&hellip;</span></div>
             <div class="hw-detail" id="hw-imu-detail"></div>
-            <div class="hw-row"><span class="status-dot dot-white" id="hw-gps-dot"></span>GPS: <span id="hw-gps-text">checking&hellip;</span></div>
+            <div class="hw-row"><span class="status-dot dot-unconfirmed" id="hw-gps-dot"></span>GPS: <span id="hw-gps-text">checking&hellip;</span></div>
             <div class="hw-detail" id="hw-gps-detail"></div>
           </div>
           <div class="collapsible-toggle" onclick="toggleCollapsibleSection('ext-hw-status', 'ext-hw-chevron')">
@@ -925,7 +881,7 @@
           </div>
           <div id="ext-hw-status" style="display:none;">
             <div class="hw-row" title="Only relevant if you've attached a plain USB or 2.4GHz-dongle numpad (e.g. a LogiLink ID0120) as a stand-in for the PiFinder keypad. Bridges its key events to PiFinder's /api/key (test_tools/fb_keyboard_bridge.py) - works against either Real or Fake Mode, no GPIO/overlay involved, no reboot needed. Runs as its own systemd unit (pifinder-numpad-bridge.service); once turned on it stays on across reboots too, and re-probes on its own after a Fake/Real Mode switch.">
-              <span class="status-dot dot-white" id="keyboard-status-dot"></span>External numpad bridge (optional, needs extra hardware): <span id="keyboard-status-state">checking&hellip;</span>
+              <span class="status-dot dot-unconfirmed" id="keyboard-status-dot"></span>External numpad bridge (optional, needs extra hardware): <span id="keyboard-status-state">checking&hellip;</span>
               <button id="keyboard-toggle-btn" class="ql-small-btn" onclick="toggleKeyboardBridge()" disabled>Checking&hellip;</button>
             </div>
             <div class="hw-row hw-keyboard">
@@ -936,7 +892,7 @@
 /home/stellarmate/PiFinder/python/.venv/bin/python3 /home/stellarmate/PiFinder_Stellarmate/test_tools/keypad_gpio_matrix_test.py 20
 sudo systemctl start pifinder</pre>
             <div class="hw-row" title="Only relevant if you've attached a small secondary SPI display (e.g. Waveshare 3.5&quot; LCD) to this Pi's GPIO header. The button enables/disables its device-tree overlay in /boot/config.txt and reboots (Pi firmware overlays only apply at boot) - it needs the same GPIO lines a real HAT's OLED/keypad use, so the two can't be active at once. Once on, Fake Mode plus the screen/numpad bridges start automatically on every boot - nothing else to start manually.">
-              <span class="status-dot dot-white" id="display-status-dot"></span>External SPI LCD (optional, needs extra hardware): <span id="display-status-state">checking&hellip;</span>
+              <span class="status-dot dot-unconfirmed" id="display-status-dot"></span>External SPI LCD (optional, needs extra hardware): <span id="display-status-state">checking&hellip;</span>
               <button id="display-toggle-btn" class="ql-small-btn" onclick="toggleDisplayBridge()" disabled>Checking&hellip;</button>
             </div>
           </div>
@@ -949,13 +905,7 @@ sudo systemctl start pifinder</pre>
            up" rows (Profile/Drivers/Mount/Connect) plus Ekos status, bridge
            settings, and the log collapse behind #mb-details-toggle - see
            its own CSS comment. -->
-      <div id="mb-tile-header">
-        <h3 class="tile-heading" title="Couples PiFinder's solved position with your mount via the Mount Bridge INDI driver - connect the pieces, then pick a coupling mode.">Mount Bridge<a class="help-link" href="/help.html#mount-bridge" target="_blank" rel="noopener" title="Help">i</a></h3>
-        <div id="mb-initial-load-banner">
-          <div id="mb-initial-load-track"><div id="mb-initial-load-fill"></div></div>
-          <div id="mb-initial-load-label">Loading Mount Bridge status&hellip;</div>
-        </div>
-      </div>
+      <h3 class="tile-heading" title="Couples PiFinder's solved position with your mount via the Mount Bridge INDI driver - connect the pieces, then pick a coupling mode.">Mount Bridge<a class="help-link" href="/help.html#mount-bridge" target="_blank" rel="noopener" title="Help">i</a></h3>
       <div id="mb-status-row">
         <div id="mb-status-line"><span class="status-dot dot-white" id="mount-bridge-dot"></span><span id="mount-bridge-text">checking&hellip;</span><span id="mount-bridge-unconfirmed" style="display:none;" title="Our own status check couldn't reach Mount Bridge just now - this is very likely just that check's own timing, not a real disconnect (see Help). Showing the last confirmed state below; interactive buttons are paused until we can confirm again."> (unconfirmed)</span></div>
         <div id="mb-action-status"></div>
@@ -1370,11 +1320,18 @@ function setHwDot(dotEl, className) {
   dotEl.className = className;
   const ampelId = HW_AMPEL_ICON_IDS[dotEl.id];
   if (!ampelId) return;
-  const color = className.includes('dot-green') ? '#4caf50'
+  const unconfirmed = className.includes('dot-unconfirmed');
+  const color = unconfirmed ? '#f5a623'
+    : className.includes('dot-green') ? '#4caf50'
     : className.includes('dot-red') ? '#e53935'
     : className.includes('dot-yellow') ? '#f5a623'
     : '#666';
-  document.getElementById(ampelId).style.color = color;
+  const ampelEl = document.getElementById(ampelId);
+  ampelEl.style.color = color;
+  // Same forced-yellow-pulse language as the detail-row dot itself (see
+  // .dot-unconfirmed) - without this the badge just went a static grey
+  // while its own detail-row dot pulsed yellow right next to it.
+  ampelEl.classList.toggle('mode-ampel-icon-unconfirmed', unconfirmed);
 }
 
 async function refreshDebugSolve() {
@@ -1503,8 +1460,10 @@ async function toggleDisplayBridge() {
   const action = wantEnable ? 'start' : 'stop';
   const btn = document.getElementById('display-toggle-btn');
   const stateEl = document.getElementById('display-status-state');
+  const dotEl = document.getElementById('display-status-dot');
   btn.disabled = true;
   stateEl.textContent = 'rebooting…';
+  dotEl.className = 'status-dot dot-unconfirmed';
   try {
     const resp = await fetch('/api/display_bridge?action=' + action, { method: 'POST' });
     const data = await resp.json();
@@ -1563,9 +1522,11 @@ async function refreshKeyboardBridge() {
 async function toggleKeyboardBridge() {
   const btn = document.getElementById('keyboard-toggle-btn');
   const stateEl = document.getElementById('keyboard-status-state');
+  const dotEl = document.getElementById('keyboard-status-dot');
   const action = lastKeyboardBridgeRunning ? 'stop' : 'start';
   btn.disabled = true;
   stateEl.textContent = action === 'start' ? 'starting…' : 'stopping…';
+  dotEl.className = 'status-dot dot-unconfirmed';
   try {
     const resp = await fetch('/api/keyboard_bridge?action=' + action, { method: 'POST' });
     const data = await resp.json();
@@ -2149,7 +2110,7 @@ async function refreshMode() {
     const resp = await fetch('/api/pifinder_mode', { cache: 'no-store' });
     const data = await resp.json();
     if (data.transitioning) {
-      dotEl.className = 'status-dot dot-yellow';
+      dotEl.className = 'status-dot dot-yellow dot-unconfirmed';
       textEl.textContent = data.target === 'real' ? 'Starting Real Mode…' : 'Starting Fake Mode…';
       btn.disabled = true;
       btn.textContent = 'Switching…';
@@ -2211,7 +2172,7 @@ async function toggleMode() {
   if (!confirm(`Really ${verb}?`)) return;
   btn.disabled = true;
   btn.textContent = 'Switching…';
-  dotEl.className = 'status-dot dot-yellow';
+  dotEl.className = 'status-dot dot-yellow dot-unconfirmed';
   textEl.textContent = wantFake ? 'Starting Fake Mode…' : 'Starting Real Mode…';
   // Fresh terminal for this attempt - but only if no install/update run
   // currently owns it (the backend already refuses to run both at once, so
@@ -2511,33 +2472,6 @@ function updateMbDiagram(data) {
 // mid-restart) could read genuinely transient/incomplete state and flash it
 // on screen before the next successful poll corrected it. The action's own
 // completion always triggers an immediate, fresh refresh anyway.
-// Mount Bridge's status is assembled from four independent async checks
-// that only run once (unawaited) on initial page load - this just tracks
-// when each has reported at least once, to hide #mb-initial-load-banner.
-// "kstars" is marked from within loadWmProfiles() itself (see there) since
-// checkKstarsLink() is only called conditionally, nested inside it, not
-// as its own top-level call.
-const _mbInitialLoad = { mb: false, profiles: false, kstars: false, ekos: false };
-function _markMbInitialLoadDone(key) {
-  _mbInitialLoad[key] = true;
-  const done = Object.values(_mbInitialLoad).filter(Boolean).length;
-  const total = Object.keys(_mbInitialLoad).length;
-  const fill = document.getElementById('mb-initial-load-fill');
-  if (fill) fill.style.width = `${Math.round((done / total) * 100)}%`;
-  if (done === total) {
-    // Fades out smoothly rather than vanishing outright (same "no sudden
-    // kick" reasoning as #mb-action-status), then collapses its reserved
-    // space only once the fade has actually finished - this one never
-    // reappears this session, so unlike the action status it doesn't need
-    // to keep holding its space open indefinitely afterward.
-    const banner = document.getElementById('mb-initial-load-banner');
-    if (banner) {
-      banner.style.opacity = '0';
-      setTimeout(() => { banner.style.display = 'none'; }, 200);
-    }
-  }
-}
-
 let mbActionInFlight = false;
 
 function setMbActionStatus(text) {
@@ -2720,7 +2654,7 @@ async function refreshMountBridgeStatus() {
   }
 }
 setInterval(() => { if (!mbActionInFlight) refreshMountBridgeStatus(); }, 20000);
-refreshMountBridgeStatus().then(() => _markMbInitialLoadDone('mb'));
+refreshMountBridgeStatus();
 
 // Fast, best-effort drift refresh - kept deliberately separate from the 20s
 // connection-status poll above. That poll's cadence is intentionally slow
@@ -2813,6 +2747,11 @@ async function setWmCoupling(preset) {
   const originalText = btn.textContent;
   btn.disabled = true;
   btn.textContent = 'setting…';
+  // Result genuinely uncertain until the refreshMountBridgeStatus() call at
+  // the end confirms it either way - same pulsing-yellow-while-unsure
+  // language as everywhere else on this page, not just a text change on the
+  // one button someone happened to click.
+  document.getElementById('mount-bridge-dot').classList.add('dot-unconfirmed');
   const threshold = document.getElementById('wm-threshold-input').value;
   try {
     const params = new URLSearchParams({ mode });
@@ -2842,6 +2781,7 @@ async function triggerManualSync() {
   const originalText = btn.textContent;
   btn.disabled = true;
   btn.textContent = 'syncing…';
+  document.getElementById('mount-bridge-dot').classList.add('dot-unconfirmed');
   try {
     const resp = await fetch('/api/mount_bridge_manual_sync', { method: 'POST' });
     const data = await resp.json();
@@ -3058,19 +2998,13 @@ async function loadWmProfiles() {
     if (wmSelectedProfile) {
       refreshWmDriverButtons();
       refreshWmConnectRow();
-      if (changedProfile) {
-        checkKstarsLink().then(() => _markMbInitialLoadDone('kstars'));
-      } else {
-        _markMbInitialLoadDone('kstars');  // already checked before - nothing new to await
-      }
+      if (changedProfile) checkKstarsLink();
     } else {
       setWmDriverButton('lx200', null);
       setWmDriverButton('bridge', null);
       document.getElementById('wm-kstars-link-row').style.display = 'none';
-      _markMbInitialLoadDone('kstars');  // no profile selected - nothing to check
     }
   } catch (e) {
-    _markMbInitialLoadDone('kstars');  // profile load itself failed - nothing to check either
     selectEl.innerHTML = '<option>unavailable</option>';
     setWmDriverButton('lx200', null);
     setWmDriverButton('bridge', null);
@@ -3167,7 +3101,7 @@ async function checkEkosStatus() {
   updateStepIndicators();
 }
 setInterval(() => { if (!mbActionInFlight) checkEkosStatus(); }, 20000);
-checkEkosStatus().then(() => _markMbInitialLoadDone('ekos'));
+checkEkosStatus();
 
 function refreshWmServerButton() {
   const btn = document.getElementById('wm-server-btn');
@@ -3345,6 +3279,7 @@ async function setWmActiveDevices() {
   btn.disabled = true;
   const originalText = btn.textContent;
   btn.textContent = unlinking ? 'unlinking…' : 'linking…';
+  document.getElementById('mount-bridge-dot').classList.add('dot-unconfirmed');
   try {
     const params = unlinking ? 'action=unlink' : `mount=${encodeURIComponent(mount)}`;
     const resp = await fetch(`/api/mount_bridge_active_devices?${params}`, { method: 'POST' });
@@ -3388,6 +3323,7 @@ async function _setDeviceConnection(deviceName, btnId, disconnecting) {
   const btn = document.getElementById(btnId);
   btn.disabled = true;
   btn.textContent = disconnecting ? 'disconnecting…' : 'connecting…';
+  document.getElementById('mount-bridge-dot').classList.add('dot-unconfirmed');
   try {
     const params = new URLSearchParams({ device: deviceName });
     if (disconnecting) params.set('action', 'disconnect');
@@ -3711,7 +3647,7 @@ async function toggleWmDriver(driver, clickedBtnId) {
   setStepBusy(3, false);
 }
 
-loadWmProfiles().then(() => _markMbInitialLoadDone('profiles'));
+loadWmProfiles();
 setInterval(() => { if (!mbActionInFlight) loadWmProfiles(); }, 30000);
 
 // --- Test Hardware button: deeper functional checks (camera capture / IMU
@@ -3795,6 +3731,13 @@ async function runHardwareTest() {
   const statusText = document.getElementById('hwtest-status-text');
   btn.disabled = true;
   statusText.textContent = 'Running…';
+  // A re-run would otherwise keep showing the PREVIOUS run's colors while
+  // the new one is in progress - pulse all four (their ampel badges follow
+  // via setHwDot()) so a fresh run reads as "results pending", not as
+  // already-known.
+  ['hw-camera-dot', 'hw-imu-dot', 'hw-gps-dot'].forEach((id) => {
+    setHwDot(document.getElementById(id), 'status-dot dot-unconfirmed');
+  });
   let data;
   try {
     const resp = await fetch('/api/hardware_test', { method: 'POST' });

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -794,6 +794,38 @@
     margin-bottom: 1rem;
     font-size: 0.9rem;
   }
+  /* Full-page lock shown while the Control Center restarts itself after a
+     successful setup run (see enterCcRestartingState() below) - covers and
+     visually disables the whole page rather than individually disabling
+     every scattered button, since the server itself is about to die and
+     come back, not just one action being mid-flight. */
+  #cc-restart-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    background: rgba(10, 10, 10, 0.88);
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 2rem;
+  }
+  #cc-restart-overlay-box {
+    max-width: 26rem;
+    color: #ddd;
+  }
+  #cc-restart-overlay-box .spinner {
+    width: 2rem;
+    height: 2rem;
+    margin: 0 auto 1rem;
+    border: 3px solid #444;
+    border-top-color: #2a6fdb;
+    border-radius: 50%;
+    animation: cc-restart-spin 0.9s linear infinite;
+  }
+  @keyframes cc-restart-spin { to { transform: rotate(360deg); } }
+  #cc-restart-overlay-box p { margin: 0.3rem 0; }
+  #cc-restart-overlay-box .cc-restart-detail { color: #888; font-size: 0.85rem; }
   /* R-ROLE1 (docs/concepts/remote_indi_coupling_split_host.md): what the
      SELECTED PROFILE makes this device do - a colored, always-visible chip
      near the tile top (per direct feedback: a plain grey text line under
@@ -818,6 +850,15 @@
 <h1>PiFinder on Stellarmate Control Center</h1>
 
 <div id="conn-lost-banner" style="display:none;"></div>
+
+<div id="cc-restart-overlay">
+  <div id="cc-restart-overlay-box">
+    <div class="spinner"></div>
+    <p><strong>Update complete.</strong></p>
+    <p>Restarting the Control Center to load the new version&hellip;</p>
+    <p class="cc-restart-detail">This page will reload automatically once it's back.</p>
+  </div>
+</div>
 
 <div class="page">
   <div class="left-col">
@@ -1815,6 +1856,35 @@ async function watchForServerLoss() {
   }
 }
 
+// Server-triggered self-restart after a successful setup run (see
+// _cc_restart_pending in server.py) - unlike watchForServerLoss() above,
+// this is a KNOWN, deliberate restart the server told us is coming, so
+// instead of just freezing with a "reload it yourself" banner, this locks
+// the page, waits it out, and reloads automatically once the new process
+// actually answers.
+let ccRestarting = false;
+
+function enterCcRestartingState() {
+  if (ccRestarting) return;
+  ccRestarting = true;
+  document.getElementById('cc-restart-overlay').style.display = 'flex';
+  waitForControlCenterRestart();
+}
+
+async function waitForControlCenterRestart() {
+  const maxAttempts = 30;  // 30 * 500ms = 15s ceiling before giving up and reloading anyway
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    try {
+      await fetch('/', { cache: 'no-store' });
+      break;  // new process answered - reload below, whether this was the loop that found it or the ceiling
+    } catch (e) {
+      // still restarting (or mid-kill from the old process) - keep waiting
+    }
+  }
+  location.reload();
+}
+
 // Runs continuously whenever this tab isn't actively polling a run (i.e.
 // whenever pollLog()'s loop has stopped - idle, cancelled, succeeded, or
 // failed). Catches the case where a run gets started some other way (a
@@ -1825,11 +1895,20 @@ async function watchForServerLoss() {
 // elsewhere. Harmless either way (the server refuses to shut down mid-run),
 // but confusing, so resume live tracking instead of leaving it stale.
 async function watchForNewRun() {
-  if (serverConnectionLost) return;
+  if (serverConnectionLost || ccRestarting) return;
   if (!polling) {
     try {
       const resp = await fetch('/state', { cache: 'no-store' });
       const data = await resp.json();
+      if (data.restarting) {
+        // Same run-just-finished handoff as pollLog() - this tab wasn't
+        // the one actively polling the run (started elsewhere, or this
+        // tab was idle when it finished), but the restart is happening
+        // regardless, so hand off here too instead of leaving the idle
+        // watcher to just keep silently failing against a dead process.
+        enterCcRestartingState();
+        return;
+      }
       if (data.running) {
         document.getElementById('reboot-wrap').style.display = 'none';
         document.getElementById('reset-wrap').style.display = 'none';
@@ -1986,6 +2065,16 @@ async function pollLog() {
     // stop polling and tell the user this view is now frozen.
     polling = false;
     showServerLostBanner();
+    return;
+  }
+  if (data.restarting) {
+    // The run just finished successfully and the server already committed
+    // to restarting itself (see _cc_restart_pending) - stop polling and
+    // hand off to the lock-overlay/reconnect flow instead of the normal
+    // success screen, which would be showing stale-by-the-time-you-read-it
+    // buttons for a process that's about to die anyway.
+    polling = false;
+    enterCcRestartingState();
     return;
   }
   if (data.lines.length > 0) {

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -3496,6 +3496,17 @@ function updateProfileRoleLine() {
   document.getElementById('mb-steps-4-6').style.display = hostMode ? 'none' : '';
   document.getElementById('mb-setup-btn-row').style.display = hostMode ? 'none' : '';
   document.getElementById('mb-thisdevice-ip-row').style.display = hostMode ? '' : 'none';
+  // The status line/diagram/caption are entirely derived from Mount
+  // Bridge's own reported state (PiFinder/Bridge/Mount connection, drift,
+  // coupling mode) - none of that is obtainable in the PiFinder-host role,
+  // since there's no Mount Bridge driver in the profile to ask. Found live
+  // (2026-07-29): leaving them visible showed a permanently red, "not
+  // coupled" diagram even while PiFinder itself was confirmed running -
+  // technically accurate (nothing to report) but read as broken. The role
+  // banner above already says everything this role needs to say.
+  document.getElementById('mb-status-row').style.display = hostMode ? 'none' : '';
+  document.getElementById('mb-diagram').style.display = hostMode ? 'none' : '';
+  document.getElementById('mb-mode-caption').style.display = hostMode ? 'none' : '';
   if (role === null) {
     el.style.display = 'none';
     return;


### PR DESCRIPTION
## Summary
Release v1.3.1 - see [CHANGELOG.md](https://github.com/apos/PiFinder_Stellarmate/blob/dev/CHANGELOG.md#131---2026-07-29) for the full list. Highlights:
- Control Center restarts itself automatically after a successful Install/Update run
- Every "still checking" indicator unified onto one pulsing-yellow-dot pattern
- Mount Bridge tile is role-aware (no more misleading diagram in PiFinder-host role)
- PiFinder "starting" status + red OLED placeholder matching real hardware

## Test plan
- [x] Live cross-device testing (Pi4 + Pi5) across All-in-one, PiFinder host, and Control host roles
- [x] `node --check`, HTML div-balance, `python3 -m py_compile` on all changed files