### PR TITLE
feat: Uninstall/Reset actions in the setup script and Control Center

### DIFF
--- a/bin/uninstall_pifinder_stellarmate.sh
+++ b/bin/uninstall_pifinder_stellarmate.sh
@@ -7,6 +7,8 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=./functions.sh
 source "${SCRIPT_DIR}/functions.sh"
+# shellcheck source=./os_detect.sh
+source "${SCRIPT_DIR}/os_detect.sh"
 
 # Every systemd unit this project installs into /etc/systemd/system. Keep in
 # sync with the "cp ... /etc/systemd/system/" lines in
@@ -87,7 +89,18 @@ _unmask_wireplumber() {
         fi
     done
     echo "   ℹ️  pipewire-libcamera was removed from the system during install (it conflicted with"
-    echo "      PiFinder's camera access) - reinstall manually if you want it back: sudo pacman -S pipewire-libcamera"
+    local manager
+    if manager="$(os_detect_package_manager 2>/dev/null)" && [ "${manager}" = "pacman" ]; then
+        echo "      PiFinder's camera access) - reinstall manually if you want it back: sudo pacman -S pipewire-libcamera"
+    else
+        # This removal only happens on the pacman/Arch (StellarMate) full
+        # install path this script otherwise targets - on any other package
+        # manager, say so honestly instead of printing an untested apt/nix
+        # command (see os_detect.sh's own header: apt/nix are design- not
+        # field-verified, and pipewire-libcamera isn't in its package table
+        # at all yet).
+        echo "      PiFinder's camera access) - reinstall manually via your system's package manager if you want it back."
+    fi
 }
 
 _remove_lgpio_build() {
@@ -111,8 +124,15 @@ _print_manual_cleanup_notes() {
     echo "      dtoverlay=pwm,pin=13,func=4, dtoverlay=imx296, and (Pi4) dtoverlay=uart3 /"
     echo "      (Pi5) dtoverlay=pwm-2chan. Other hardware/StellarMate features may also depend on"
     echo "      SPI/I2C being enabled - review and remove by hand if you're sure nothing else needs them."
-    echo "    - /etc/pacman.conf: 'IgnorePkg = python-libcamera' pin (prevents an incompatible"
-    echo "      libcamera-vs-python-libcamera version mismatch) - remove by hand if desired."
+    # The python-libcamera pin only exists on the pacman/Arch (StellarMate)
+    # full install path - pacman.conf's IgnorePkg mechanism has no apt/nix
+    # equivalent, so this note would be actively wrong (references a file
+    # that doesn't exist) on those systems. Only print it where it applies.
+    local manager
+    if manager="$(os_detect_package_manager 2>/dev/null)" && [ "${manager}" = "pacman" ]; then
+        echo "    - /etc/pacman.conf: 'IgnorePkg = python-libcamera' pin (prevents an incompatible"
+        echo "      libcamera-vs-python-libcamera version mismatch) - remove by hand if desired."
+    fi
     echo "    - Hardware group memberships added to your user (spi, gpio, i2c, kmem, input, video)."
 }
 

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -1096,6 +1096,30 @@ def _do_poweroff():
 _server = None  # set in main(); used by /shutdown to stop serve_forever()
 
 
+UNINSTALL_SCRIPT = REPO_ROOT / "bin" / "uninstall_pifinder_stellarmate.sh"
+
+
+def _do_uninstall():
+    # This server process runs from inside the very directory tree being
+    # deleted (~/PiFinder_Stellarmate) - --selfmove copies the uninstall
+    # script to /tmp first and continues from there, so the removal of this
+    # repo (and this server's own pifinder-control-center.service) survives
+    # this process's own directory disappearing out from under it. See the
+    # script's own --selfmove header comment for the full rationale.
+    time.sleep(1)  # give the HTTP response a moment to reach the browser
+    subprocess.run(["bash", str(UNINSTALL_SCRIPT), "--selfmove"])
+
+
+def _do_reset():
+    # --reset only touches ~/PiFinder's own venv/build state, never this
+    # repo's own directory - unlike _do_uninstall() above, safe to run
+    # directly and report the result, no --selfmove/self-deletion concern.
+    result = subprocess.run(
+        ["bash", str(UNINSTALL_SCRIPT), "--reset"], capture_output=True, text=True,
+    )
+    return result.returncode == 0, (result.stdout + result.stderr)[-4000:]
+
+
 def _do_shutdown():
     time.sleep(1)  # give the HTTP response a moment to reach the browser
     # Persist "should NOT run after a reboot" the same way starting it (via
@@ -1520,7 +1544,7 @@ class Handler(BaseHTTPRequestHandler):
         self.send_error(404)
 
     def do_POST(self):
-        global _hwtest_running
+        global _hwtest_running, _mode_action_running
         parsed = urlparse(self.path)
 
         # /shutdown stays open: PiFinder's PFSM page (a different
@@ -1590,8 +1614,31 @@ class Handler(BaseHTTPRequestHandler):
             threading.Thread(target=_do_poweroff, daemon=True).start()
             return
 
+        if parsed.path == "/uninstall":
+            with _lock:
+                if _running or _mode_action_running or _hwtest_running:
+                    self._send_json(
+                        {"uninstalling": False, "error": "An install/update run, mode switch, or hardware test is in progress - wait for it to finish first."},
+                        status=409,
+                    )
+                    return
+            self._send_json({"uninstalling": True})
+            threading.Thread(target=_do_uninstall, daemon=True).start()
+            return
+
+        if parsed.path == "/reset":
+            with _lock:
+                if _running or _mode_action_running or _hwtest_running:
+                    self._send_json(
+                        {"success": False, "error": "An install/update run, mode switch, or hardware test is in progress - wait for it to finish first."},
+                        status=409,
+                    )
+                    return
+            ok, output = _do_reset()
+            self._send_json({"success": ok, "output": output})
+            return
+
         if parsed.path == "/api/pifinder_mode":
-            global _mode_action_running
             qs = parse_qs(parsed.query)
             action = qs.get("action", [""])[0]
             if action not in ("enable_fake", "disable_fake"):

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -314,8 +314,15 @@
   .mode-power-group-buttons-stacked { flex-direction: column; }
   #power-reboot-btn { background: #2a6fdb; }
   #power-poweroff-btn { background: #a33; }
+  #install-uninstall-btn { background: #a33; }
   .power-btn:hover { filter: brightness(1.15); }
   .power-btn:disabled { background: #444; cursor: default; filter: none; }
+  #install-power-divider {
+    width: 1px;
+    align-self: stretch;
+    background: #444;
+    margin-top: 1.2rem;
+  }
   #mode-tile {
     background: #1a1a1a;
     border: 1px solid #333;
@@ -855,6 +862,14 @@
             <div class="mode-power-group-buttons mode-power-group-buttons-stacked">
               <button id="power-reboot-btn" class="power-btn" onclick="powerAction('reboot')">Reboot Pi</button>
               <button id="power-poweroff-btn" class="power-btn" onclick="powerAction('poweroff')">Shutdown Pi</button>
+            </div>
+          </div>
+          <div id="install-power-divider"></div>
+          <div class="mode-power-group" title="Uses bin/uninstall_pifinder_stellarmate.sh. Reset keeps your data/config and only wipes the Python venv/build state, ready for a fresh setup run. Uninstall removes everything this project installed (services, INDI drivers, ~/PiFinder).">
+            <div class="group-label">Installation</div>
+            <div class="mode-power-group-buttons mode-power-group-buttons-stacked">
+              <button id="install-reset-btn" class="ql-small-btn" onclick="installAction('reset')" style="margin-left:0;">Reset</button>
+              <button id="install-uninstall-btn" class="power-btn" onclick="installAction('uninstall')">Uninstall</button>
             </div>
           </div>
         </div>
@@ -1961,6 +1976,62 @@ async function powerAction(kind) {
     // accepted the request - treat it the same as a confirmed action.
   }
   watchForServerLoss();
+}
+
+// Uninstall/Reset - both drive bin/uninstall_pifinder_stellarmate.sh (see
+// its own header comments for --selfmove/--reset). Reset is comparatively
+// low-risk (venv/build state only, keeps data/config); Uninstall is final
+// and removes everything this project installed, including this very
+// server's own directory - handled the same way as reboot/poweroff
+// (watchForServerLoss(), since there's no coming back from this one).
+async function installAction(kind) {
+  const isUninstall = kind === 'uninstall';
+  const message = isUninstall
+    ? '⚠ Uninstall PiFinder completely? This stops and removes all PiFinder services, INDI drivers, and ~/PiFinder itself. This page (and this whole Control Center) will stop working once it starts. This cannot be undone from here.'
+    : 'Reset PiFinder? This wipes the Python venv/build state only - your data, config, and installed services/drivers are kept. Ready for a fresh setup run afterward.';
+  if (!confirm(message)) return;
+  const resetBtn = document.getElementById('install-reset-btn');
+  const uninstallBtn = document.getElementById('install-uninstall-btn');
+  const btn = isUninstall ? uninstallBtn : resetBtn;
+  resetBtn.disabled = true;
+  uninstallBtn.disabled = true;
+  btn.textContent = isUninstall ? 'Uninstalling…' : 'Resetting…';
+  try {
+    const resp = await fetch(`/${kind}`, { method: 'POST' });
+    const data = await resp.json();
+    if (isUninstall) {
+      if (!data.uninstalling) {
+        resetBtn.disabled = false;
+        uninstallBtn.disabled = false;
+        btn.textContent = 'Uninstall';
+        alert('Could not start uninstall: ' + (data.error || 'unknown error'));
+        return;
+      }
+      watchForServerLoss();
+      return;
+    }
+    // Reset runs synchronously server-side and returns its own result -
+    // no server-loss handling needed, this repo's own directory is untouched.
+    resetBtn.disabled = false;
+    uninstallBtn.disabled = false;
+    btn.textContent = 'Reset';
+    if (data.success) {
+      alert('Reset complete - venv/build state cleared. Run the setup script again to rebuild.');
+    } else {
+      alert('Reset failed:\n\n' + (data.output || data.error || 'unknown error'));
+    }
+  } catch (e) {
+    if (isUninstall) {
+      // Network error here can also mean the server went down right as it
+      // accepted the request - treat it the same as a confirmed action.
+      watchForServerLoss();
+    } else {
+      resetBtn.disabled = false;
+      uninstallBtn.disabled = false;
+      btn.textContent = 'Reset';
+      alert('Reset request failed.');
+    }
+  }
 }
 
 // Direct pifinder.service control (start/stop/restart) - shouldn't normally

--- a/pifinder_stellarmate_setup.sh
+++ b/pifinder_stellarmate_setup.sh
@@ -268,17 +268,21 @@ if [ -d "${pifinder_home}/PiFinder" ]; then
         echo "   1. Delete the existing installation and reinstall from scratch."
         echo "   2. Update the existing installation with 'git reset --hard origin/release'."
         echo "   3. Cancel the installation."
+        echo "   4. Uninstall PiFinder completely (removes services, INDI drivers, ~/PiFinder)."
+        echo "   5. Reset (keep data/config, wipe venv/build only, ready to re-run setup)."
 
         case "$ACTION" in
             reinstall) choice="1" ;;
             update)    choice="2" ;;
             cancel)    choice="3" ;;
+            uninstall) choice="4" ;;
+            reset)     choice="5" ;;
             "")
-                read -p "Enter your choice (1, 2, or 3): " choice
+                read -p "Enter your choice (1-5): " choice
                 choice="${choice//[$'\r\n']}"
                 ;;
             *)
-                echo "❌ Unknown --action='$ACTION' (expected reinstall|update|cancel)."
+                echo "❌ Unknown --action='$ACTION' (expected reinstall|update|cancel|uninstall|reset)."
                 exit 1
                 ;;
         esac
@@ -378,9 +382,24 @@ if [ -d "${pifinder_home}/PiFinder" ]; then
                 echo "ℹ️  Installation cancelled by user."
                 exit 0
                 ;;
+            4)
+                echo "➡️  Selected: 4. Uninstall PiFinder completely."
+                # Plain (non-selfmove) invocation: safe to run directly here,
+                # this is a bash-level call, not the Control Center's own
+                # long-running Python server serving out of this directory -
+                # see bin/uninstall_pifinder_stellarmate.sh's own --selfmove
+                # comment for why that distinction matters.
+                bash "${pifinder_stellarmate_bin}/uninstall_pifinder_stellarmate.sh"
+                exit 0
+                ;;
+            5)
+                echo "➡️  Selected: 5. Reset (keep data/config, wipe venv/build only)."
+                bash "${pifinder_stellarmate_bin}/uninstall_pifinder_stellarmate.sh" --reset
+                exit 0
+                ;;
             *)
                 echo "➡️  Selected: $choice (invalid)"
-                echo "❌ Invalid choice. Please run the script again and select 1, 2, or 3."
+                echo "❌ Invalid choice. Please run the script again and select 1-5."
                 exit 1
                 ;;
         esac


### PR DESCRIPTION
## Summary

`bin/uninstall_pifinder_stellarmate.sh` existed and was kept up to date, but was never wired up anywhere - no menu choice in `pifinder_stellarmate_setup.sh`, no button in the Control Center, SSH-only. Found while reviewing the project's own gaps.

- **Setup script**: new choices 4 (Uninstall) and 5 (Reset) in the existing-install menu, `--action=uninstall|reset`.
- **Control Center**: new "Installation" button group (Reset/Uninstall) next to the Pi power controls. Uninstall uses the script's own `--selfmove` (this server's own process runs from inside the directory being deleted); Reset runs synchronously and reports its own output (only touches `~/PiFinder`'s venv/build state). Confirmation dialogs + server-loss handling for Uninstall mirror the existing Reboot/Shutdown pattern.
- **`bin/uninstall_pifinder_stellarmate.sh`**: two cleanup hints were hardcoded to pacman/Arch phrasing even though the project's own `os_detect.sh` abstraction (added for `--mode=indi_only`) already distinguishes pacman/apt/nix - now only printed where they actually apply.

## Test plan

Covered by [TC-PFSM-84-01 (#86)](https://github.com/apos/PiFinder_Stellarmate/issues/86) in the [test case catalog](https://github.com/users/apos/projects/15).