### PR TITLE
feat: Solve badge reflects real plate-solve status

### DIFF
--- a/.github/ISSUE_TEMPLATE/test-case.yml
+++ b/.github/ISSUE_TEMPLATE/test-case.yml
@@ -1,0 +1,60 @@
+name: Test Case
+description: New test case for the reusable test case catalog
+title: "[Test Case] "
+labels: ["test-case"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A test case is a **reusable definition** — not an execution result and not a Pass/Fail.
+        See [CONVENTIONS.md](../../CONVENTIONS.md) for how to use it.
+
+  - type: textarea
+    id: precondition
+    attributes:
+      label: Precondition
+      description: State that must be true before testing starts.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps
+      description: >
+        Numbered, exact steps — no paraphrasing. Give an expected result only for steps where
+        something checkable happens; pure navigation/setup steps stay without their own result.
+      placeholder: |
+        1. ...
+           Expected: ...
+        2. ...
+        3. ...
+           Expected: ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: postcondition
+    attributes:
+      label: Postcondition
+      description: State after a successful test run.
+    validations:
+      required: false
+
+  - type: input
+    id: test-type
+    attributes:
+      label: Test Type / Category
+      description: >
+        e.g. functional, regression, smoke, installation — determines which set:* label(s)
+        should be added to the issue.
+    validations:
+      required: false
+
+  - type: input
+    id: reference
+    attributes:
+      label: Reference (Requirement / Issue / Feature)
+      description: Traceability — what does this test case relate to?
+    validations:
+      required: false

--- a/bin/uninstall_pifinder_stellarmate.sh
+++ b/bin/uninstall_pifinder_stellarmate.sh
@@ -7,6 +7,8 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=./functions.sh
 source "${SCRIPT_DIR}/functions.sh"
+# shellcheck source=./os_detect.sh
+source "${SCRIPT_DIR}/os_detect.sh"
 
 # Every systemd unit this project installs into /etc/systemd/system. Keep in
 # sync with the "cp ... /etc/systemd/system/" lines in
@@ -87,7 +89,18 @@ _unmask_wireplumber() {
         fi
     done
     echo "   ℹ️  pipewire-libcamera was removed from the system during install (it conflicted with"
-    echo "      PiFinder's camera access) - reinstall manually if you want it back: sudo pacman -S pipewire-libcamera"
+    local manager
+    if manager="$(os_detect_package_manager 2>/dev/null)" && [ "${manager}" = "pacman" ]; then
+        echo "      PiFinder's camera access) - reinstall manually if you want it back: sudo pacman -S pipewire-libcamera"
+    else
+        # This removal only happens on the pacman/Arch (StellarMate) full
+        # install path this script otherwise targets - on any other package
+        # manager, say so honestly instead of printing an untested apt/nix
+        # command (see os_detect.sh's own header: apt/nix are design- not
+        # field-verified, and pipewire-libcamera isn't in its package table
+        # at all yet).
+        echo "      PiFinder's camera access) - reinstall manually via your system's package manager if you want it back."
+    fi
 }
 
 _remove_lgpio_build() {
@@ -111,8 +124,15 @@ _print_manual_cleanup_notes() {
     echo "      dtoverlay=pwm,pin=13,func=4, dtoverlay=imx296, and (Pi4) dtoverlay=uart3 /"
     echo "      (Pi5) dtoverlay=pwm-2chan. Other hardware/StellarMate features may also depend on"
     echo "      SPI/I2C being enabled - review and remove by hand if you're sure nothing else needs them."
-    echo "    - /etc/pacman.conf: 'IgnorePkg = python-libcamera' pin (prevents an incompatible"
-    echo "      libcamera-vs-python-libcamera version mismatch) - remove by hand if desired."
+    # The python-libcamera pin only exists on the pacman/Arch (StellarMate)
+    # full install path - pacman.conf's IgnorePkg mechanism has no apt/nix
+    # equivalent, so this note would be actively wrong (references a file
+    # that doesn't exist) on those systems. Only print it where it applies.
+    local manager
+    if manager="$(os_detect_package_manager 2>/dev/null)" && [ "${manager}" = "pacman" ]; then
+        echo "    - /etc/pacman.conf: 'IgnorePkg = python-libcamera' pin (prevents an incompatible"
+        echo "      libcamera-vs-python-libcamera version mismatch) - remove by hand if desired."
+    fi
     echo "    - Hardware group memberships added to your user (spi, gpio, i2c, kmem, input, video)."
 }
 

--- a/gui_installer/indi_client.py
+++ b/gui_installer/indi_client.py
@@ -551,7 +551,7 @@ def set_number(
 # maps to - which mode needs DRIFT_THRESHOLD/CORRECTION_ACTION and which
 # doesn't (MODE_GOTO_FORWARD needs neither, confirmed against
 # pifinder_mount_bridge.cpp's TimerHit()).
-COUPLING_MODES = {"MODE_VERIFY_ALERT", "MODE_AUTO_CORRECT", "MODE_GOTO_FORWARD"}
+COUPLING_MODES = {"MODE_OFF", "MODE_VERIFY_ALERT", "MODE_AUTO_CORRECT", "MODE_GOTO_FORWARD"}
 DRIFT_THRESHOLD_DEFAULT = 5.0  # matches the driver's own IUFillNumber default
 CORRECTION_ACTION_DEFAULT = "sync"  # matches the driver's own default (ACTION_SYNC is ISS_ON)
 

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -1096,6 +1096,30 @@ def _do_poweroff():
 _server = None  # set in main(); used by /shutdown to stop serve_forever()
 
 
+UNINSTALL_SCRIPT = REPO_ROOT / "bin" / "uninstall_pifinder_stellarmate.sh"
+
+
+def _do_uninstall():
+    # This server process runs from inside the very directory tree being
+    # deleted (~/PiFinder_Stellarmate) - --selfmove copies the uninstall
+    # script to /tmp first and continues from there, so the removal of this
+    # repo (and this server's own pifinder-control-center.service) survives
+    # this process's own directory disappearing out from under it. See the
+    # script's own --selfmove header comment for the full rationale.
+    time.sleep(1)  # give the HTTP response a moment to reach the browser
+    subprocess.run(["bash", str(UNINSTALL_SCRIPT), "--selfmove"])
+
+
+def _do_reset():
+    # --reset only touches ~/PiFinder's own venv/build state, never this
+    # repo's own directory - unlike _do_uninstall() above, safe to run
+    # directly and report the result, no --selfmove/self-deletion concern.
+    result = subprocess.run(
+        ["bash", str(UNINSTALL_SCRIPT), "--reset"], capture_output=True, text=True,
+    )
+    return result.returncode == 0, (result.stdout + result.stderr)[-4000:]
+
+
 def _do_shutdown():
     time.sleep(1)  # give the HTTP response a moment to reach the browser
     # Persist "should NOT run after a reboot" the same way starting it (via
@@ -1520,7 +1544,7 @@ class Handler(BaseHTTPRequestHandler):
         self.send_error(404)
 
     def do_POST(self):
-        global _hwtest_running
+        global _hwtest_running, _mode_action_running
         parsed = urlparse(self.path)
 
         # /shutdown stays open: PiFinder's PFSM page (a different
@@ -1590,8 +1614,31 @@ class Handler(BaseHTTPRequestHandler):
             threading.Thread(target=_do_poweroff, daemon=True).start()
             return
 
+        if parsed.path == "/uninstall":
+            with _lock:
+                if _running or _mode_action_running or _hwtest_running:
+                    self._send_json(
+                        {"uninstalling": False, "error": "An install/update run, mode switch, or hardware test is in progress - wait for it to finish first."},
+                        status=409,
+                    )
+                    return
+            self._send_json({"uninstalling": True})
+            threading.Thread(target=_do_uninstall, daemon=True).start()
+            return
+
+        if parsed.path == "/reset":
+            with _lock:
+                if _running or _mode_action_running or _hwtest_running:
+                    self._send_json(
+                        {"success": False, "error": "An install/update run, mode switch, or hardware test is in progress - wait for it to finish first."},
+                        status=409,
+                    )
+                    return
+            ok, output = _do_reset()
+            self._send_json({"success": ok, "output": output})
+            return
+
         if parsed.path == "/api/pifinder_mode":
-            global _mode_action_running
             qs = parse_qs(parsed.query)
             action = qs.get("action", [""])[0]
             if action not in ("enable_fake", "disable_fake"):

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -2010,22 +2010,25 @@ class Handler(BaseHTTPRequestHandler):
             return
 
         if parsed.path == "/api/mount_bridge_coupling":
-            # Phase 4: the three one-click Coupling presets. mode is
-            # "verify_alert"|"auto_correct"|"goto_forward" (short form here,
-            # translated to the driver's own MODE_* constants in
-            # indi_client.set_coupling_mode()). threshold/action are only
-            # meaningful for verify_alert/auto_correct - harmless if sent
-            # for goto_forward, indi_client.py ignores them there.
+            # Phase 4: the three one-click Coupling presets, plus "off" (the
+            # Decouple button - no dedicated preset button of its own, see
+            # onDecoupleClick()). mode is "verify_alert"|"auto_correct"|
+            # "goto_forward"|"off" (short form here, translated to the
+            # driver's own MODE_* constants in indi_client.set_coupling_
+            # mode()). threshold/action are only meaningful for
+            # verify_alert/auto_correct - harmless if sent for goto_forward
+            # or off, indi_client.py ignores them there.
             qs = parse_qs(parsed.query)
             mode_arg = qs.get("mode", [""])[0]
             mode_map = {
                 "verify_alert": "MODE_VERIFY_ALERT",
                 "auto_correct": "MODE_AUTO_CORRECT",
                 "goto_forward": "MODE_GOTO_FORWARD",
+                "off": "MODE_OFF",
             }
             if mode_arg not in mode_map:
                 self._send_json(
-                    {"success": False, "error": "expected ?mode=verify_alert|auto_correct|goto_forward"},
+                    {"success": False, "error": "expected ?mode=verify_alert|auto_correct|goto_forward|off"},
                     status=400,
                 )
                 return

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -847,16 +847,28 @@ def _startup_hardware_test(timeout=120, interval=2):
     _run_hardware_test()
 
 
-def _pifinder_debug_solve_status(port: str):
+def _pifinder_solve_status(port: str):
     """GET the currently-reachable PiFinder instance's own /api/status and
-    pull out debug_solve (Tools -> Test Mode's on/off state - PiFinder's own
-    feature, unrelated to this tile's Fake/Real Mode). None if unreachable."""
+    pull out debug_solve (Tools -> Test Mode's on/off state) plus the real
+    solve-freshness fields (solve_source/last_solve_attempt/last_solve_success)
+    - all from the same request, since /api/status already returns both.
+    None if unreachable.
+
+    solve_source is "CAM" (fresh plate-solve), "CAM_FAILED" (attempted, no
+    star match - normal indoors/no sky view, not itself a hardware problem),
+    or "IMU" (currently dead-reckoning between solves). See
+    PiFinder/types/positioning.py's SolveSource enum."""
     if port not in _ALLOWED_PIFINDER_PORTS:
         return None
     try:
         with urllib.request.urlopen(f"http://127.0.0.1:{port}/api/status", timeout=3) as resp:
             data = json.loads(resp.read())
-        return data.get("debug_solve")
+        return {
+            "debug_solve": data.get("debug_solve"),
+            "solve_source": data.get("solve_source"),
+            "last_solve_attempt": data.get("last_solve_attempt"),
+            "last_solve_success": data.get("last_solve_success"),
+        }
     except Exception:
         return None
 
@@ -1474,7 +1486,7 @@ class Handler(BaseHTTPRequestHandler):
         if parsed.path == "/api/debug_solve":
             qs = parse_qs(parsed.query)
             port = qs.get("port", [""])[0]
-            self._send_json({"debug_solve": _pifinder_debug_solve_status(port)})
+            self._send_json(_pifinder_solve_status(port) or {"debug_solve": None})
             return
 
         if parsed.path == "/api/hardware_test_log":

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -649,7 +649,9 @@
   .mb-arrow.mb-arrow-read { color: #5b9bd5; }
   .mb-arrow.mb-arrow-write { color: #f5a623; font-weight: bold; }
   .mb-arrow.mb-arrow-goto { color: #4caf50; font-weight: bold; }
-  #mb-mode-caption { color: #888; font-size: 0.76rem; margin-bottom: 0.6rem; }
+  #mb-mode-caption-row { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.6rem; }
+  #mb-mode-caption { color: #888; font-size: 0.76rem; }
+  #mb-decouple-btn { margin-left: 0; }
   /* Shared collapsible-section header, reused wherever a tile has a
      "matters every time" part and a "one-time setup / rarely touched"
      part - per live feedback/design principle, the latter defaults to
@@ -984,7 +986,10 @@ sudo systemctl start pifinder</pre>
           <span id="mb-node-mount-name">Mount</span>
         </div>
       </div>
-      <div id="mb-mode-caption">Not coupled yet</div>
+      <div id="mb-mode-caption-row">
+        <span id="mb-mode-caption">Not coupled yet</span>
+        <button id="mb-decouple-btn" class="ql-small-btn" onclick="onDecoupleClick()" style="display:none;" title="Sets Coupling back to Off - PiFinder and mount stop syncing automatically until you pick a preset again. No dedicated preset button for this (Off is the driver's own default/neutral state).">Decouple</button>
+      </div>
       <!-- Everything from coupling presets to manual sync is meaningless in
            the "PiFinder host" role (no Mount Bridge in the profile) - this
            wrapper lets updateProfileRoleLine() hide the whole block at once
@@ -2511,12 +2516,15 @@ function applyMbDriftAndMode(couplingMode, correctionAction, driftArcmin) {
   updateDriftBadge(driftArcmin, threshold);
   updateCouplingButtons(couplingMode, correctionAction);
 
+  const decoupleBtn = document.getElementById('mb-decouple-btn');
   if (!couplingMode || couplingMode === 'MODE_OFF') {
     setMbArrow('mb-arrow-left', 'off');
     setMbArrow('mb-arrow-right', 'off');
     captionEl.textContent = 'Not coupled - PiFinder and mount move independently';
+    decoupleBtn.style.display = 'none';
     return false;
   }
+  decoupleBtn.style.display = '';
   if (couplingMode === 'MODE_VERIFY_ALERT') {
     setMbArrow('mb-arrow-left', 'read');
     setMbArrow('mb-arrow-right', 'read');
@@ -2857,6 +2865,34 @@ async function setWmCoupling(preset) {
     // buttons on this page.
   }
   btn.textContent = originalText;
+  pollMbLog();
+  await refreshMountBridgeStatus();
+  mbActionInFlight = false;
+  clearMbActionStatus();
+}
+
+// Sets Coupling back to Off. No dedicated preset button for this (unlike
+// verify_alert/auto_correct/goto_forward) - Off is the driver's own default/
+// neutral state, previously only reachable via the raw INDI Control Panel in
+// KStars/Ekos, not from this simplified tile at all (found live, 2026-07-31).
+async function onDecoupleClick() {
+  mbActionInFlight = true;
+  setMbActionStatus('⏳ Decoupling…');
+  const btn = document.getElementById('mb-decouple-btn');
+  const originalText = btn.textContent;
+  btn.disabled = true;
+  btn.textContent = 'decoupling…';
+  document.getElementById('mount-bridge-dot').classList.add('dot-unconfirmed');
+  try {
+    const resp = await fetch('/api/mount_bridge_coupling?mode=off', { method: 'POST' });
+    const data = await resp.json();
+    if (!data.success) throw new Error(data.error || 'failed');
+  } catch (e) {
+    // fall through - errors show up via pollMbLog() below, same pattern as
+    // the Coupling preset buttons.
+  }
+  btn.textContent = originalText;
+  btn.disabled = false;
   pollMbLog();
   await refreshMountBridgeStatus();
   mbActionInFlight = false;

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -314,8 +314,15 @@
   .mode-power-group-buttons-stacked { flex-direction: column; }
   #power-reboot-btn { background: #2a6fdb; }
   #power-poweroff-btn { background: #a33; }
+  #install-uninstall-btn { background: #a33; }
   .power-btn:hover { filter: brightness(1.15); }
   .power-btn:disabled { background: #444; cursor: default; filter: none; }
+  #install-power-divider {
+    width: 1px;
+    align-self: stretch;
+    background: #444;
+    margin-top: 1.2rem;
+  }
   #mode-tile {
     background: #1a1a1a;
     border: 1px solid #333;
@@ -855,6 +862,14 @@
             <div class="mode-power-group-buttons mode-power-group-buttons-stacked">
               <button id="power-reboot-btn" class="power-btn" onclick="powerAction('reboot')">Reboot Pi</button>
               <button id="power-poweroff-btn" class="power-btn" onclick="powerAction('poweroff')">Shutdown Pi</button>
+            </div>
+          </div>
+          <div id="install-power-divider"></div>
+          <div class="mode-power-group" title="Uses bin/uninstall_pifinder_stellarmate.sh. Reset keeps your data/config and only wipes the Python venv/build state, ready for a fresh setup run. Uninstall removes everything this project installed (services, INDI drivers, ~/PiFinder).">
+            <div class="group-label">Installation</div>
+            <div class="mode-power-group-buttons mode-power-group-buttons-stacked">
+              <button id="install-reset-btn" class="ql-small-btn" onclick="installAction('reset')" style="margin-left:0;">Reset</button>
+              <button id="install-uninstall-btn" class="power-btn" onclick="installAction('uninstall')">Uninstall</button>
             </div>
           </div>
         </div>
@@ -1961,6 +1976,62 @@ async function powerAction(kind) {
     // accepted the request - treat it the same as a confirmed action.
   }
   watchForServerLoss();
+}
+
+// Uninstall/Reset - both drive bin/uninstall_pifinder_stellarmate.sh (see
+// its own header comments for --selfmove/--reset). Reset is comparatively
+// low-risk (venv/build state only, keeps data/config); Uninstall is final
+// and removes everything this project installed, including this very
+// server's own directory - handled the same way as reboot/poweroff
+// (watchForServerLoss(), since there's no coming back from this one).
+async function installAction(kind) {
+  const isUninstall = kind === 'uninstall';
+  const message = isUninstall
+    ? '⚠ Uninstall PiFinder completely? This stops and removes all PiFinder services, INDI drivers, and ~/PiFinder itself. This page (and this whole Control Center) will stop working once it starts. This cannot be undone from here.'
+    : 'Reset PiFinder? This wipes the Python venv/build state only - your data, config, and installed services/drivers are kept. Ready for a fresh setup run afterward.';
+  if (!confirm(message)) return;
+  const resetBtn = document.getElementById('install-reset-btn');
+  const uninstallBtn = document.getElementById('install-uninstall-btn');
+  const btn = isUninstall ? uninstallBtn : resetBtn;
+  resetBtn.disabled = true;
+  uninstallBtn.disabled = true;
+  btn.textContent = isUninstall ? 'Uninstalling…' : 'Resetting…';
+  try {
+    const resp = await fetch(`/${kind}`, { method: 'POST' });
+    const data = await resp.json();
+    if (isUninstall) {
+      if (!data.uninstalling) {
+        resetBtn.disabled = false;
+        uninstallBtn.disabled = false;
+        btn.textContent = 'Uninstall';
+        alert('Could not start uninstall: ' + (data.error || 'unknown error'));
+        return;
+      }
+      watchForServerLoss();
+      return;
+    }
+    // Reset runs synchronously server-side and returns its own result -
+    // no server-loss handling needed, this repo's own directory is untouched.
+    resetBtn.disabled = false;
+    uninstallBtn.disabled = false;
+    btn.textContent = 'Reset';
+    if (data.success) {
+      alert('Reset complete - venv/build state cleared. Run the setup script again to rebuild.');
+    } else {
+      alert('Reset failed:\n\n' + (data.output || data.error || 'unknown error'));
+    }
+  } catch (e) {
+    if (isUninstall) {
+      // Network error here can also mean the server went down right as it
+      // accepted the request - treat it the same as a confirmed action.
+      watchForServerLoss();
+    } else {
+      resetBtn.disabled = false;
+      uninstallBtn.disabled = false;
+      btn.textContent = 'Reset';
+      alert('Reset request failed.');
+    }
+  }
 }
 
 // Direct pifinder.service control (start/stop/restart) - shouldn't normally

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -889,7 +889,7 @@
             </svg>
             <span>Cam</span>
           </div>
-          <div class="mode-ampel-badge" title="Solve Simulation">
+          <div class="mode-ampel-badge" title="Solve">
             <svg class="mode-ampel-icon mode-ampel-icon-unconfirmed" id="mode-ampel-solve-icon" style="color:#f5a623;" viewBox="0 0 24 24" aria-hidden="true">
               <circle cx="12" cy="12" r="8" fill="none" stroke="currentColor" stroke-width="1.3"/>
               <path d="M12 2.5v4M12 17.5v4M2.5 12h4M17.5 12h4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
@@ -924,6 +924,9 @@
             </div>
             <div class="hw-row"><span class="status-dot dot-unconfirmed" id="hw-camera-dot"></span>Camera: <span id="hw-camera-text">checking&hellip;</span></div>
             <div class="hw-detail" id="hw-camera-detail"></div>
+            <div class="hw-row" title="Whether the current pointing estimate comes from a fresh plate-solve (CAM), no star match on the last attempt (CAM_FAILED - normal indoors/no sky view, not itself a hardware problem), or IMU dead-reckoning between solves (IMU). Distinct from Solve Simulation below, which only says whether test images are being used.">
+              <span class="status-dot dot-unconfirmed" id="solve-status-dot"></span>Solve: <span id="solve-status-text">checking&hellip;</span>
+            </div>
             <div class="hw-row" title="PiFinder's own &quot;Tools -> Test Mode&quot; feature - substitutes canned test images for the camera so plate-solving can be exercised without sky access, while IMU/keyboard/GPS stay live. Not the same as this tile's Fake Mode switch above (which runs a whole separate headless instance with no hardware at all).">
               <span class="status-dot dot-unconfirmed" id="debug-solve-dot"></span>Solve Simulation: <span id="debug-solve-text">unknown</span>
               <button id="debug-solve-btn" class="ql-small-btn" onclick="toggleDebugSolve()" disabled>Toggle</button>
@@ -1360,10 +1363,16 @@ function updatePiFinderStatusAndWizardLink() {
 
 // PiFinder's own "Tools -> Test Mode" (callbacks.activate_debug() ->
 // shared_state.debug_solve()) - entirely separate from this page's Fake Mode
-// tile. Triggered via gui_installer/server.py's own proxy (POST/GET
+// tile. Triggered via gui_installer/server.py's own proxy (GET/POST
 // /api/debug_solve?port=N, always dialing 127.0.0.1 on that port) rather
 // than fetching PiFinder's API directly from the browser, since PiFinder
-// sets no CORS headers and this page is served from a different port.
+// sets no CORS headers and this page is served from a different port. The
+// GET side now also returns solve_source/last_solve_attempt/last_solve_success
+// from the same /api/status call - refreshDebugSolve() below updates both the
+// Solve Simulation row (debug_solve on/off) and the separate, real "Solve"
+// row/badge (solve_source-based - see #85: the ampel badge used to just
+// mirror Solve Simulation, which said nothing about whether a real plate-solve
+// was actually succeeding).
 // Maps each of the 4 "Hardware test and details" status dots to its
 // counterpart badge icon in the always-visible #mode-ampel-row strip above
 // it (see that row's own CSS comment) - setHwDot() is a drop-in replacement
@@ -1373,7 +1382,7 @@ function updatePiFinderStatusAndWizardLink() {
 // refreshDebugSolve()/applyHwTestRow()/applyHwTestResult().
 const HW_AMPEL_ICON_IDS = {
   'hw-camera-dot': 'mode-ampel-camera-icon',
-  'debug-solve-dot': 'mode-ampel-solve-icon',
+  'solve-status-dot': 'mode-ampel-solve-icon',
   'hw-imu-dot': 'mode-ampel-imu-icon',
   'hw-gps-dot': 'mode-ampel-gps-icon',
 };
@@ -1395,6 +1404,31 @@ function setHwDot(dotEl, className) {
   ampelEl.classList.toggle('mode-ampel-icon-unconfirmed', unconfirmed);
 }
 
+// solve_source ("CAM"/"CAM_FAILED"/"IMU", see PiFinder/types/positioning.py's
+// SolveSource enum) is the real "is a plate-solve currently succeeding"
+// signal - independent of Solve Simulation, which only says whether test
+// images are being fed in. CAM_FAILED just means the last attempt found no
+// star match (normal indoors/no sky view, not a hardware problem) - not
+// worded as an alarming "FAILED" here for that reason.
+function applySolveStatus(data) {
+  const dotEl = document.getElementById('solve-status-dot');
+  const textEl = document.getElementById('solve-status-text');
+  const suffix = data.debug_solve === true ? ' (simulated image)' : '';
+  if (data.solve_source === 'CAM') {
+    setHwDot(dotEl, 'status-dot dot-green');
+    textEl.textContent = 'solving' + suffix;
+  } else if (data.solve_source === 'CAM_FAILED') {
+    setHwDot(dotEl, 'status-dot dot-red');
+    textEl.textContent = 'no star match' + suffix + ' - normal indoors/no sky view';
+  } else if (data.solve_source === 'IMU') {
+    setHwDot(dotEl, 'status-dot dot-unconfirmed');
+    textEl.textContent = 'no fresh solve yet - estimating from IMU' + suffix;
+  } else {
+    setHwDot(dotEl, 'status-dot dot-white');
+    textEl.textContent = 'unknown';
+  }
+}
+
 async function refreshDebugSolve() {
   const dotEl = document.getElementById('debug-solve-dot');
   const textEl = document.getElementById('debug-solve-text');
@@ -1404,6 +1438,7 @@ async function refreshDebugSolve() {
     textEl.textContent = 'unknown (PiFinder not reachable)';
     btn.disabled = true;
     lastDebugSolve = null;
+    applySolveStatus({});
     return null;
   }
   const port = new URL(pifinderScreenUrl).port || '80';
@@ -1427,6 +1462,7 @@ async function refreshDebugSolve() {
       setHwDot(dotEl, 'status-dot dot-white');
       textEl.textContent = 'unknown';
     }
+    applySolveStatus(data);
     btn.disabled = false;
     return data.debug_solve;
   } catch (e) {
@@ -1434,6 +1470,7 @@ async function refreshDebugSolve() {
     textEl.textContent = 'unknown';
     btn.disabled = true;
     lastDebugSolve = null;
+    applySolveStatus({});
     return null;
   }
 }

--- a/pifinder_stellarmate_setup.sh
+++ b/pifinder_stellarmate_setup.sh
@@ -268,17 +268,21 @@ if [ -d "${pifinder_home}/PiFinder" ]; then
         echo "   1. Delete the existing installation and reinstall from scratch."
         echo "   2. Update the existing installation with 'git reset --hard origin/release'."
         echo "   3. Cancel the installation."
+        echo "   4. Uninstall PiFinder completely (removes services, INDI drivers, ~/PiFinder)."
+        echo "   5. Reset (keep data/config, wipe venv/build only, ready to re-run setup)."
 
         case "$ACTION" in
             reinstall) choice="1" ;;
             update)    choice="2" ;;
             cancel)    choice="3" ;;
+            uninstall) choice="4" ;;
+            reset)     choice="5" ;;
             "")
-                read -p "Enter your choice (1, 2, or 3): " choice
+                read -p "Enter your choice (1-5): " choice
                 choice="${choice//[$'\r\n']}"
                 ;;
             *)
-                echo "❌ Unknown --action='$ACTION' (expected reinstall|update|cancel)."
+                echo "❌ Unknown --action='$ACTION' (expected reinstall|update|cancel|uninstall|reset)."
                 exit 1
                 ;;
         esac
@@ -378,9 +382,24 @@ if [ -d "${pifinder_home}/PiFinder" ]; then
                 echo "ℹ️  Installation cancelled by user."
                 exit 0
                 ;;
+            4)
+                echo "➡️  Selected: 4. Uninstall PiFinder completely."
+                # Plain (non-selfmove) invocation: safe to run directly here,
+                # this is a bash-level call, not the Control Center's own
+                # long-running Python server serving out of this directory -
+                # see bin/uninstall_pifinder_stellarmate.sh's own --selfmove
+                # comment for why that distinction matters.
+                bash "${pifinder_stellarmate_bin}/uninstall_pifinder_stellarmate.sh"
+                exit 0
+                ;;
+            5)
+                echo "➡️  Selected: 5. Reset (keep data/config, wipe venv/build only)."
+                bash "${pifinder_stellarmate_bin}/uninstall_pifinder_stellarmate.sh" --reset
+                exit 0
+                ;;
             *)
                 echo "➡️  Selected: $choice (invalid)"
-                echo "❌ Invalid choice. Please run the script again and select 1, 2, or 3."
+                echo "❌ Invalid choice. Please run the script again and select 1-5."
                 exit 1
                 ;;
         esac


### PR DESCRIPTION
## Summary
- Fixes #85: the Control Center's "Solve" ampel badge used to just mirror the Solve Simulation on/off toggle, saying nothing about whether a real plate-solve was actually succeeding under a real sky.
- PiFinder's own `/api/status` already exposes `solve_source`/`last_solve_attempt`/`last_solve_success` - no PiFinder-side patch needed, only Control Center wiring (`server.py`, `status_page.html`).
- New, separate "Solve" detail row (distinct from "Solve Simulation" below it): green while actively solving, non-alarmingly worded red when the last attempt found no star match (`CAM_FAILED` is normal indoors/no sky view, not a hardware problem), pulsing-yellow while dead-reckoning from IMU between solves.

## Test plan
See TC-PFSM-85-01 (#97) - real-sky steps (4/5) still need a live run under the night sky, not yet executed.