### PR TITLE
fix: uninstall/reset UI cleanup + two real bugs found while testing TC-PFSM-84-01

### DIFF
--- a/.github/ISSUE_TEMPLATE/test-case.yml
+++ b/.github/ISSUE_TEMPLATE/test-case.yml
@@ -1,0 +1,60 @@
+name: Test Case
+description: New test case for the reusable test case catalog
+title: "[Test Case] "
+labels: ["test-case"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A test case is a **reusable definition** — not an execution result and not a Pass/Fail.
+        See [CONVENTIONS.md](../../CONVENTIONS.md) for how to use it.
+
+  - type: textarea
+    id: precondition
+    attributes:
+      label: Precondition
+      description: State that must be true before testing starts.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps
+      description: >
+        Numbered, exact steps — no paraphrasing. Give an expected result only for steps where
+        something checkable happens; pure navigation/setup steps stay without their own result.
+      placeholder: |
+        1. ...
+           Expected: ...
+        2. ...
+        3. ...
+           Expected: ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: postcondition
+    attributes:
+      label: Postcondition
+      description: State after a successful test run.
+    validations:
+      required: false
+
+  - type: input
+    id: test-type
+    attributes:
+      label: Test Type / Category
+      description: >
+        e.g. functional, regression, smoke, installation — determines which set:* label(s)
+        should be added to the issue.
+    validations:
+      required: false
+
+  - type: input
+    id: reference
+    attributes:
+      label: Reference (Requirement / Issue / Feature)
+      description: Traceability — what does this test case relate to?
+    validations:
+      required: false

--- a/bin/uninstall_pifinder_stellarmate.sh
+++ b/bin/uninstall_pifinder_stellarmate.sh
@@ -136,26 +136,33 @@ _print_manual_cleanup_notes() {
     echo "    - Hardware group memberships added to your user (spi, gpio, i2c, kmem, input, video)."
 }
 
-echo "🚫 Uninstalling PiFinder (Stellarmate version) ..."
+# The --reset path further below is meant to be non-destructive (keep
+# services/drivers/data, only wipe venv/build) - it must never fall through
+# this full-uninstall body first. Everything else (plain invocation,
+# --selfmove, --run) is supposed to do a real uninstall, so they still run
+# this normally.
+if [[ "${1:-}" != "--reset" ]]; then
+    echo "🚫 Uninstalling PiFinder (Stellarmate version) ..."
 
-_stop_disable_remove_units
-_remove_indi_drivers
-_remove_gpiomem_udev_rule
-_unmask_wireplumber
-_remove_lgpio_build
+    _stop_disable_remove_units
+    _remove_indi_drivers
+    _remove_gpiomem_udev_rule
+    _unmask_wireplumber
+    _remove_lgpio_build
 
-echo "🗂️ Deleting PiFinder installation directory ..."
-sudo rm -rf "${pifinder_dir}"
+    echo "🗂️ Deleting PiFinder installation directory ..."
+    sudo rm -rf "${pifinder_dir}"
 
-echo "⚠️  NOTE: The folder ${pifinder_data_dir} was NOT removed."
-echo "    You can delete it manually if needed."
+    echo "⚠️  NOTE: The folder ${pifinder_data_dir} was NOT removed."
+    echo "    You can delete it manually if needed."
 
-echo "📦 Optional: You may now remove the repository clone with:"
-echo "    rm -rf ${pifinder_stellarmate_dir}"
+    echo "📦 Optional: You may now remove the repository clone with:"
+    echo "    rm -rf ${pifinder_stellarmate_dir}"
 
-_print_manual_cleanup_notes
+    _print_manual_cleanup_notes
 
-echo "✅ Uninstall complete."
+    echo "✅ Uninstall complete."
+fi
 
 
 if [[ "${1:-}" == "--selfmove" ]]; then

--- a/bin/uninstall_pifinder_stellarmate.sh
+++ b/bin/uninstall_pifinder_stellarmate.sh
@@ -7,6 +7,8 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=./functions.sh
 source "${SCRIPT_DIR}/functions.sh"
+# shellcheck source=./os_detect.sh
+source "${SCRIPT_DIR}/os_detect.sh"
 
 # Every systemd unit this project installs into /etc/systemd/system. Keep in
 # sync with the "cp ... /etc/systemd/system/" lines in
@@ -87,7 +89,18 @@ _unmask_wireplumber() {
         fi
     done
     echo "   ℹ️  pipewire-libcamera was removed from the system during install (it conflicted with"
-    echo "      PiFinder's camera access) - reinstall manually if you want it back: sudo pacman -S pipewire-libcamera"
+    local manager
+    if manager="$(os_detect_package_manager 2>/dev/null)" && [ "${manager}" = "pacman" ]; then
+        echo "      PiFinder's camera access) - reinstall manually if you want it back: sudo pacman -S pipewire-libcamera"
+    else
+        # This removal only happens on the pacman/Arch (StellarMate) full
+        # install path this script otherwise targets - on any other package
+        # manager, say so honestly instead of printing an untested apt/nix
+        # command (see os_detect.sh's own header: apt/nix are design- not
+        # field-verified, and pipewire-libcamera isn't in its package table
+        # at all yet).
+        echo "      PiFinder's camera access) - reinstall manually via your system's package manager if you want it back."
+    fi
 }
 
 _remove_lgpio_build() {
@@ -111,8 +124,15 @@ _print_manual_cleanup_notes() {
     echo "      dtoverlay=pwm,pin=13,func=4, dtoverlay=imx296, and (Pi4) dtoverlay=uart3 /"
     echo "      (Pi5) dtoverlay=pwm-2chan. Other hardware/StellarMate features may also depend on"
     echo "      SPI/I2C being enabled - review and remove by hand if you're sure nothing else needs them."
-    echo "    - /etc/pacman.conf: 'IgnorePkg = python-libcamera' pin (prevents an incompatible"
-    echo "      libcamera-vs-python-libcamera version mismatch) - remove by hand if desired."
+    # The python-libcamera pin only exists on the pacman/Arch (StellarMate)
+    # full install path - pacman.conf's IgnorePkg mechanism has no apt/nix
+    # equivalent, so this note would be actively wrong (references a file
+    # that doesn't exist) on those systems. Only print it where it applies.
+    local manager
+    if manager="$(os_detect_package_manager 2>/dev/null)" && [ "${manager}" = "pacman" ]; then
+        echo "    - /etc/pacman.conf: 'IgnorePkg = python-libcamera' pin (prevents an incompatible"
+        echo "      libcamera-vs-python-libcamera version mismatch) - remove by hand if desired."
+    fi
     echo "    - Hardware group memberships added to your user (spi, gpio, i2c, kmem, input, video)."
 }
 

--- a/bin/uninstall_pifinder_stellarmate.sh
+++ b/bin/uninstall_pifinder_stellarmate.sh
@@ -16,13 +16,21 @@ source "${SCRIPT_DIR}/os_detect.sh"
 # once already (pifinder-setup.service, pifinder-fake-mode-autostart.service,
 # pifinder-control-center.service and pifinder-numpad-bridge.service all
 # postdate the original version of this script and were missing here).
+# pifinder-control-center.service deliberately LAST: when this runs via the
+# Control Center's own Uninstall button, that service IS this process's own
+# systemd unit - stopping it here kills the server mid-uninstall. Ordering
+# it last (not e.g. 5th of 6, its original position) buys the frontend the
+# most possible time to poll and render the other units' stop/disable/
+# remove output before that happens (found live 2026-08-01: with the
+# original ordering, the connection dropped before even the first poll
+# completed - "Jetzt kam sofort die Meldung, nix im Terminal").
 SYSTEM_UNITS=(
     pifinder.service
     pifinder_splash.service
     pifinder-setup.service
     pifinder-fake-mode-autostart.service
-    pifinder-control-center.service
     pifinder-numpad-bridge.service
+    pifinder-control-center.service
 )
 
 SYSTEM_DRIVERS_XML="/usr/share/indi/drivers.xml"

--- a/gui_installer/help.html
+++ b/gui_installer/help.html
@@ -110,6 +110,13 @@
 <p>For running just the INDI drivers and Control Center on a host with no PiFinder hardware attached at all - e.g. a separate StellarMate/Astroberry "control host" coupled to a real PiFinder elsewhere over the network (see <code>docs/concepts/remote_indi_coupling_split_host.md</code>). Check the box, then click <strong>Install INDI-only</strong>.</p>
 <p>Installs the INDI build dependencies (<code>cmake</code>, build tools, <code>libindi-dev</code>, <code>git</code>) and builds/installs both INDI drivers - nothing else. Your existing <code>~/PiFinder</code> installation (if any) is never touched: no clone/patch, no Python environment, no star catalog, no GPIO/udev setup. On StellarMate, package installation briefly and automatically disables StellarMate's own Atomic Updates protection (voids the warranty while running) and restores it immediately afterward, success or failure - you'll see StellarMate's own warning text scroll past in the log; that's expected, not an error.</p>
 
+<h2 id="reset-uninstall">Reset / Uninstall</h2>
+<p>Both use <code>bin/uninstall_pifinder_stellarmate.sh</code> and act on the whole PiFinder_Stellarmate installation - services, INDI drivers, and <code>~/PiFinder</code> - separately from the Reinstall/Update actions above (those only touch <code>~/PiFinder</code>'s code).</p>
+<ul>
+  <li><strong>Reset</strong>: wipes the Python virtual environment and build state only. Your data, config, and installed services/drivers are kept. Use this to get a clean slate for a fresh setup run without losing anything else.</li>
+  <li><strong>Uninstall</strong>: stops and removes everything this project installed - systemd services, INDI drivers, and the <code>~/PiFinder</code> directory itself. This page (and this whole Control Center) stops working once it starts, since the Control Center's own service is one of the things removed. Cannot be undone from here.</li>
+</ul>
+
 <h2 id="pifinder-host-setup">Device roles: All-in-one, PiFinder host, Control host</h2>
 
 <h3 id="pifinder-host-what">What is this about?</h3>

--- a/gui_installer/indi_client.py
+++ b/gui_installer/indi_client.py
@@ -551,7 +551,7 @@ def set_number(
 # maps to - which mode needs DRIFT_THRESHOLD/CORRECTION_ACTION and which
 # doesn't (MODE_GOTO_FORWARD needs neither, confirmed against
 # pifinder_mount_bridge.cpp's TimerHit()).
-COUPLING_MODES = {"MODE_VERIFY_ALERT", "MODE_AUTO_CORRECT", "MODE_GOTO_FORWARD"}
+COUPLING_MODES = {"MODE_OFF", "MODE_VERIFY_ALERT", "MODE_AUTO_CORRECT", "MODE_GOTO_FORWARD"}
 DRIFT_THRESHOLD_DEFAULT = 5.0  # matches the driver's own IUFillNumber default
 CORRECTION_ACTION_DEFAULT = "sync"  # matches the driver's own default (ACTION_SYNC is ISS_ON)
 

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -827,18 +827,32 @@ def _run_hardware_test():
     test's PiFinder-is-running branch and the GPS snapshot both hit the same
     /api/status endpoint, and running I2C/camera probes concurrently would
     only make failures harder to attribute to one subsystem."""
+    # try/finally is load-bearing, not defensive style: found live 2026-08-01
+    # that without it, an uncaught exception from any of the three checks
+    # below (plausible whenever the device is between installs - ~/PiFinder
+    # missing, no venv, etc.) leaves _hwtest_running stuck True forever, in a
+    # daemon thread that just dies silently - permanently locking out every
+    # other mutex-guarded action (Reset/Uninstall/Reinstall/mode switch/...)
+    # until the whole service is restarted, and the startup auto-run (see
+    # _startup_hardware_test() below) can then hit the exact same failure
+    # again on the very next start.
     global _hwtest_running, _hwtest_result
     with _lock:
         _hwtest_lines.clear()
         _hwtest_result = {"camera": None, "imu": None, "gps": None}
-    _hwtest_log("=== Test Hardware: starting Camera / IMU / GPS checks ===")
-    camera_result = _camera_functional_test(_hwtest_log)
-    imu_result = _imu_functional_test(_hwtest_log)
-    gps_location = _gps_status_snapshot(_hwtest_log)
-    _hwtest_log("=== Test Hardware: done ===")
-    with _lock:
-        _hwtest_result = {"camera": camera_result, "imu": imu_result, "gps": gps_location}
-        _hwtest_running = False
+    try:
+        _hwtest_log("=== Test Hardware: starting Camera / IMU / GPS checks ===")
+        camera_result = _camera_functional_test(_hwtest_log)
+        imu_result = _imu_functional_test(_hwtest_log)
+        gps_location = _gps_status_snapshot(_hwtest_log)
+        _hwtest_log("=== Test Hardware: done ===")
+        with _lock:
+            _hwtest_result = {"camera": camera_result, "imu": imu_result, "gps": gps_location}
+    except Exception as e:
+        _hwtest_log(f"=== Test Hardware: internal error - {e} ===")
+    finally:
+        with _lock:
+            _hwtest_running = False
 
 
 def _startup_hardware_test(timeout=120, interval=2):
@@ -894,7 +908,25 @@ def _pifinder_toggle_debug_solve(port: str) -> bool:
 
 
 def _run_fake_mode_action(action):
-    global _mode_action_running, _mode_lines, _mode_exit_code, _mode_error, _mode_target
+    # try/finally wrapper is load-bearing, not defensive style - see
+    # _run_hardware_test()'s comment for the general shape of this bug
+    # (found live there first, 2026-08-01). _run_fake_mode_action_inner()'s
+    # tail (settle-check loop, _camera_hardware_present()/
+    # _imu_hardware_present() probes, a journalctl subprocess.run() call) has
+    # no exception handling of its own - an uncaught exception anywhere in
+    # there would leave _mode_action_running stuck True forever, same
+    # lock-everything-out consequence. Wrapped here instead of re-indenting
+    # the whole (long, already-branchy) inner function.
+    global _mode_action_running
+    try:
+        _run_fake_mode_action_inner(action)
+    finally:
+        with _lock:
+            _mode_action_running = False
+
+
+def _run_fake_mode_action_inner(action):
+    global _mode_lines, _mode_exit_code, _mode_error, _mode_target
     target = "fake" if action == "start" else "real"
     with _lock:
         _mode_lines = []
@@ -975,7 +1007,8 @@ def _run_fake_mode_action(action):
                 _mode_lines.extend(journal.splitlines())
             else:
                 _mode_error = "Fake Mode failed to start - see Terminal below."
-        _mode_action_running = False
+    # _mode_action_running is cleared by the _run_fake_mode_action() wrapper's
+    # finally block, not here - see its comment.
 
 
 def _get_all_ips():
@@ -1012,38 +1045,52 @@ def _restart_control_center():
 
 
 def _reader_thread(proc):
+    # try/finally is load-bearing, not defensive style - see
+    # _run_hardware_test()'s comment for the general shape of this bug
+    # (found live there first, 2026-08-01). This is the MAIN install/update/
+    # reinstall run's own reader - previously had no exception handling at
+    # all, so a failure here (LOG_FILE unwritable, a readline() error, ...)
+    # would've left _running stuck True forever, locking out every other
+    # mutex-guarded action AND blocking any retry of the run itself.
     global _running, _exit_code, _phase_index, _reboot_needed, _cc_restart_pending
     # _last_mode is set by _start_run() before this thread starts and never
     # changes for the lifetime of this run - safe to read once, unlocked.
     phases = PHASES_INDI_ONLY if _last_mode == "indi_only" else PHASES
-    with open(LOG_FILE, "w") as log_f:
-        for line in iter(proc.stdout.readline, ""):
-            log_f.write(line)
-            log_f.flush()
-            stripped = line.rstrip("\n")
-            if stripped.startswith(PHASE_MARKER):
-                label = stripped[len(PHASE_MARKER):]
-                if label in phases:
+    try:
+        with open(LOG_FILE, "w") as log_f:
+            for line in iter(proc.stdout.readline, ""):
+                log_f.write(line)
+                log_f.flush()
+                stripped = line.rstrip("\n")
+                if stripped.startswith(PHASE_MARKER):
+                    label = stripped[len(PHASE_MARKER):]
+                    if label in phases:
+                        with _lock:
+                            _phase_index = max(_phase_index, phases.index(label))
+                    continue  # phase markers are for the progress bar, not the log panel
+                if stripped.startswith(REBOOT_MARKER):
                     with _lock:
-                        _phase_index = max(_phase_index, phases.index(label))
-                continue  # phase markers are for the progress bar, not the log panel
-            if stripped.startswith(REBOOT_MARKER):
+                        _reboot_needed = stripped[len(REBOOT_MARKER):] == "true"
+                    continue  # marker is for the Reboot button, not the log panel
                 with _lock:
-                    _reboot_needed = stripped[len(REBOOT_MARKER):] == "true"
-                continue  # marker is for the Reboot button, not the log panel
-            with _lock:
-                _lines.append(stripped)
-    proc.wait()
-    with _lock:
-        _running = False
-        _exit_code = proc.returncode
-        # Any successful run (fresh/reinstall/update, any mode) already ran
-        # switch_branch.sh + self_update.sh at its very start, so it may have
-        # landed on different PiFinder_Stellarmate code regardless of which
-        # action was picked - always restart on success, not just for
-        # specific actions.
-        if _exit_code == 0:
-            _cc_restart_pending = True
+                    _lines.append(stripped)
+        proc.wait()
+        with _lock:
+            _exit_code = proc.returncode
+    except Exception as e:
+        with _lock:
+            _lines.append(f"[setup GUI] internal error: {e}")
+            _exit_code = -1
+    finally:
+        with _lock:
+            _running = False
+            # Any successful run (fresh/reinstall/update, any mode) already ran
+            # switch_branch.sh + self_update.sh at its very start, so it may have
+            # landed on different PiFinder_Stellarmate code regardless of which
+            # action was picked - always restart on success, not just for
+            # specific actions.
+            if _exit_code == 0:
+                _cc_restart_pending = True
     if _exit_code == 0:
         threading.Thread(target=_restart_control_center, daemon=True).start()
 
@@ -1171,18 +1218,30 @@ def _run_reset():
     ~/PiFinder's own venv/build state, never this repo's own directory -
     unlike _do_uninstall(), safe to run directly, no --selfmove/self-deletion
     concern."""
+    # try/finally is load-bearing - see _run_hardware_test()'s comment for
+    # why (found live 2026-08-01: the same missing-try/finally bug, there in
+    # _run_hardware_test(), permanently locked out every other mutex-guarded
+    # action). Popen()/readline() throwing here is less likely than a real
+    # hardware check throwing, but "less likely" isn't "impossible."
     global _reset_running, _reset_exit_code
-    proc = subprocess.Popen(
-        ["bash", str(UNINSTALL_SCRIPT), "--reset"],
-        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1,
-    )
-    for line in iter(proc.stdout.readline, ""):
+    try:
+        proc = subprocess.Popen(
+            ["bash", str(UNINSTALL_SCRIPT), "--reset"],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1,
+        )
+        for line in iter(proc.stdout.readline, ""):
+            with _lock:
+                _reset_lines.append(line.rstrip("\n"))
+        proc.wait()
         with _lock:
-            _reset_lines.append(line.rstrip("\n"))
-    proc.wait()
-    with _lock:
-        _reset_running = False
-        _reset_exit_code = proc.returncode
+            _reset_exit_code = proc.returncode
+    except Exception as e:
+        with _lock:
+            _reset_lines.append(f"[setup GUI] internal error: {e}")
+            _reset_exit_code = -1
+    finally:
+        with _lock:
+            _reset_running = False
 
 
 def _do_shutdown():

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -1096,6 +1096,30 @@ def _do_poweroff():
 _server = None  # set in main(); used by /shutdown to stop serve_forever()
 
 
+UNINSTALL_SCRIPT = REPO_ROOT / "bin" / "uninstall_pifinder_stellarmate.sh"
+
+
+def _do_uninstall():
+    # This server process runs from inside the very directory tree being
+    # deleted (~/PiFinder_Stellarmate) - --selfmove copies the uninstall
+    # script to /tmp first and continues from there, so the removal of this
+    # repo (and this server's own pifinder-control-center.service) survives
+    # this process's own directory disappearing out from under it. See the
+    # script's own --selfmove header comment for the full rationale.
+    time.sleep(1)  # give the HTTP response a moment to reach the browser
+    subprocess.run(["bash", str(UNINSTALL_SCRIPT), "--selfmove"])
+
+
+def _do_reset():
+    # --reset only touches ~/PiFinder's own venv/build state, never this
+    # repo's own directory - unlike _do_uninstall() above, safe to run
+    # directly and report the result, no --selfmove/self-deletion concern.
+    result = subprocess.run(
+        ["bash", str(UNINSTALL_SCRIPT), "--reset"], capture_output=True, text=True,
+    )
+    return result.returncode == 0, (result.stdout + result.stderr)[-4000:]
+
+
 def _do_shutdown():
     time.sleep(1)  # give the HTTP response a moment to reach the browser
     # Persist "should NOT run after a reboot" the same way starting it (via
@@ -1520,7 +1544,7 @@ class Handler(BaseHTTPRequestHandler):
         self.send_error(404)
 
     def do_POST(self):
-        global _hwtest_running
+        global _hwtest_running, _mode_action_running
         parsed = urlparse(self.path)
 
         # /shutdown stays open: PiFinder's PFSM page (a different
@@ -1590,8 +1614,31 @@ class Handler(BaseHTTPRequestHandler):
             threading.Thread(target=_do_poweroff, daemon=True).start()
             return
 
+        if parsed.path == "/uninstall":
+            with _lock:
+                if _running or _mode_action_running or _hwtest_running:
+                    self._send_json(
+                        {"uninstalling": False, "error": "An install/update run, mode switch, or hardware test is in progress - wait for it to finish first."},
+                        status=409,
+                    )
+                    return
+            self._send_json({"uninstalling": True})
+            threading.Thread(target=_do_uninstall, daemon=True).start()
+            return
+
+        if parsed.path == "/reset":
+            with _lock:
+                if _running or _mode_action_running or _hwtest_running:
+                    self._send_json(
+                        {"success": False, "error": "An install/update run, mode switch, or hardware test is in progress - wait for it to finish first."},
+                        status=409,
+                    )
+                    return
+            ok, output = _do_reset()
+            self._send_json({"success": ok, "output": output})
+            return
+
         if parsed.path == "/api/pifinder_mode":
-            global _mode_action_running
             qs = parse_qs(parsed.query)
             action = qs.get("action", [""])[0]
             if action not in ("enable_fake", "disable_fake"):

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -1073,6 +1073,8 @@ def _start_run(action, branch=None, mode=None):
             return False, "A hardware test is still in progress - wait for it to finish first."
         if _reset_running:
             return False, "A reset is still in progress - wait for it to finish first."
+        if _uninstall_running:
+            return False, "An uninstall is still in progress - wait for it to finish first."
         _lines = []
         _running = True
         _exit_code = None
@@ -1116,6 +1118,10 @@ _server = None  # set in main(); used by /shutdown to stop serve_forever()
 UNINSTALL_SCRIPT = REPO_ROOT / "bin" / "uninstall_pifinder_stellarmate.sh"
 
 
+_uninstall_running = False  # True while an Uninstall run is in flight
+_uninstall_lines = []  # progress log, shown in the shared Terminal tile
+
+
 def _do_uninstall():
     # This server process runs from inside the very directory tree being
     # deleted (~/PiFinder_Stellarmate) - --selfmove copies the uninstall
@@ -1123,8 +1129,35 @@ def _do_uninstall():
     # repo (and this server's own pifinder-control-center.service) survives
     # this process's own directory disappearing out from under it. See the
     # script's own --selfmove header comment for the full rationale.
+    #
+    # Streams into _uninstall_lines exactly like _run_reset() (found live,
+    # 2026-08-01, user: "der User muss sehen, was passiert") - the bulk of
+    # the real work (stopping/disabling/removing units incl. this server's
+    # own pifinder-control-center.service, removing INDI drivers, deleting
+    # ~/PiFinder) runs in *this* subprocess, before --selfmove hands off to
+    # the detached /tmp copy that deletes ~/PiFinder_Stellarmate itself -
+    # that final step is no longer observable here once this process's own
+    # unit gets stopped partway through, same as it always was; this only
+    # changes how the part that IS still running gets surfaced (Popen +
+    # incremental read instead of blocking subprocess.run(), same child
+    # process either way - no change to what actually runs or how/when it
+    # can get signaled).
+    global _uninstall_running
     time.sleep(1)  # give the HTTP response a moment to reach the browser
-    subprocess.run(["bash", str(UNINSTALL_SCRIPT), "--selfmove"])
+    try:
+        proc = subprocess.Popen(
+            ["bash", str(UNINSTALL_SCRIPT), "--selfmove"],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1,
+        )
+        for line in iter(proc.stdout.readline, ""):
+            with _lock:
+                _uninstall_lines.append(line.rstrip("\n"))
+        proc.wait()
+    except Exception:
+        pass
+    finally:
+        with _lock:
+            _uninstall_running = False
 
 
 def _run_reset():
@@ -1539,6 +1572,16 @@ class Handler(BaseHTTPRequestHandler):
             )
             return
 
+        if parsed.path == "/api/uninstall_log":
+            qs = parse_qs(parsed.query)
+            position = int(qs.get("position", ["0"])[0])
+            with _lock:
+                new_lines = _uninstall_lines[position:]
+                new_position = len(_uninstall_lines)
+                running = _uninstall_running
+            self._send_json({"lines": new_lines, "position": new_position, "running": running})
+            return
+
         if parsed.path == "/api/mount_bridge_log":
             qs = parse_qs(parsed.query)
             position = int(qs.get("position", ["0"])[0])
@@ -1593,7 +1636,7 @@ class Handler(BaseHTTPRequestHandler):
         self.send_error(404)
 
     def do_POST(self):
-        global _hwtest_running, _mode_action_running, _reset_running, _reset_exit_code
+        global _hwtest_running, _mode_action_running, _reset_running, _reset_exit_code, _uninstall_running
         parsed = urlparse(self.path)
 
         # /shutdown stays open: PiFinder's PFSM page (a different
@@ -1665,21 +1708,23 @@ class Handler(BaseHTTPRequestHandler):
 
         if parsed.path == "/uninstall":
             with _lock:
-                if _running or _mode_action_running or _hwtest_running or _reset_running:
+                if _running or _mode_action_running or _hwtest_running or _reset_running or _uninstall_running:
                     self._send_json(
-                        {"uninstalling": False, "error": "An install/update run, mode switch, hardware test, or reset is in progress - wait for it to finish first."},
+                        {"uninstalling": False, "error": "An install/update run, mode switch, hardware test, reset, or uninstall is in progress - wait for it to finish first."},
                         status=409,
                     )
                     return
+                _uninstall_lines.clear()
+                _uninstall_running = True
             self._send_json({"uninstalling": True})
             threading.Thread(target=_do_uninstall, daemon=True).start()
             return
 
         if parsed.path == "/reset":
             with _lock:
-                if _running or _mode_action_running or _hwtest_running or _reset_running:
+                if _running or _mode_action_running or _hwtest_running or _reset_running or _uninstall_running:
                     self._send_json(
-                        {"started": False, "error": "An install/update run, mode switch, hardware test, or reset is in progress - wait for it to finish first."},
+                        {"started": False, "error": "An install/update run, mode switch, hardware test, reset, or uninstall is in progress - wait for it to finish first."},
                         status=409,
                     )
                     return
@@ -1709,6 +1754,9 @@ class Handler(BaseHTTPRequestHandler):
                 if _reset_running:
                     self._send_json({"started": False, "error": "A reset is in progress - wait for it to finish first."}, status=409)
                     return
+                if _uninstall_running:
+                    self._send_json({"started": False, "error": "An uninstall is in progress - wait for it to finish first."}, status=409)
+                    return
                 _mode_action_running = True
             script_arg = "start" if action == "enable_fake" else "stop"
             threading.Thread(target=_run_fake_mode_action, args=(script_arg,), daemon=True).start()
@@ -1729,9 +1777,9 @@ class Handler(BaseHTTPRequestHandler):
                 self._send_json({"success": False, "error": f"invalid action '{action}'"}, status=400)
                 return
             with _lock:
-                if _running or _mode_action_running or _hwtest_running or _reset_running:
+                if _running or _mode_action_running or _hwtest_running or _reset_running or _uninstall_running:
                     self._send_json(
-                        {"success": False, "error": "An install/update run, mode switch, hardware test, or reset is in progress - wait for it to finish first."},
+                        {"success": False, "error": "An install/update run, mode switch, hardware test, reset, or uninstall is in progress - wait for it to finish first."},
                         status=409,
                     )
                     return
@@ -1769,6 +1817,9 @@ class Handler(BaseHTTPRequestHandler):
                 if _reset_running:
                     self._send_json({"started": False, "error": "A reset is in progress - wait for it to finish first."}, status=409)
                     return
+                if _uninstall_running:
+                    self._send_json({"started": False, "error": "An uninstall is in progress - wait for it to finish first."}, status=409)
+                    return
                 _hwtest_running = True
             threading.Thread(target=_run_hardware_test, daemon=True).start()
             self._send_json({"started": True})
@@ -1781,8 +1832,8 @@ class Handler(BaseHTTPRequestHandler):
                 self._send_json({"success": False, "error": f"invalid action '{action}'"}, status=400)
                 return
             with _lock:
-                if _mode_action_running or _running or _hwtest_running or _reset_running:
-                    self._send_json({"success": False, "error": "An install/update, mode switch, hardware test, or reset is in progress - wait for it to finish first."}, status=409)
+                if _mode_action_running or _running or _hwtest_running or _reset_running or _uninstall_running:
+                    self._send_json({"success": False, "error": "An install/update, mode switch, hardware test, reset, or uninstall is in progress - wait for it to finish first."}, status=409)
                     return
             want_enabled = action == "start"
             if _lcd_overlay_active() == want_enabled:

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -1351,7 +1351,13 @@ class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
         parsed = urlparse(self.path)
 
-        if parsed.path not in ("/state", "/log", "/page_version") and not self._require_auth():
+        # /api/uninstall_log exempted like /state and /log: the PAM check
+        # inside _require_auth() adds real latency per request, and every
+        # millisecond matters here specifically - this server stops its own
+        # systemd unit partway through an uninstall run, so a slower/
+        # authenticated poll has a worse chance of completing at all before
+        # the connection drops (found live 2026-08-01).
+        if parsed.path not in ("/state", "/log", "/page_version", "/api/uninstall_log") and not self._require_auth():
             return
 
         if parsed.path == "/page_version":

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -2010,22 +2010,25 @@ class Handler(BaseHTTPRequestHandler):
             return
 
         if parsed.path == "/api/mount_bridge_coupling":
-            # Phase 4: the three one-click Coupling presets. mode is
-            # "verify_alert"|"auto_correct"|"goto_forward" (short form here,
-            # translated to the driver's own MODE_* constants in
-            # indi_client.set_coupling_mode()). threshold/action are only
-            # meaningful for verify_alert/auto_correct - harmless if sent
-            # for goto_forward, indi_client.py ignores them there.
+            # Phase 4: the three one-click Coupling presets, plus "off" (the
+            # Decouple button - no dedicated preset button of its own, see
+            # onDecoupleClick()). mode is "verify_alert"|"auto_correct"|
+            # "goto_forward"|"off" (short form here, translated to the
+            # driver's own MODE_* constants in indi_client.set_coupling_
+            # mode()). threshold/action are only meaningful for
+            # verify_alert/auto_correct - harmless if sent for goto_forward
+            # or off, indi_client.py ignores them there.
             qs = parse_qs(parsed.query)
             mode_arg = qs.get("mode", [""])[0]
             mode_map = {
                 "verify_alert": "MODE_VERIFY_ALERT",
                 "auto_correct": "MODE_AUTO_CORRECT",
                 "goto_forward": "MODE_GOTO_FORWARD",
+                "off": "MODE_OFF",
             }
             if mode_arg not in mode_map:
                 self._send_json(
-                    {"success": False, "error": "expected ?mode=verify_alert|auto_correct|goto_forward"},
+                    {"success": False, "error": "expected ?mode=verify_alert|auto_correct|goto_forward|off"},
                     status=400,
                 )
                 return

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -12,6 +12,7 @@ but the bare system python3.
 """
 
 import base64
+import hashlib
 import json
 import os
 import re
@@ -56,6 +57,16 @@ PIFINDER_WELCOME_IMAGE = PIFINDER_DIR / "images" / "welcome.png"
 LOG_FILE = REPO_ROOT / ".gui_setup.log"
 STATUS_PAGE = GUI_DIR / "status_page.html"
 HELP_PAGE = GUI_DIR / "help.html"
+
+
+def _page_version() -> str:
+    """Short content hash of status_page.html - lets an already-open browser
+    tab notice its HTML/JS has changed on disk (e.g. this file was edited, or
+    the whole service was restarted with newer code) even though it has no
+    other way to find out short of the user manually reloading. Cheap enough
+    to read+hash on every /page_version request - this file is a few hundred
+    KB at most, polled at most every few seconds by any one client."""
+    return hashlib.sha256(STATUS_PAGE.read_bytes()).hexdigest()[:12]
 # Deliberately decoupled from PiFinder's own web server/codebase: this just
 # shells out to test_tools/fake_mode.sh (see its own header comment for the
 # full rationale), which itself toggles between the real systemd service and
@@ -1248,7 +1259,11 @@ class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
         parsed = urlparse(self.path)
 
-        if parsed.path not in ("/state", "/log") and not self._require_auth():
+        if parsed.path not in ("/state", "/log", "/page_version") and not self._require_auth():
+            return
+
+        if parsed.path == "/page_version":
+            self._send_json({"version": _page_version()})
             return
 
         if parsed.path == "/":

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -1343,6 +1343,10 @@ class Handler(BaseHTTPRequestHandler):
                 last_action = _last_action
                 restarting = _cc_restart_pending
                 phases = PHASES_INDI_ONLY if _last_mode == "indi_only" else PHASES
+                mode_action_running = _mode_action_running
+                hwtest_running = _hwtest_running
+                reset_running = _reset_running
+                uninstall_running = _uninstall_running
             self._send_json(
                 {
                     "existing_install": PIFINDER_DIR.is_dir(),
@@ -1359,6 +1363,15 @@ class Handler(BaseHTTPRequestHandler):
                     "action": last_action,
                     "current_branch": _current_pifinder_stellarmate_branch(),
                     "restarting": restarting,
+                    # Diagnostic - lets a stuck mutex guard (any action
+                    # rejected with "X is in progress" when nothing visibly
+                    # is) be root-caused from the outside instead of guessed
+                    # at (found live, 2026-08-01: a rejected Uninstall click
+                    # with no way to tell which flag was actually stuck).
+                    "mode_action_running": mode_action_running,
+                    "hwtest_running": hwtest_running,
+                    "reset_running": reset_running,
+                    "uninstall_running": uninstall_running,
                 }
             )
             return

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -706,6 +706,10 @@ _hwtest_running = False  # True while a Test Hardware run is in flight
 _hwtest_lines = []  # progress log, shown in the shared Terminal tile
 _hwtest_result = {"camera": None, "imu": None, "gps": None}
 
+_reset_running = False  # True while a Reset run is in flight
+_reset_lines = []  # progress log, shown in the shared Terminal tile
+_reset_exit_code = None
+
 
 def _hwtest_log(line: str):
     with _lock:
@@ -1056,6 +1060,8 @@ def _start_run(action, branch=None, mode=None):
             return False, "A PiFinder mode switch is still in progress - wait for it to finish first."
         if _hwtest_running:
             return False, "A hardware test is still in progress - wait for it to finish first."
+        if _reset_running:
+            return False, "A reset is still in progress - wait for it to finish first."
         _lines = []
         _running = True
         _exit_code = None
@@ -1110,14 +1116,29 @@ def _do_uninstall():
     subprocess.run(["bash", str(UNINSTALL_SCRIPT), "--selfmove"])
 
 
-def _do_reset():
-    # --reset only touches ~/PiFinder's own venv/build state, never this
-    # repo's own directory - unlike _do_uninstall() above, safe to run
-    # directly and report the result, no --selfmove/self-deletion concern.
-    result = subprocess.run(
-        ["bash", str(UNINSTALL_SCRIPT), "--reset"], capture_output=True, text=True,
+def _run_reset():
+    """Runs bin/uninstall_pifinder_stellarmate.sh --reset via Popen, streaming
+    output into _reset_lines line-by-line so it shows live in the shared
+    Terminal tile (like Install/Update/Test Hardware) - unlike the previous
+    _do_reset(), which blocked on subprocess.run(capture_output=True) and
+    only reported the result via a browser alert() at the end, with nothing
+    visible in the terminal while it ran (found live during TC-PFSM-84-01,
+    user: "There is no Terminal output at all"). --reset only touches
+    ~/PiFinder's own venv/build state, never this repo's own directory -
+    unlike _do_uninstall(), safe to run directly, no --selfmove/self-deletion
+    concern."""
+    global _reset_running, _reset_exit_code
+    proc = subprocess.Popen(
+        ["bash", str(UNINSTALL_SCRIPT), "--reset"],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1,
     )
-    return result.returncode == 0, (result.stdout + result.stderr)[-4000:]
+    for line in iter(proc.stdout.readline, ""):
+        with _lock:
+            _reset_lines.append(line.rstrip("\n"))
+    proc.wait()
+    with _lock:
+        _reset_running = False
+        _reset_exit_code = proc.returncode
 
 
 def _do_shutdown():
@@ -1490,6 +1511,19 @@ class Handler(BaseHTTPRequestHandler):
             )
             return
 
+        if parsed.path == "/api/reset_log":
+            qs = parse_qs(parsed.query)
+            position = int(qs.get("position", ["0"])[0])
+            with _lock:
+                new_lines = _reset_lines[position:]
+                new_position = len(_reset_lines)
+                running = _reset_running
+                exit_code = _reset_exit_code
+            self._send_json(
+                {"lines": new_lines, "position": new_position, "running": running, "exit_code": exit_code}
+            )
+            return
+
         if parsed.path == "/api/mount_bridge_log":
             qs = parse_qs(parsed.query)
             position = int(qs.get("position", ["0"])[0])
@@ -1544,7 +1578,7 @@ class Handler(BaseHTTPRequestHandler):
         self.send_error(404)
 
     def do_POST(self):
-        global _hwtest_running, _mode_action_running
+        global _hwtest_running, _mode_action_running, _reset_running, _reset_exit_code
         parsed = urlparse(self.path)
 
         # /shutdown stays open: PiFinder's PFSM page (a different
@@ -1616,9 +1650,9 @@ class Handler(BaseHTTPRequestHandler):
 
         if parsed.path == "/uninstall":
             with _lock:
-                if _running or _mode_action_running or _hwtest_running:
+                if _running or _mode_action_running or _hwtest_running or _reset_running:
                     self._send_json(
-                        {"uninstalling": False, "error": "An install/update run, mode switch, or hardware test is in progress - wait for it to finish first."},
+                        {"uninstalling": False, "error": "An install/update run, mode switch, hardware test, or reset is in progress - wait for it to finish first."},
                         status=409,
                     )
                     return
@@ -1628,14 +1662,17 @@ class Handler(BaseHTTPRequestHandler):
 
         if parsed.path == "/reset":
             with _lock:
-                if _running or _mode_action_running or _hwtest_running:
+                if _running or _mode_action_running or _hwtest_running or _reset_running:
                     self._send_json(
-                        {"success": False, "error": "An install/update run, mode switch, or hardware test is in progress - wait for it to finish first."},
+                        {"started": False, "error": "An install/update run, mode switch, hardware test, or reset is in progress - wait for it to finish first."},
                         status=409,
                     )
                     return
-            ok, output = _do_reset()
-            self._send_json({"success": ok, "output": output})
+                _reset_lines.clear()
+                _reset_running = True
+                _reset_exit_code = None
+            self._send_json({"started": True})
+            threading.Thread(target=_run_reset, daemon=True).start()
             return
 
         if parsed.path == "/api/pifinder_mode":
@@ -1653,6 +1690,9 @@ class Handler(BaseHTTPRequestHandler):
                     return
                 if _hwtest_running:
                     self._send_json({"started": False, "error": "A hardware test is in progress - wait for it to finish first."}, status=409)
+                    return
+                if _reset_running:
+                    self._send_json({"started": False, "error": "A reset is in progress - wait for it to finish first."}, status=409)
                     return
                 _mode_action_running = True
             script_arg = "start" if action == "enable_fake" else "stop"
@@ -1674,9 +1714,9 @@ class Handler(BaseHTTPRequestHandler):
                 self._send_json({"success": False, "error": f"invalid action '{action}'"}, status=400)
                 return
             with _lock:
-                if _running or _mode_action_running or _hwtest_running:
+                if _running or _mode_action_running or _hwtest_running or _reset_running:
                     self._send_json(
-                        {"success": False, "error": "An install/update run, mode switch, or hardware test is in progress - wait for it to finish first."},
+                        {"success": False, "error": "An install/update run, mode switch, hardware test, or reset is in progress - wait for it to finish first."},
                         status=409,
                     )
                     return
@@ -1711,6 +1751,9 @@ class Handler(BaseHTTPRequestHandler):
                         status=409,
                     )
                     return
+                if _reset_running:
+                    self._send_json({"started": False, "error": "A reset is in progress - wait for it to finish first."}, status=409)
+                    return
                 _hwtest_running = True
             threading.Thread(target=_run_hardware_test, daemon=True).start()
             self._send_json({"started": True})
@@ -1723,8 +1766,8 @@ class Handler(BaseHTTPRequestHandler):
                 self._send_json({"success": False, "error": f"invalid action '{action}'"}, status=400)
                 return
             with _lock:
-                if _mode_action_running or _running or _hwtest_running:
-                    self._send_json({"success": False, "error": "An install/update, mode switch, or hardware test is in progress - wait for it to finish first."}, status=409)
+                if _mode_action_running or _running or _hwtest_running or _reset_running:
+                    self._send_json({"success": False, "error": "An install/update, mode switch, hardware test, or reset is in progress - wait for it to finish first."}, status=409)
                     return
             want_enabled = action == "start"
             if _lcd_overlay_active() == want_enabled:

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -649,7 +649,9 @@
   .mb-arrow.mb-arrow-read { color: #5b9bd5; }
   .mb-arrow.mb-arrow-write { color: #f5a623; font-weight: bold; }
   .mb-arrow.mb-arrow-goto { color: #4caf50; font-weight: bold; }
-  #mb-mode-caption { color: #888; font-size: 0.76rem; margin-bottom: 0.6rem; }
+  #mb-mode-caption-row { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.6rem; }
+  #mb-mode-caption { color: #888; font-size: 0.76rem; }
+  #mb-decouple-btn { margin-left: 0; }
   /* Shared collapsible-section header, reused wherever a tile has a
      "matters every time" part and a "one-time setup / rarely touched"
      part - per live feedback/design principle, the latter defaults to
@@ -984,7 +986,10 @@ sudo systemctl start pifinder</pre>
           <span id="mb-node-mount-name">Mount</span>
         </div>
       </div>
-      <div id="mb-mode-caption">Not coupled yet</div>
+      <div id="mb-mode-caption-row">
+        <span id="mb-mode-caption">Not coupled yet</span>
+        <button id="mb-decouple-btn" class="ql-small-btn" onclick="onDecoupleClick()" style="display:none;" title="Sets Coupling back to Off - PiFinder and mount stop syncing automatically until you pick a preset again. No dedicated preset button for this (Off is the driver's own default/neutral state).">Decouple</button>
+      </div>
       <!-- Everything from coupling presets to manual sync is meaningless in
            the "PiFinder host" role (no Mount Bridge in the profile) - this
            wrapper lets updateProfileRoleLine() hide the whole block at once
@@ -2511,12 +2516,15 @@ function applyMbDriftAndMode(couplingMode, correctionAction, driftArcmin) {
   updateDriftBadge(driftArcmin, threshold);
   updateCouplingButtons(couplingMode, correctionAction);
 
+  const decoupleBtn = document.getElementById('mb-decouple-btn');
   if (!couplingMode || couplingMode === 'MODE_OFF') {
     setMbArrow('mb-arrow-left', 'off');
     setMbArrow('mb-arrow-right', 'off');
     captionEl.textContent = 'Not coupled - PiFinder and mount move independently';
+    decoupleBtn.style.display = 'none';
     return false;
   }
+  decoupleBtn.style.display = '';
   if (couplingMode === 'MODE_VERIFY_ALERT') {
     setMbArrow('mb-arrow-left', 'read');
     setMbArrow('mb-arrow-right', 'read');
@@ -2857,6 +2865,34 @@ async function setWmCoupling(preset) {
     // buttons on this page.
   }
   btn.textContent = originalText;
+  pollMbLog();
+  await refreshMountBridgeStatus();
+  mbActionInFlight = false;
+  clearMbActionStatus();
+}
+
+// Sets Coupling back to Off. No dedicated preset button for this (unlike
+// verify_alert/auto_correct/goto_forward) - Off is the driver's own default/
+// neutral state, previously only reachable via the raw INDI Control Panel in
+// KStars/Ekos, not from this simplified tile at all (found live, 2026-07-31).
+async function onDecoupleClick() {
+  mbActionInFlight = true;
+  setMbActionStatus('⏳ Decoupling…');
+  const btn = document.getElementById('mb-decouple-btn');
+  const originalText = btn.textContent;
+  btn.disabled = true;
+  btn.textContent = 'decoupling…';
+  document.getElementById('mount-bridge-dot').classList.add('dot-unconfirmed');
+  try {
+    const resp = await fetch('/api/mount_bridge_coupling?mode=off', { method: 'POST' });
+    const data = await resp.json();
+    if (!data.success) throw new Error(data.error || 'failed');
+  } catch (e) {
+    // fall through - errors show up via pollMbLog() below, same pattern as
+    // the Coupling preset buttons.
+  }
+  btn.textContent = originalText;
+  btn.disabled = false;
   pollMbLog();
   await refreshMountBridgeStatus();
   mbActionInFlight = false;

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -1143,7 +1143,7 @@ sudo systemctl start pifinder</pre>
 
     <div id="install-groups">
       <div class="mode-power-group">
-        <div class="group-label">Source</div>
+        <div class="group-label">PFSM Source Branch</div>
         <div id="branch-picker-row">
           <select id="branch-select" onchange="onBranchSelectChange(true)">
             <option value="main">main (stable)</option>
@@ -1161,12 +1161,12 @@ sudo systemctl start pifinder</pre>
       </div>
       <div class="vgroup-divider"></div>
       <div class="mode-power-group">
-        <div class="group-label">Install</div>
+        <div class="group-label">Install PiFinder Software</div>
         <div id="choices" style="display:none;"></div>
       </div>
       <div class="vgroup-divider"></div>
       <div class="mode-power-group" title="Uses bin/uninstall_pifinder_stellarmate.sh - acts on the whole PiFinder_Stellarmate installation (services, INDI drivers, ~/PiFinder), separately from the Reinstall/Update actions above. Reset keeps your data/config and only wipes the Python venv/build state, ready for a fresh setup run. Uninstall removes everything this project installed.">
-        <div class="group-label">Reset / Uninstall<a class="help-link" href="/help.html#reset-uninstall" target="_blank" rel="noopener" title="Help">i</a></div>
+        <div class="group-label">Reset / Uninstall PFSM<a class="help-link" href="/help.html#reset-uninstall" target="_blank" rel="noopener" title="Help">i</a></div>
         <div class="mode-power-group-buttons">
           <button id="install-reset-btn" class="ql-small-btn" onclick="installAction('reset')" style="margin-left:0;">Reset</button>
           <button id="install-uninstall-btn" class="power-btn" onclick="installAction('uninstall')">Uninstall</button>

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -756,6 +756,28 @@
     margin-bottom: 1rem;
     font-size: 0.9rem;
   }
+  #stale-page-banner {
+    background: #1a2433;
+    color: #bcd4ee;
+    border: 1px solid #2c4a6e;
+    padding: 0.6rem 1rem;
+    border-radius: 6px;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+  }
+  #stale-page-banner button {
+    background: #2a6fdb;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    padding: 0.35rem 0.8rem;
+    font-size: 0.85rem;
+    cursor: pointer;
+  }
+  #stale-page-banner button:hover { filter: brightness(1.15); }
   /* Full-page lock shown while the Control Center restarts itself after a
      successful setup run (see enterCcRestartingState() below) - covers and
      visually disables the whole page rather than individually disabling
@@ -812,6 +834,10 @@
 <h1>PiFinder on Stellarmate Control Center</h1>
 
 <div id="conn-lost-banner" style="display:none;"></div>
+<div id="stale-page-banner" style="display:none;">
+  <span>This page is running an older version - the Control Center has been updated since you loaded it.</span>
+  <button onclick="location.reload()">Reload now</button>
+</div>
 
 <div id="cc-restart-overlay">
   <div id="cc-restart-overlay-box">
@@ -1740,6 +1766,35 @@ async function refreshBranchInfo() {
   }
 }
 setInterval(refreshBranchInfo, 30000);
+
+// Notices when this already-open tab's HTML/JS has fallen behind what the
+// server is now actually serving - e.g. the service was restarted from a
+// terminal (systemctl restart), or status_page.html was edited on disk,
+// completely outside anything this page itself triggered/watched (unlike
+// enterCcRestartingState()'s auto-reload, which only covers a restart THIS
+// page's own Install/Update run caused). Found live (2026-08-01): a stale
+// tab kept showing an old confirm() dialog and outdated behavior across
+// several server-side fixes, with no indication anything had changed.
+let pageVersionAtLoad = null;
+
+async function checkPageVersion() {
+  let data;
+  try {
+    const resp = await fetch('/page_version', { cache: 'no-store' });
+    data = await resp.json();
+  } catch (e) {
+    return; // transient network hiccup - not worth alarming over
+  }
+  if (pageVersionAtLoad === null) {
+    pageVersionAtLoad = data.version;
+    return;
+  }
+  if (data.version !== pageVersionAtLoad) {
+    document.getElementById('stale-page-banner').style.display = 'flex';
+  }
+}
+checkPageVersion();
+setInterval(checkPageVersion, 20000);
 
 // A click needs its own visible acknowledgment, distinct from
 // refreshBranchInfo()'s silent periodic use - the result (the hint text)

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -317,11 +317,7 @@
   #install-uninstall-btn { background: #a33; }
   .power-btn:hover { filter: brightness(1.15); }
   .power-btn:disabled { background: #444; cursor: default; filter: none; }
-  #install-danger-zone {
-    margin-top: 0.9rem;
-    padding-top: 0.7rem;
-    border-top: 1px solid #444;
-  }
+  #install-danger-zone { margin-top: 0.8rem; }
   #mode-tile {
     background: #1a1a1a;
     border: 1px solid #333;
@@ -1164,7 +1160,7 @@ sudo systemctl start pifinder</pre>
 
     <div id="install-danger-zone">
       <div class="mode-power-group" title="Uses bin/uninstall_pifinder_stellarmate.sh - acts on the whole PiFinder_Stellarmate installation (services, INDI drivers, ~/PiFinder), separately from the Reinstall/Update actions above. Reset keeps your data/config and only wipes the Python venv/build state, ready for a fresh setup run. Uninstall removes everything this project installed.">
-        <div class="group-label">Reset / Uninstall this installation</div>
+        <div class="group-label">Reset / Uninstall</div>
         <div class="mode-power-group-buttons">
           <button id="install-reset-btn" class="ql-small-btn" onclick="installAction('reset')" style="margin-left:0;">Reset</button>
           <button id="install-uninstall-btn" class="power-btn" onclick="installAction('uninstall')">Uninstall</button>

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -2064,7 +2064,23 @@ async function installAction(kind) {
         alert('Could not start uninstall: ' + (data.error || 'unknown error'));
         return;
       }
-      watchForServerLoss();
+      // Streams live into the shared Terminal like Reset, for as long as
+      // this server process is still around to answer - see
+      // pollUninstallLog(). Found live, user: "der User muss sehen, was
+      // passiert." Most of the actual work (stopping/removing services incl.
+      // this server's own, removing INDI drivers, deleting ~/PiFinder) runs
+      // before this process's own unit gets stopped partway through -
+      // pollUninstallLog() hands off to watchForServerLoss() once the
+      // connection actually drops, same end state as before.
+      if (!polling && !hwTestPolling && !modeLogPolling) {
+        const logEl = document.getElementById('log');
+        logEl.textContent = '';
+        logEl.classList.add('log-placeholder');
+      }
+      document.getElementById('log').style.display = 'block';
+      uninstallLogPosition = 0;
+      uninstallPolling = true;
+      pollUninstallLog();
       return;
     }
     // Reset now runs in the background, streaming output into the shared
@@ -2139,6 +2155,44 @@ async function pollResetLog() {
     } else {
       alert('Reset failed - see the terminal output above for details.');
     }
+  }
+}
+
+let uninstallLogPosition = 0;
+let uninstallPolling = false;
+
+async function pollUninstallLog() {
+  if (!uninstallPolling) return;
+  let data;
+  try {
+    const resp = await fetch('/api/uninstall_log?position=' + uninstallLogPosition);
+    data = await resp.json();
+  } catch (e) {
+    // Expected eventually, not an error - this server process stops itself
+    // partway through (its own systemd unit is one of the things Uninstall
+    // removes). Hand off to the existing "server is gone" handling instead
+    // of alerting.
+    uninstallPolling = false;
+    watchForServerLoss();
+    return;
+  }
+  if (data.lines.length > 0) {
+    const logEl = document.getElementById('log');
+    logEl.classList.remove('log-placeholder');
+    const atBottom = logEl.scrollTop + logEl.clientHeight >= logEl.scrollHeight - 20;
+    logEl.textContent += data.lines.join('\n') + '\n';
+    uninstallLogPosition = data.position;
+    if (atBottom) logEl.scrollTop = logEl.scrollHeight;
+  }
+  if (data.running) {
+    setTimeout(pollUninstallLog, 500);
+  } else {
+    // The visible part of the run finished on its own (rare - usually the
+    // connection just drops first, handled in the catch above) - either
+    // way, from here it's the same "wait for the server to actually go
+    // away" as before.
+    uninstallPolling = false;
+    watchForServerLoss();
   }
 }
 

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -2012,16 +2012,27 @@ async function installAction(kind) {
       watchForServerLoss();
       return;
     }
-    // Reset runs synchronously server-side and returns its own result -
-    // no server-loss handling needed, this repo's own directory is untouched.
-    resetBtn.disabled = false;
-    uninstallBtn.disabled = false;
-    btn.textContent = 'Reset';
-    if (data.success) {
-      alert('Reset complete - venv/build state cleared. Run the setup script again to rebuild.');
-    } else {
-      alert('Reset failed:\n\n' + (data.output || data.error || 'unknown error'));
+    // Reset now runs in the background, streaming output into the shared
+    // Terminal tile like Install/Update/Test Hardware - see pollResetLog().
+    // Previously ran synchronously with nothing shown until a final alert()
+    // (found live during TC-PFSM-84-01, user: "There is no Terminal output
+    // at all").
+    if (!data.started) {
+      resetBtn.disabled = false;
+      uninstallBtn.disabled = false;
+      btn.textContent = 'Reset';
+      alert('Could not start reset: ' + (data.error || 'unknown error'));
+      return;
     }
+    if (!polling && !hwTestPolling && !modeLogPolling) {
+      const logEl = document.getElementById('log');
+      logEl.textContent = '';
+      logEl.classList.add('log-placeholder');
+    }
+    document.getElementById('log').style.display = 'block';
+    resetLogPosition = 0;
+    resetPolling = true;
+    pollResetLog();
   } catch (e) {
     if (isUninstall) {
       // Network error here can also mean the server went down right as it
@@ -2032,6 +2043,46 @@ async function installAction(kind) {
       uninstallBtn.disabled = false;
       btn.textContent = 'Reset';
       alert('Reset request failed.');
+    }
+  }
+}
+
+let resetLogPosition = 0;
+let resetPolling = false;
+
+async function pollResetLog() {
+  if (!resetPolling) return;
+  let data;
+  try {
+    const resp = await fetch('/api/reset_log?position=' + resetLogPosition);
+    data = await resp.json();
+  } catch (e) {
+    resetPolling = false;
+    document.getElementById('install-reset-btn').disabled = false;
+    document.getElementById('install-uninstall-btn').disabled = false;
+    document.getElementById('install-reset-btn').textContent = 'Reset';
+    alert('Lost connection while resetting.');
+    return;
+  }
+  if (data.lines.length > 0) {
+    const logEl = document.getElementById('log');
+    logEl.classList.remove('log-placeholder');
+    const atBottom = logEl.scrollTop + logEl.clientHeight >= logEl.scrollHeight - 20;
+    logEl.textContent += data.lines.join('\n') + '\n';
+    resetLogPosition = data.position;
+    if (atBottom) logEl.scrollTop = logEl.scrollHeight;
+  }
+  if (data.running) {
+    setTimeout(pollResetLog, 500);
+  } else {
+    resetPolling = false;
+    document.getElementById('install-reset-btn').disabled = false;
+    document.getElementById('install-uninstall-btn').disabled = false;
+    document.getElementById('install-reset-btn').textContent = 'Reset';
+    if (data.exit_code === 0) {
+      alert('Reset complete - venv/build state cleared. Run the setup script again to rebuild.');
+    } else {
+      alert('Reset failed - see the terminal output above for details.');
     }
   }
 }

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -314,8 +314,15 @@
   .mode-power-group-buttons-stacked { flex-direction: column; }
   #power-reboot-btn { background: #2a6fdb; }
   #power-poweroff-btn { background: #a33; }
+  #install-uninstall-btn { background: #a33; }
   .power-btn:hover { filter: brightness(1.15); }
   .power-btn:disabled { background: #444; cursor: default; filter: none; }
+  #install-power-divider {
+    width: 1px;
+    align-self: stretch;
+    background: #444;
+    margin-top: 1.2rem;
+  }
   #mode-tile {
     background: #1a1a1a;
     border: 1px solid #333;
@@ -855,6 +862,14 @@
             <div class="mode-power-group-buttons mode-power-group-buttons-stacked">
               <button id="power-reboot-btn" class="power-btn" onclick="powerAction('reboot')">Reboot Pi</button>
               <button id="power-poweroff-btn" class="power-btn" onclick="powerAction('poweroff')">Shutdown Pi</button>
+            </div>
+          </div>
+          <div id="install-power-divider"></div>
+          <div class="mode-power-group" title="Uses bin/uninstall_pifinder_stellarmate.sh. Reset keeps your data/config and only wipes the Python venv/build state, ready for a fresh setup run. Uninstall removes everything this project installed (services, INDI drivers, ~/PiFinder).">
+            <div class="group-label">Installation</div>
+            <div class="mode-power-group-buttons mode-power-group-buttons-stacked">
+              <button id="install-reset-btn" class="ql-small-btn" onclick="installAction('reset')" style="margin-left:0;">Reset</button>
+              <button id="install-uninstall-btn" class="power-btn" onclick="installAction('uninstall')">Uninstall</button>
             </div>
           </div>
         </div>
@@ -1961,6 +1976,62 @@ async function powerAction(kind) {
     // accepted the request - treat it the same as a confirmed action.
   }
   watchForServerLoss();
+}
+
+// Uninstall/Reset - both drive bin/uninstall_pifinder_stellarmate.sh (see
+// its own header comments for --selfmove/--reset). Reset is comparatively
+// low-risk (venv/build state only, keeps data/config); Uninstall is final
+// and removes everything this project installed, including this very
+// server's own directory - handled the same way as reboot/poweroff
+// (watchForServerLoss(), since there's no coming back from this one).
+async function installAction(kind) {
+  const isUninstall = kind === 'uninstall';
+  const message = isUninstall
+    ? '⚠ Uninstall PiFinder completely? This stops and removes all PiFinder services, INDI drivers, and ~/PiFinder itself. This page (and this whole Control Center) will stop working once it starts. This cannot be undone from here.'
+    : 'Reset PiFinder? This wipes the Python venv/build state only - your data, config, and installed services/drivers are kept. Ready for a fresh setup run afterward.';
+  if (!confirm(message)) return;
+  const resetBtn = document.getElementById('install-reset-btn');
+  const uninstallBtn = document.getElementById('install-uninstall-btn');
+  const btn = isUninstall ? uninstallBtn : resetBtn;
+  resetBtn.disabled = true;
+  uninstallBtn.disabled = true;
+  btn.textContent = isUninstall ? 'Uninstalling…' : 'Resetting…';
+  try {
+    const resp = await fetch(`/${kind}`, { method: 'POST' });
+    const data = await resp.json();
+    if (isUninstall) {
+      if (!data.uninstalling) {
+        resetBtn.disabled = false;
+        uninstallBtn.disabled = false;
+        btn.textContent = 'Uninstall';
+        alert('Could not start uninstall: ' + (data.error || 'unknown error'));
+        return;
+      }
+      watchForServerLoss();
+      return;
+    }
+    // Reset runs synchronously server-side and returns its own result -
+    // no server-loss handling needed, this repo's own directory is untouched.
+    resetBtn.disabled = false;
+    uninstallBtn.disabled = false;
+    btn.textContent = 'Reset';
+    if (data.success) {
+      alert('Reset complete - venv/build state cleared. Run the setup script again to rebuild.');
+    } else {
+      alert('Reset failed:\n\n' + (data.output || data.error || 'unknown error'));
+    }
+  } catch (e) {
+    if (isUninstall) {
+      // Network error here can also mean the server went down right as it
+      // accepted the request - treat it the same as a confirmed action.
+      watchForServerLoss();
+    } else {
+      resetBtn.disabled = false;
+      uninstallBtn.disabled = false;
+      btn.textContent = 'Reset';
+      alert('Reset request failed.');
+    }
+  }
 }
 
 // Direct pifinder.service control (start/stop/restart) - shouldn't normally

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -317,11 +317,10 @@
   #install-uninstall-btn { background: #a33; }
   .power-btn:hover { filter: brightness(1.15); }
   .power-btn:disabled { background: #444; cursor: default; filter: none; }
-  #install-power-divider {
-    width: 1px;
-    align-self: stretch;
-    background: #444;
-    margin-top: 1.2rem;
+  #install-danger-zone {
+    margin-top: 0.9rem;
+    padding-top: 0.7rem;
+    border-top: 1px solid #444;
   }
   #mode-tile {
     background: #1a1a1a;
@@ -864,14 +863,6 @@
               <button id="power-poweroff-btn" class="power-btn" onclick="powerAction('poweroff')">Shutdown Pi</button>
             </div>
           </div>
-          <div id="install-power-divider"></div>
-          <div class="mode-power-group" title="Uses bin/uninstall_pifinder_stellarmate.sh. Reset keeps your data/config and only wipes the Python venv/build state, ready for a fresh setup run. Uninstall removes everything this project installed (services, INDI drivers, ~/PiFinder).">
-            <div class="group-label">Installation</div>
-            <div class="mode-power-group-buttons mode-power-group-buttons-stacked">
-              <button id="install-reset-btn" class="ql-small-btn" onclick="installAction('reset')" style="margin-left:0;">Reset</button>
-              <button id="install-uninstall-btn" class="power-btn" onclick="installAction('uninstall')">Uninstall</button>
-            </div>
-          </div>
         </div>
         <!-- Compact, always-visible hardware summary - same visual language
              as the Mount Bridge diagram's icon nodes (bordered box, currentColor
@@ -1170,6 +1161,16 @@ sudo systemctl start pifinder</pre>
     </div>
 
     <div id="choices" style="display:none;"></div>
+
+    <div id="install-danger-zone">
+      <div class="mode-power-group" title="Uses bin/uninstall_pifinder_stellarmate.sh - acts on the whole PiFinder_Stellarmate installation (services, INDI drivers, ~/PiFinder), separately from the Reinstall/Update actions above. Reset keeps your data/config and only wipes the Python venv/build state, ready for a fresh setup run. Uninstall removes everything this project installed.">
+        <div class="group-label">Reset / Uninstall this installation</div>
+        <div class="mode-power-group-buttons">
+          <button id="install-reset-btn" class="ql-small-btn" onclick="installAction('reset')" style="margin-left:0;">Reset</button>
+          <button id="install-uninstall-btn" class="power-btn" onclick="installAction('uninstall')">Uninstall</button>
+        </div>
+      </div>
+    </div>
 
     <div id="status-row">
       <div id="status" class="status-idle">Checking current state&hellip;</div>

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -1989,7 +1989,7 @@ async function powerAction(kind) {
 async function installAction(kind) {
   const isUninstall = kind === 'uninstall';
   const message = isUninstall
-    ? '⚠ Uninstall PiFinder completely? This stops and removes all PiFinder services, INDI drivers, and ~/PiFinder itself. This page (and this whole Control Center) will stop working once it starts. This cannot be undone from here.'
+    ? '⚠ Uninstall PFSM completely? This stops and removes all PiFinder services, INDI drivers, ~/PiFinder itself, AND ~/PiFinder_Stellarmate - the folder this Control Center itself runs from. This page will go permanently offline within a few seconds, not just pause. This cannot be undone from here.'
     : 'Reset PiFinder? This wipes the Python venv/build state only - your data, config, and installed services/drivers are kept. Ready for a fresh setup run afterward.';
   if (!confirm(message)) return;
   const resetBtn = document.getElementById('install-reset-btn');

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -161,9 +161,9 @@
     border-radius: 8px;
     padding: 0.7rem 0.9rem;
   }
-  #branch-picker-row { margin-bottom: 0.8rem; font-size: 0.82rem; }
-  #mode-picker-row { margin-bottom: 0.8rem; font-size: 0.82rem; }
-  #branch-current-hint { color: #777; margin-left: 0.5rem; font-size: 0.78rem; }
+  #branch-picker-row { margin-bottom: 0.4rem; font-size: 0.82rem; }
+  #indi-only-label { font-size: 0.78rem; color: #999; cursor: pointer; }
+  #branch-current-hint { color: #777; margin-left: 0.5rem; font-size: 0.78rem; display: block; }
   #branch-other-input { margin-left: 0.4rem; }
   #choices button, #start-fresh {
     background: #2a6fdb;
@@ -300,7 +300,7 @@
     margin-top: 0.3rem;
   }
   .mode-power-group { flex: 0 1 auto; }
-  #mode-power-divider {
+  .vgroup-divider {
     width: 1px;
     align-self: stretch;
     background: #444;
@@ -317,7 +317,9 @@
   #install-uninstall-btn { background: #a33; }
   .power-btn:hover { filter: brightness(1.15); }
   .power-btn:disabled { background: #444; cursor: default; filter: none; }
-  #install-danger-zone { margin-top: 0.8rem; }
+  #install-groups { display: flex; gap: 1rem; align-items: flex-start; margin: 0.3rem 0 0.8rem; }
+  #install-heading-row { display: flex; align-items: center; justify-content: space-between; gap: 0.6rem; margin-bottom: 0.5rem; }
+  #install-heading-row .tile-heading { margin: 0; }
   #mode-tile {
     background: #1a1a1a;
     border: 1px solid #333;
@@ -851,7 +853,7 @@
               <button id="pifinder-svc-restart-btn" class="ql-small-btn" onclick="pifinderServiceAction('restart')" style="margin-left:0;">Restart</button>
             </div>
           </div>
-          <div id="mode-power-divider"></div>
+          <div class="vgroup-divider"></div>
           <div class="mode-power-group" title="Affects the whole Raspberry Pi, not just PiFinder or this setup page.">
             <div class="group-label">This Pi</div>
             <div class="mode-power-group-buttons mode-power-group-buttons-stacked">
@@ -1122,7 +1124,10 @@ sudo systemctl start pifinder</pre>
 
   <div class="right-col">
     <div id="install-tile">
-      <h3 class="tile-heading">Install or Update<a class="help-link" href="/help.html#install-update" target="_blank" rel="noopener" title="Help">i</a></h3>
+      <div id="install-heading-row">
+        <h3 class="tile-heading">Install or Update<a class="help-link" href="/help.html#install-update" target="_blank" rel="noopener" title="Help">i</a></h3>
+        <div id="status" class="status-idle">Checking current state&hellip;</div>
+      </div>
     <div id="top-images">
       <img id="header-image" src="/pifinder.jpg" alt="PiFinder">
     </div>
@@ -1136,31 +1141,32 @@ sudo systemctl start pifinder</pre>
 
     <ul id="phase-checklist" style="display:none;"></ul>
 
-    <div id="branch-picker-row">
-      <span class="mb-row-label">Install from:</span><a class="help-link" href="/help.html#install-update" target="_blank" rel="noopener" title="Help">i</a>
-      <select id="branch-select" onchange="onBranchSelectChange(true)">
-        <option value="main">main (stable)</option>
-        <option value="dev">dev (beta)</option>
-        <option value="__other__">Other&hellip;</option>
-      </select>
-      <input type="text" id="branch-other-input" placeholder="branch name" style="display:none;" oninput="branchTouched = true;">
-      <span id="branch-current-hint" style="display:none;"></span>
-      <button type="button" id="branch-refresh-btn" class="refresh-link" onclick="manualRefreshBranchInfo(this)" title="Re-check which branch is actually on disk right now - useful if it was switched elsewhere (another tab, a terminal, a merged PR) since this page loaded.">&#8635;</button>
-    </div>
-
-    <div id="mode-picker-row">
-      <label>
-        <input type="checkbox" id="indi-only-checkbox" onchange="onIndiOnlyToggle(this.checked)">
-        INDI-only (no PiFinder hardware - for control-host setups)
-      </label>
-      <a class="help-link" href="/help.html#indi-only-mode" target="_blank" rel="noopener" title="Help">i</a>
-    </div>
-
-    <div id="choices" style="display:none;"></div>
-
-    <div id="install-danger-zone">
+    <div id="install-groups">
+      <div class="mode-power-group">
+        <div class="group-label">Source</div>
+        <div id="branch-picker-row">
+          <select id="branch-select" onchange="onBranchSelectChange(true)">
+            <option value="main">main (stable)</option>
+            <option value="dev">dev (beta)</option>
+            <option value="__other__">Other&hellip;</option>
+          </select>
+          <button type="button" id="branch-refresh-btn" class="refresh-link" onclick="manualRefreshBranchInfo(this)" title="Re-check which branch is actually on disk right now - useful if it was switched elsewhere (another tab, a terminal, a merged PR) since this page loaded.">&#8635;</button>
+          <input type="text" id="branch-other-input" placeholder="branch name" style="display:none;" oninput="branchTouched = true;">
+          <span id="branch-current-hint" style="display:none;"></span>
+        </div>
+        <label id="indi-only-label">
+          <input type="checkbox" id="indi-only-checkbox" onchange="onIndiOnlyToggle(this.checked)">
+          INDI-only (no PiFinder hardware - for control-host setups)
+        </label><a class="help-link" href="/help.html#indi-only-mode" target="_blank" rel="noopener" title="Help">i</a>
+      </div>
+      <div class="vgroup-divider"></div>
+      <div class="mode-power-group">
+        <div class="group-label">Install</div>
+        <div id="choices" style="display:none;"></div>
+      </div>
+      <div class="vgroup-divider"></div>
       <div class="mode-power-group" title="Uses bin/uninstall_pifinder_stellarmate.sh - acts on the whole PiFinder_Stellarmate installation (services, INDI drivers, ~/PiFinder), separately from the Reinstall/Update actions above. Reset keeps your data/config and only wipes the Python venv/build state, ready for a fresh setup run. Uninstall removes everything this project installed.">
-        <div class="group-label">Reset / Uninstall</div>
+        <div class="group-label">Reset / Uninstall<a class="help-link" href="/help.html#reset-uninstall" target="_blank" rel="noopener" title="Help">i</a></div>
         <div class="mode-power-group-buttons">
           <button id="install-reset-btn" class="ql-small-btn" onclick="installAction('reset')" style="margin-left:0;">Reset</button>
           <button id="install-uninstall-btn" class="power-btn" onclick="installAction('uninstall')">Uninstall</button>
@@ -1169,7 +1175,6 @@ sudo systemctl start pifinder</pre>
     </div>
 
     <div id="status-row">
-      <div id="status" class="status-idle">Checking current state&hellip;</div>
       <div id="reboot-wrap">
         <button id="reboot-button" onclick="reboot()">Reboot Now</button>
       </div>

--- a/pifinder_stellarmate_setup.sh
+++ b/pifinder_stellarmate_setup.sh
@@ -60,6 +60,11 @@ esac
 # re-execs below rely on `$(pwd)` (via `source $(pwd)/bin/functions.sh`) being
 # the repo root again, so they must `cd` back here first.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Absolute path to this script itself, for the venv re-exec calls below -
+# using bare $0 there breaks when invoked as "bash pifinder_stellarmate_setup.sh"
+# (no "/" in the name, so bash's `exec` does a $PATH lookup and fails to
+# find it) instead of "./pifinder_stellarmate_setup.sh" or an absolute path.
+SCRIPT_PATH="${SCRIPT_DIR}/$(basename "$0")"
 
 # Branch switch (if requested) runs before self-update, which only ever
 # fast-forwards whichever branch is already checked out - it has no notion
@@ -535,7 +540,7 @@ if ! is_venv_active "${python_venv}"; then
       if [ -n "$ACTION" ]; then
         echo "🔁 Virtual environment created — re-executing inside it automatically ..."
         cd "$SCRIPT_DIR"
-        exec bash -c "source '${python_venv}/bin/activate' && exec '$0' \"\$@\"" -- "$@"
+        exec bash -c "source '${python_venv}/bin/activate' && exec '${SCRIPT_PATH}' \"\$@\"" -- "$@"
       fi
       echo " "
       echo "##### STOP ##########################################################"
@@ -558,7 +563,7 @@ if ! is_venv_active "${python_venv}"; then
     if [ -n "$ACTION" ]; then
       echo "🔁 Virtual environment directory exists but isn't active — re-executing inside it automatically ..."
       cd "$SCRIPT_DIR"
-      exec bash -c "source '${python_venv}/bin/activate' && exec '$0' \"\$@\"" -- "$@"
+      exec bash -c "source '${python_venv}/bin/activate' && exec '${SCRIPT_PATH}' \"\$@\"" -- "$@"
     fi
     echo -e "STOP: Python venv directory exists. Please activate the venv manually with:\n vvvvvvvv"
     echo "source ${python_venv}/bin/activate"
@@ -575,7 +580,7 @@ else
       # re-detects the (missing) venv and goes through the normal create path.
       echo "🔁 Stale venv reference (directory was removed) — re-executing cleanly ..."
       cd "$SCRIPT_DIR"
-      exec env -u VIRTUAL_ENV bash "$0" "$@"
+      exec env -u VIRTUAL_ENV bash "${SCRIPT_PATH}" "$@"
     fi
     echo "###################################################################"
     echo "WARNING: Your shell thinks a virtual environment is active,"

--- a/pifinder_stellarmate_setup.sh
+++ b/pifinder_stellarmate_setup.sh
@@ -268,17 +268,21 @@ if [ -d "${pifinder_home}/PiFinder" ]; then
         echo "   1. Delete the existing installation and reinstall from scratch."
         echo "   2. Update the existing installation with 'git reset --hard origin/release'."
         echo "   3. Cancel the installation."
+        echo "   4. Uninstall PiFinder completely (removes services, INDI drivers, ~/PiFinder)."
+        echo "   5. Reset (keep data/config, wipe venv/build only, ready to re-run setup)."
 
         case "$ACTION" in
             reinstall) choice="1" ;;
             update)    choice="2" ;;
             cancel)    choice="3" ;;
+            uninstall) choice="4" ;;
+            reset)     choice="5" ;;
             "")
-                read -p "Enter your choice (1, 2, or 3): " choice
+                read -p "Enter your choice (1-5): " choice
                 choice="${choice//[$'\r\n']}"
                 ;;
             *)
-                echo "❌ Unknown --action='$ACTION' (expected reinstall|update|cancel)."
+                echo "❌ Unknown --action='$ACTION' (expected reinstall|update|cancel|uninstall|reset)."
                 exit 1
                 ;;
         esac
@@ -378,9 +382,24 @@ if [ -d "${pifinder_home}/PiFinder" ]; then
                 echo "ℹ️  Installation cancelled by user."
                 exit 0
                 ;;
+            4)
+                echo "➡️  Selected: 4. Uninstall PiFinder completely."
+                # Plain (non-selfmove) invocation: safe to run directly here,
+                # this is a bash-level call, not the Control Center's own
+                # long-running Python server serving out of this directory -
+                # see bin/uninstall_pifinder_stellarmate.sh's own --selfmove
+                # comment for why that distinction matters.
+                bash "${pifinder_stellarmate_bin}/uninstall_pifinder_stellarmate.sh"
+                exit 0
+                ;;
+            5)
+                echo "➡️  Selected: 5. Reset (keep data/config, wipe venv/build only)."
+                bash "${pifinder_stellarmate_bin}/uninstall_pifinder_stellarmate.sh" --reset
+                exit 0
+                ;;
             *)
                 echo "➡️  Selected: $choice (invalid)"
-                echo "❌ Invalid choice. Please run the script again and select 1, 2, or 3."
+                echo "❌ Invalid choice. Please run the script again and select 1-5."
                 exit 1
                 ;;
         esac


### PR DESCRIPTION
## Summary
- Fixes #92: the Reset/Uninstall buttons lived under "PiFinder Mode, Test and Power" (Start/Stop/Restart of the `pifinder` process), misleadingly suggesting Uninstall only affected that process, not the whole PiFinder_Stellarmate installation it actually removes. Moved into the "Install or Update" card, restructured into the Mode-tile's group pattern (Source/Install/Reset-Uninstall), status pill moved to top-right - all placement/styling only, no behavior change.
- Fixes #94: `--reset` silently ran the full uninstall body first (unconditional top-level code, no gate on `$1`) before doing its own venv-only cleanup - Reset was actually Uninstall+Reset. Found live during TC-PFSM-84-01 step 2.
- Fixes #95: the venv two-pass-restart re-exec used bare `$0`, which breaks when the script is invoked as `bash pifinder_stellarmate_setup.sh` instead of `./pifinder_stellarmate_setup.sh` - found while recovering the device after #94's fallout.

## Test plan
See TC-PFSM-84-01 (#86), execution #88 - in progress, steps 2-8 being re-run against these fixes.