### PR TITLE
Fix #118: Control-Center-side auto-reconnect for stale PiFinder LX200 connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project are documented in this file. Format loosely 
 
 ## [Unreleased]
 
+### Added
+
+- Control Center: automatic recovery from #118's "PiFinder LX200" stale-connection bug. When
+  `pifinder.service` restarts (deploy, crash-recovery, manual restart), the already-open TCP
+  connection between the `LX200_PIFINDER` INDI driver and `pos_server.py` used to die silently -
+  `CONNECTION` stayed `On` and the driver kept serving its last-known RA/Dec forever, with nothing
+  surfacing the failure. A new background watchdog in `gui_installer/server.py`
+  (`_pifinder_lx200_reconnect_watchdog()`) now detects the service restart (via
+  `pifinder.service`'s own `ActiveEnterTimestampMonotonic`) and forces a fresh reconnect - the same
+  fix already confirmed by hand via `indi_setprop`, now automatic and independent of whether the
+  Control Center's web page is even open. Runs for the Control Center's whole lifetime, retrying
+  every ~20s until PiFinder itself has finished restarting. An in-driver alternative (fixing this at
+  the `LX200_PIFINDER` driver level directly) was attempted and found not to self-heal live; that
+  approach is tracked separately for future investigation (#139).
+
 ## [1.4.0] - 2026-08-02
 
 ### Added

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -831,6 +831,127 @@ def _mb_log(line: str):
         _mb_lines.append(f"{time.strftime('%H:%M:%S')} {line}")
 
 
+# #118: pos_server.py restarting (PiFinder service restart/crash-recovery/
+# redeploy) silently breaks "PiFinder LX200"'s already-open TCP connection -
+# CONNECTION stays On but ReadScopeStatus() keeps serving the frozen
+# pre-restart RA/Dec forever, with nothing surfacing the failure. An
+# in-driver fix was attempted and confirmed NOT to self-heal live (see
+# #139, which tracks that alternative separately); this is the approved
+# Control-Center-side fix instead: detect the restart from here and redo
+# the same disconnect/connect cycle already confirmed live by hand via
+# indi_setprop (#118's documented workaround).
+_pifinder_lx200_healed_for_start = None  # pifinder.service start time we last confirmed LX200 connected against
+_pifinder_lx200_reconnect_in_flight = False
+
+
+def _pifinder_service_start_monotonic():
+    """pifinder.service's ActiveEnterTimestampMonotonic (microseconds since
+    boot), or None if the service isn't running / systemctl can't answer.
+    Monotonic rather than the wall-clock timestamp - a plain integer,
+    always comparable, and immune to wall-clock/timezone parsing edge
+    cases; changes exactly once per service (re)start, which is all that's
+    needed here."""
+    try:
+        result = subprocess.run(
+            ["systemctl", "show", "pifinder.service", "--property=ActiveEnterTimestampMonotonic", "--value"],
+            capture_output=True, text=True, timeout=5,
+        )
+        return int(result.stdout.strip())
+    except (subprocess.TimeoutExpired, ValueError, OSError):
+        return None
+
+
+def _pifinder_lx200_auto_reconnect(status: dict) -> None:
+    """Called every _pifinder_lx200_reconnect_watchdog() tick: whenever
+    pifinder.service's own start time has moved on since we last confirmed
+    "PiFinder LX200" freshly connected, force a reconnect to redo the TCP
+    handshake. Deliberately keeps retrying every tick - not just once -
+    until a fresh connect is actually confirmed: found live (2026-08-03)
+    that pos_server.py isn't necessarily listening again the moment
+    pifinder.service's own start time changes (PiFinder itself can still be
+    mid-startup for camera/IMU init), so a single disconnect+connect attempt
+    right after detecting the restart can itself fail and leave the driver
+    *honestly* disconnected - gating retries on "still looks connected"
+    would then never retry again. Once _pifinder_lx200_healed_for_start
+    catches up to the current start time, this goes quiet again; only a
+    genuinely new restart (a further-advanced start time) reawakens it.
+    Runs the actual attempt in a background thread so a detected restart
+    never blocks the watchdog loop; the in-flight guard means a still-
+    pending attempt is left alone rather than stacking a second one."""
+    global _pifinder_lx200_healed_for_start, _pifinder_lx200_reconnect_in_flight
+    if status.get("active_pifinder") != "PiFinder LX200":
+        return
+    current_start = _pifinder_service_start_monotonic()
+    if current_start is None:
+        return
+    if _pifinder_lx200_healed_for_start is None:
+        # First observation since this Control Center process started -
+        # assume whatever's currently connected is already healthy rather
+        # than forcing a reconnect for no reason on every restart of the
+        # Control Center itself.
+        _pifinder_lx200_healed_for_start = current_start
+        return
+    if current_start == _pifinder_lx200_healed_for_start:
+        return
+    if _pifinder_lx200_reconnect_in_flight:
+        return
+    _pifinder_lx200_reconnect_in_flight = True
+    was_connected = status.get("pifinder_connected") is True
+    _mb_log(
+        f"pifinder.service restarted (monotonic start {_pifinder_lx200_healed_for_start} -> "
+        f"{current_start}) - PiFinder LX200 {'still showed connected' if was_connected else 'not connected yet'}, "
+        "attempting reconnect (#118)"
+    )
+
+    def _do_reconnect(start_seen, was_connected):
+        global _pifinder_lx200_healed_for_start, _pifinder_lx200_reconnect_in_flight
+        try:
+            if was_connected:
+                # Frozen-stale case: CONNECTION was already On, so DISCONNECT
+                # first (mirrors the manual indi_setprop workaround from #118).
+                indi_client.disconnect_device("PiFinder LX200")
+                time.sleep(1.0)
+            indi_client.connect_device("PiFinder LX200")
+            time.sleep(1.0)
+            fresh = indi_client.get_properties(device="PiFinder LX200").get("PiFinder LX200", {})
+            now_connected = fresh.get("CONNECTION", {}).get("elements", {}).get("CONNECT") == "On"
+            if now_connected:
+                _pifinder_lx200_healed_for_start = start_seen
+                _mb_log("PiFinder LX200 auto-reconnect after pifinder.service restart succeeded")
+            else:
+                _mb_log(
+                    "PiFinder LX200 auto-reconnect attempt did not take yet "
+                    "(pos_server.py likely still starting) - will retry"
+                )
+        except indi_client.INDIClientError as e:
+            _mb_log(f"PiFinder LX200 auto-reconnect after pifinder.service restart failed: {e}")
+        finally:
+            _pifinder_lx200_reconnect_in_flight = False
+
+    threading.Thread(target=_do_reconnect, args=(current_start, was_connected), daemon=True).start()
+
+
+def _pifinder_lx200_reconnect_watchdog(interval=20):
+    """Runs for the Control Center's whole lifetime, independent of whether
+    anyone has this web page open - #118's staleness bites just as easily
+    during a KStars/Ekos-only session that never touches this GUI. Started
+    once from main() as a daemon thread. Same 20s cadence as the frontend's
+    own /api/mount_bridge_status poll (not tied to it - see that handler's
+    own comment for why device_timeout is kept short by default here)."""
+    while True:
+        time.sleep(interval)
+        try:
+            status = indi_client.mount_bridge_status()
+        except indi_client.INDIClientError:
+            continue
+        if not status.get("running"):
+            continue
+        try:
+            _pifinder_lx200_auto_reconnect(status)
+        except Exception as e:  # a watchdog thread must never die silently
+            _mb_log(f"auto-reconnect watchdog raised unexpectedly: {e}")
+
+
 def _run_hardware_test():
     """Runs all three checks in sequence and stores the combined result.
     Camera/IMU/GPS are deliberately sequential, not parallel: the camera
@@ -2510,6 +2631,10 @@ def main():
     # needed here: nothing else can possibly be running yet this early.
     _hwtest_running = True
     threading.Thread(target=_startup_hardware_test, daemon=True).start()
+    # #118: auto-heal "PiFinder LX200"'s silent stale-connection bug after a
+    # pifinder.service restart - see _pifinder_lx200_reconnect_watchdog()'s
+    # own docstring.
+    threading.Thread(target=_pifinder_lx200_reconnect_watchdog, daemon=True).start()
     _server.serve_forever()
 
 


### PR DESCRIPTION
## Summary

- Fixes #118 (PiFinder LX200 INDI driver silently going stale after a `pifinder.service` restart) via a Control-Center-side automated reconnect, rather than an in-driver fix.
- Adds `_pifinder_lx200_reconnect_watchdog()` to `gui_installer/server.py`: a daemon thread, started once in `main()`, that runs for the Control Center's whole lifetime and polls `indi_client.mount_bridge_status()` every 20s.
- `_pifinder_lx200_auto_reconnect()` compares `pifinder.service`'s own `ActiveEnterTimestampMonotonic` against the last value we confirmed "PiFinder LX200" freshly connected against; on a mismatch it forces a disconnect (if needed)+connect cycle via the existing `indi_client.connect_device()`/`disconnect_device()`, and keeps retrying every tick until a fresh connection is actually confirmed (not just attempted once) - needed because PiFinder itself can take anywhere from ~25s to several minutes to fully restart (camera/IMU re-init), so a single attempt right after detecting the restart can itself fail if `pos_server.py` isn't listening yet.
- An in-driver alternative (detecting the dead connection inside `LX200_PIFINDER::ReadScopeStatus()` itself and calling `Disconnect()`/`Connect()`) was attempted first (branch `fix/118-lx200-reconnect`, commit `abb80c2`) and confirmed live NOT to self-heal (driver stayed frozen 35+s with zero established TCP connections). That branch was not merged; the analysis of what would be needed to make the in-driver approach work is tracked separately in #139 for later.
- CHANGELOG entry added under `[Unreleased]`.

## Test plan

- [x] Live-verified: baseline healthy connection (`CONNECT=On`, established TCP to :4030, live RA/Dec matching PiFinder).
- [x] Triggered `sudo systemctl restart pifinder.service` - driver correctly went stale (`CONNECT=On`, zero established TCP connections - the classic #118 symptom reproduced).
- [x] Watchdog detected the restart, issued disconnect+connect - confirmed via a fresh local TCP port to :4030 once `pos_server.py` came back up (PiFinder's own restart took ~6 minutes this run), with **no manual intervention**.
- [x] Confirmed the watchdog correctly retries every ~20s rather than giving up after one failed attempt (this run's unusually long PiFinder restart time exercised that retry path directly).
- [ ] Not yet tested: a second/rapid consecutive `pifinder.service` restart while a reconnect attempt is still in flight (the in-flight guard should prevent stacking, not yet exercised live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)