### PR TITLE
#130: Mount Bridge gains 'Mount is source' mode - mount drives PiFinder's position

### DIFF
--- a/gui_installer/help.html
+++ b/gui_installer/help.html
@@ -79,6 +79,7 @@
           <ul>
             <li><a href="#coupling-visual">Visual group</a></li>
             <li><a href="#coupling-goto">GoTo group</a></li>
+            <li><a href="#coupling-mount-source">Simulation group</a></li>
           </ul>
         </li>
         <li><a href="#drift-badge">Drift readout</a></li>
@@ -198,6 +199,9 @@
 <p><strong>Setup</strong>: runs steps 1-4/6 above in one click (start profile, add drivers, connect - pausing for you to link your mount, the one step it can't decide for you) without applying any Coupling preset at the end. Use this to get everything ready first, then pick a mode deliberately once it's all connected.</p>
 <p><strong>Autoconnect</strong>: clicking any preset before steps 1-6 are actually finished doesn't just fail - it runs the exact same setup as the Setup button above automatically, then applies the coupling mode you originally clicked once it's done. The Setup button exists so you're not only discovering this by clicking a preset and seeing setup start unexpectedly.</p>
 <p><strong>Manual: Sync mount from PiFinder</strong>: a one-shot action, works regardless of which Coupling preset (or none) is active. Syncs the mount to PiFinder's current solved position right now - no Goto, no drift comparison, just an instant correction. Useful specifically after moving the mount by hand: none of the Coupling presets react to that on their own (Auto-correct only reacts on its next poll if drift already exceeds Threshold, Goto-Forward only reacts to a new PiFinder target, not a mount move).</p>
+
+<h4 id="coupling-mount-source">Simulation group</h4>
+<p><strong>Mount is source</strong> reverses every other mode's direction: instead of PiFinder's solve driving the mount, the mount's own position (a real mount, or the stock INDI Telescope Simulator) is pushed to PiFinder as an Injected Solve (Dead Reckoning) - see the "PiFinder Mode, Test and Power" tile's Simulation and testing section. Mirrors physical reality (a real mount and a real PiFinder are rigidly coupled, so wherever the mount points, PiFinder points too), and enables testing/demoing the whole setup with zero real PiFinder hardware: point or slew the mount from any INDI client (its own hand controller, SkySafari, KStars, OnStep's own apps - the source doesn't matter, INDI doesn't care who issued the command) and a Fake-Mode PiFinder instance follows. Only pushes on a meaningful mount move, not continuously, so it doesn't flood PiFinder with redundant re-injections of an essentially unchanged position.</p>
 
 <h3 id="drift-badge">Drift readout</h3>
 <p>The large number top-right of the tile is the current angular drift between PiFinder's solved position and the mount's reported position, in arcminutes:</p>

--- a/gui_installer/indi_client.py
+++ b/gui_installer/indi_client.py
@@ -551,7 +551,7 @@ def set_number(
 # maps to - which mode needs DRIFT_THRESHOLD/CORRECTION_ACTION and which
 # doesn't (MODE_GOTO_FORWARD needs neither, confirmed against
 # pifinder_mount_bridge.cpp's TimerHit()).
-COUPLING_MODES = {"MODE_OFF", "MODE_VERIFY_ALERT", "MODE_AUTO_CORRECT", "MODE_GOTO_FORWARD"}
+COUPLING_MODES = {"MODE_OFF", "MODE_VERIFY_ALERT", "MODE_AUTO_CORRECT", "MODE_GOTO_FORWARD", "MODE_MOUNT_SOURCE"}
 DRIFT_THRESHOLD_DEFAULT = 5.0  # matches the driver's own IUFillNumber default
 CORRECTION_ACTION_DEFAULT = "sync"  # matches the driver's own default (ACTION_SYNC is ISS_ON)
 
@@ -589,6 +589,8 @@ def set_coupling_mode(
       - MODE_VERIFY_ALERT: DRIFT_THRESHOLD only
       - MODE_AUTO_CORRECT: DRIFT_THRESHOLD + CORRECTION_ACTION
       - MODE_GOTO_FORWARD: neither (both args silently ignored if given)
+      - MODE_MOUNT_SOURCE: neither either (see #130 - reverses direction,
+        mount drives PiFinder instead of the other way round)
     `correction_action` is "sync" or "goto" (matching the driver's own
     Sync/Goto-Track choice). Supporting properties are set *before*
     BRIDGE_MODE itself, so there's no window where coupling is already

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -2411,11 +2411,12 @@ class Handler(BaseHTTPRequestHandler):
                 "verify_alert": "MODE_VERIFY_ALERT",
                 "auto_correct": "MODE_AUTO_CORRECT",
                 "goto_forward": "MODE_GOTO_FORWARD",
+                "mount_source": "MODE_MOUNT_SOURCE",
                 "off": "MODE_OFF",
             }
             if mode_arg not in mode_map:
                 self._send_json(
-                    {"success": False, "error": "expected ?mode=verify_alert|auto_correct|goto_forward|off"},
+                    {"success": False, "error": "expected ?mode=verify_alert|auto_correct|goto_forward|mount_source|off"},
                     status=400,
                 )
                 return

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -393,7 +393,7 @@
     flex-wrap: wrap;
     gap: 0.5rem;
   }
-  #mb-coupling-divider {
+  #mb-coupling-divider, .mb-coupling-divider {
     width: 1px;
     background: #444;
     margin-top: 1.3rem;
@@ -1103,6 +1103,13 @@ sudo systemctl start pifinder</pre>
             <div class="mb-coupling-group-buttons">
               <button id="wm-preset-auto-goto-btn" class="mb-coupling-btn" onclick="onCouplingPresetClick('auto_correct_goto')" disabled title="Corrects by slewing the mount to PiFinder's solved position once drift exceeds the threshold - actually moves the mount, needs a Goto-capable mount.">Auto-correct (Goto &amp; Track)</button>
               <button id="wm-preset-goto-btn" class="mb-coupling-btn" onclick="onCouplingPresetClick('goto_forward')" disabled>Goto-Forward</button>
+            </div>
+          </div>
+          <div id="mb-coupling-divider-2" class="mb-coupling-divider"></div>
+          <div class="mb-coupling-group">
+            <div class="group-label mb-coupling-label"><span>Simulation</span><a class="help-link" href="/help.html#coupling-mount-source" target="_blank" rel="noopener" title="Help">i</a></div>
+            <div class="mb-coupling-group-buttons">
+              <button id="wm-preset-mount-source-btn" class="mb-coupling-btn" onclick="onCouplingPresetClick('mount_source')" disabled title="Reverses the usual direction: the mount's position (real, or the stock INDI Telescope Simulator) is injected into PiFinder as an Injected Solve instead of PiFinder driving the mount. Enables full simulation with zero real PiFinder hardware (see #130).">Mount is source</button>
             </div>
           </div>
         </div>
@@ -2997,10 +3004,11 @@ function updateCouplingButtons(mode, correctionAction) {
   let active = null;
   if (mode === 'MODE_VERIFY_ALERT') active = 'wm-preset-verify-btn';
   else if (mode === 'MODE_GOTO_FORWARD') active = 'wm-preset-goto-btn';
+  else if (mode === 'MODE_MOUNT_SOURCE') active = 'wm-preset-mount-source-btn';
   else if (mode === 'MODE_AUTO_CORRECT') {
     active = correctionAction === 'goto' ? 'wm-preset-auto-goto-btn' : 'wm-preset-auto-sync-btn';
   }
-  ['wm-preset-verify-btn', 'wm-preset-auto-sync-btn', 'wm-preset-auto-goto-btn', 'wm-preset-goto-btn'].forEach((id) => {
+  ['wm-preset-verify-btn', 'wm-preset-auto-sync-btn', 'wm-preset-auto-goto-btn', 'wm-preset-goto-btn', 'wm-preset-mount-source-btn'].forEach((id) => {
     document.getElementById(id).classList.toggle('mb-btn-active', id === active);
   });
 }
@@ -3088,6 +3096,13 @@ function applyMbDriftAndMode(couplingMode, correctionAction, driftArcmin) {
     setMbArrow('mb-arrow-left', 'goto');
     setMbArrow('mb-arrow-right', 'goto');
     captionEl.textContent = 'Forwarding goto commands straight to the mount';
+  } else if (couplingMode === 'MODE_MOUNT_SOURCE') {
+    // Reversed direction from every other mode - the mount drives PiFinder,
+    // not the other way round (see #130), so the arrows point the opposite
+    // way too: reading from the mount (right), writing to PiFinder (left).
+    setMbArrow('mb-arrow-left', 'write');
+    setMbArrow('mb-arrow-right', 'read');
+    captionEl.textContent = "Mount is the source - pushing its position to PiFinder as an Injected Solve";
   }
   const drift = driftArcmin !== null ? ` (drift ${driftArcmin.toFixed(1)}')` : '';
   document.getElementById('mount-bridge-text').textContent =
@@ -3356,6 +3371,7 @@ const MB_PRESET_INFO = {
   auto_correct_sync: { btnId: 'wm-preset-auto-sync-btn', mode: 'auto_correct', action: 'sync' },
   auto_correct_goto: { btnId: 'wm-preset-auto-goto-btn', mode: 'auto_correct', action: 'goto' },
   goto_forward: { btnId: 'wm-preset-goto-btn', mode: 'goto_forward' },
+  mount_source: { btnId: 'wm-preset-mount-source-btn', mode: 'mount_source' },
 };
 
 // Pushes a changed threshold to the driver immediately, without requiring
@@ -3400,7 +3416,7 @@ async function setWmCoupling(preset) {
   const threshold = document.getElementById('wm-threshold-input').value;
   try {
     const params = new URLSearchParams({ mode });
-    if (mode !== 'goto_forward') {
+    if (mode !== 'goto_forward' && mode !== 'mount_source') {
       params.set('threshold', threshold);
       if (action) params.set('action', action);
     }

--- a/indi_pifinder_bridge/pifinder_mount_bridge.cpp
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.cpp
@@ -112,6 +112,37 @@ bool isPiFinderSolveFresh(double maxAgeSeconds)
     const double ageSeconds = static_cast<double>(time(nullptr)) - lastSolveSuccess;
     return ageSeconds >= 0.0 && ageSeconds <= maxAgeSeconds;
 }
+
+// MODE_MOUNT_SOURCE (#130): pushes a one-time Fake-Solve seed to PiFinder's
+// /api/fake_solve, RA in degrees (PiFinder's API expects degrees, INDI
+// reports RA in hours - the caller is responsible for that conversion).
+// Returns false on any request failure.
+bool httpPostFakeSolve(const std::string &url, double raDeg, double decDeg)
+{
+    CURL *curl = curl_easy_init();
+    if (curl == nullptr)
+        return false;
+
+    const std::string body = "{\"ra\":" + std::to_string(raDeg) + ",\"dec\":" + std::to_string(decDeg) + "}";
+
+    struct curl_slist *headers = nullptr;
+    headers = curl_slist_append(headers, "Content-Type: application/json");
+
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, 1500L);
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+
+    const CURLcode res = curl_easy_perform(curl);
+    long httpCode = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpCode);
+
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+
+    return res == CURLE_OK && httpCode == 200;
+}
 } // namespace
 
 PiFinderMountBridge::PiFinderMountBridge()
@@ -145,7 +176,8 @@ bool PiFinderMountBridge::initProperties()
     IUFillSwitch(&BridgeModeS[MODE_VERIFY_ALERT], "MODE_VERIFY_ALERT", "Verify/Alert only", ISS_OFF);
     IUFillSwitch(&BridgeModeS[MODE_AUTO_CORRECT], "MODE_AUTO_CORRECT", "Auto-correct on drift", ISS_OFF);
     IUFillSwitch(&BridgeModeS[MODE_GOTO_FORWARD], "MODE_GOTO_FORWARD", "Goto-Forward", ISS_OFF);
-    IUFillSwitchVector(&BridgeModeSP, BridgeModeS, 4, getDeviceName(), "BRIDGE_MODE", "Coupling",
+    IUFillSwitch(&BridgeModeS[MODE_MOUNT_SOURCE], "MODE_MOUNT_SOURCE", "Mount is source", ISS_OFF);
+    IUFillSwitchVector(&BridgeModeSP, BridgeModeS, 5, getDeviceName(), "BRIDGE_MODE", "Coupling",
                        "Main Control", IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
 
     IUFillSwitch(&CorrectionActionS[ACTION_SYNC], "ACTION_SYNC", "Sync", ISS_ON);
@@ -268,6 +300,48 @@ void PiFinderMountBridge::syncMountTypeToPiFinder()
     }
 }
 
+// MODE_MOUNT_SOURCE (#130): the reverse of every other coupling mode - the
+// mount (real, or the stock INDI Telescope Simulator) is the position
+// source, PiFinder mirrors it via a Fake-Solve injection. Mirrors physical
+// reality: a real mount and a real PiFinder are rigidly coupled, so
+// wherever the mount points, PiFinder points too. Enables full simulation
+// with zero real PiFinder hardware - point/slew the mount (from its own
+// hand controller, SkySafari, KStars, any INDI client - the source doesn't
+// matter, INDI doesn't care who issued the GoTo) and a Fake-Mode PiFinder
+// instance follows.
+//
+// Only pushes on a meaningful change (MOUNT_SOURCE_MIN_CHANGE_ARCMIN), not
+// every tick - the mount's own tracking-rate jitter would otherwise
+// re-inject an essentially-unchanged position constantly, which is both
+// pointless HTTP traffic and would keep resetting PiFinder's
+// last_solve_success to "just now" forever.
+void PiFinderMountBridge::handleMountSource()
+{
+    double mountRA, mountDec;
+    if (!m_client->getMountRADE(mountRA, mountDec))
+        return;
+
+    if (!std::isnan(m_lastPushedMountRA))
+    {
+        const double changeArcmin = angularSeparationArcmin(mountRA, mountDec, m_lastPushedMountRA, m_lastPushedMountDec);
+        if (changeArcmin < MOUNT_SOURCE_MIN_CHANGE_ARCMIN)
+            return;
+    }
+
+    const double raDeg = mountRA * 15.0; // INDI reports RA in hours
+    if (httpPostFakeSolve("http://127.0.0.1/api/fake_solve", raDeg, mountDec) ||
+        httpPostFakeSolve("http://127.0.0.1:8080/api/fake_solve", raDeg, mountDec))
+    {
+        LOGF_INFO("Mount moved to RA %.4fh/DEC %.4f - pushed to PiFinder as Fake-Solve.", mountRA, mountDec);
+        m_lastPushedMountRA = mountRA;
+        m_lastPushedMountDec = mountDec;
+    }
+    else
+    {
+        LOG_ERROR("Failed to push mount position to PiFinder.");
+    }
+}
+
 void PiFinderMountBridge::TimerHit()
 {
     if (!isConnected())
@@ -284,6 +358,13 @@ void PiFinderMountBridge::TimerHit()
     if (BridgeModeS[MODE_GOTO_FORWARD].s == ISS_ON)
     {
         handleGotoForward();
+        SetTimer(getCurrentPollingPeriod());
+        return;
+    }
+
+    if (BridgeModeS[MODE_MOUNT_SOURCE].s == ISS_ON)
+    {
+        handleMountSource();
         SetTimer(getCurrentPollingPeriod());
         return;
     }
@@ -492,6 +573,14 @@ bool PiFinderMountBridge::ISNewSwitch(const char *dev, const char *name, ISState
             m_forwardState = ForwardState::IDLE;
             m_lastForwardedRA = std::nan("");
             m_lastForwardedDec = std::nan("");
+
+            // Same idea for Mount-Source (#130): re-entering it should
+            // always push a fresh baseline seed immediately, not wait for
+            // the mount to move by MOUNT_SOURCE_MIN_CHANGE_ARCMIN from
+            // whatever position happened to be recorded during a previous
+            // stint in this mode.
+            m_lastPushedMountRA = std::nan("");
+            m_lastPushedMountDec = std::nan("");
             return true;
         }
 

--- a/indi_pifinder_bridge/pifinder_mount_bridge.h
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.h
@@ -72,10 +72,16 @@ class PiFinderMountBridge : public INDI::DefaultDevice
         IText ActiveDeviceT[2] {};
         enum { ACTIVE_PIFINDER, ACTIVE_MOUNT };
 
-        // Coupling degree - see 00009 for the rationale of each stage
+        // Coupling degree - see 00009 for the rationale of each stage.
+        // MODE_MOUNT_SOURCE (see #130) reverses the usual direction: instead
+        // of PiFinder's solve driving the mount, the mount's own position
+        // (real or the stock INDI Telescope Simulator) is injected into
+        // PiFinder as a Fake-Solve - for testing/demoing without any real
+        // PiFinder hardware at all. One-time seeds only (see
+        // pushMountPositionToPiFinder()), not literally every tick.
         ISwitchVectorProperty BridgeModeSP;
-        ISwitch BridgeModeS[4];
-        enum { MODE_OFF, MODE_VERIFY_ALERT, MODE_AUTO_CORRECT, MODE_GOTO_FORWARD };
+        ISwitch BridgeModeS[5];
+        enum { MODE_OFF, MODE_VERIFY_ALERT, MODE_AUTO_CORRECT, MODE_GOTO_FORWARD, MODE_MOUNT_SOURCE };
 
         // AUTO_CORRECT sends Sync or Goto/Track - separate from the above so
         // the one-shot manual actions below can also pick either.
@@ -126,4 +132,16 @@ class PiFinderMountBridge : public INDI::DefaultDevice
         static constexpr int MAX_SETTLE_RETRIES = 3;
 
         void handleGotoForward();
+
+        // MODE_MOUNT_SOURCE: pushes the mount's current position to PiFinder
+        // as a Fake-Solve whenever it has moved meaningfully since the last
+        // push (not on every tick - that would just be needlessly noisy
+        // re-injection of an unchanged position). See #130.
+        void handleMountSource();
+        double m_lastPushedMountRA = std::nan("");
+        double m_lastPushedMountDec = std::nan("");
+
+        // Below this, a mount position change is considered noise/tracking
+        // jitter, not a deliberate slew worth re-seeding PiFinder over.
+        static constexpr double MOUNT_SOURCE_MIN_CHANGE_ARCMIN = 2.0;
 };


### PR DESCRIPTION
## Summary
- New 5th Coupling mode (`MODE_MOUNT_SOURCE`), reversing every other mode's direction: the mount's own position (real, or the stock INDI Telescope Simulator) is read and injected into PiFinder as an Injected Solve, instead of PiFinder's solve driving the mount.
- Mirrors physical reality (mount + PiFinder are rigidly coupled) and enables full simulation with zero real PiFinder hardware - point/slew the mount from any INDI client and a Fake-Mode PiFinder instance follows.
- Only pushes on a >= 2 arcmin change from the last pushed position (`MOUNT_SOURCE_MIN_CHANGE_ARCMIN`), not every tick.
- New Control Center "Simulation" Coupling group with a single "Mount is source" button, following the exact existing preset-button pattern. Connection-diagram arrows reversed for this mode (mount->PiFinder instead of PiFinder->mount).
- `help.html` gained a "Simulation group" section.

Existing Mount Bridge actions (Sync/Auto-correct/Goto-Forward) needed no changes - they already only read whatever PiFinder reports, agnostic to real vs. Injected Solve.

Closes #130 (as the concrete "mount-as-source" piece of that concept; the separate "(a) full simulation with animated stepwise injection" and "on-device/OLED integration" pieces remain explicitly out of scope, per the concept doc).

## Test plan
- [x] Builds cleanly.
- [x] Live-verified end-to-end: activated `MODE_MOUNT_SOURCE` against the real mount bridge + a real mount, confirmed PiFinder's `/api/status` picked up the mount's exact RA/Dec via Injected Solve. Reverted to Verify/Alert cleanly afterward.
- [ ] Not yet tested with the INDI Telescope Simulator specifically, or with actual mount motion while the mode is active (only a static-position injection was verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)