### PR TITLE
Revert accidentally-merged #139 driver commit from dev

### DIFF
--- a/indi_pifinder/lx200_pifinder.cpp
+++ b/indi_pifinder/lx200_pifinder.cpp
@@ -187,7 +187,7 @@ bool LX200_PIFINDER::ReadScopeStatus()
     if (setStandardProcedureAndReturnResponse(fd, "#:GR#", ra_response, sizeof(ra_response)) != 0)
     {
         LOG_ERROR("Failed to get RA from PiFinder.");
-        return handleReadFailure();
+        return false;
     }
     // Parse RA (HH:MM:SS)
     if (f_scansexa(ra_response, &ra_val) == -1)
@@ -200,7 +200,7 @@ bool LX200_PIFINDER::ReadScopeStatus()
     if (setStandardProcedureAndReturnResponse(fd, "#:GD#", dec_response, sizeof(dec_response)) != 0)
     {
         LOG_ERROR("Failed to get Dec from PiFinder.");
-        return handleReadFailure();
+        return false;
     }
     // Parse Dec (+/-DD*MM'SS)
     if (f_scansexa(dec_response, &dec_val) == -1)
@@ -217,44 +217,7 @@ bool LX200_PIFINDER::ReadScopeStatus()
     // For now, assume a default pier side or infer from RA/Dec if possible.
     setPierSide(INDI::Telescope::PIER_EAST); // Default to East for now
 
-    m_consecutiveReadFailures = 0;
     return true;
-}
-
-// #118/#139: see the header's own comment for the full root-cause writeup.
-// Calling the raw Connect()/Disconnect() virtuals alone does NOT work -
-// Connect() early-returns true if isConnected() is still (wrongly) true,
-// and only setConnected() (normally only called by the CONNECTION property
-// handler) ever flips that flag. This replicates that handler's exact
-// sequence instead.
-bool LX200_PIFINDER::handleReadFailure()
-{
-    ++m_consecutiveReadFailures;
-    if (m_consecutiveReadFailures < MAX_CONSECUTIVE_READ_FAILURES)
-        return false;
-
-    LOGF_WARN("%d consecutive read failures - forcing a reconnect.", m_consecutiveReadFailures);
-    m_consecutiveReadFailures = 0;
-
-    if (Disconnect())
-    {
-        setConnected(false, IPS_IDLE);
-        updateProperties();
-    }
-
-    if (Connect())
-    {
-        setConnected(true);
-        updateProperties();
-        LOG_INFO("Reconnect succeeded.");
-    }
-    else
-    {
-        setConnected(false, IPS_ALERT);
-        LOG_WARN("Reconnect attempt failed - will retry after the next read failure streak.");
-    }
-
-    return false;
 }
 
 // PiFinder has no motor: "Goto" reuses PiFinder's existing SkySafari push-to

--- a/indi_pifinder/lx200_pifinder.h
+++ b/indi_pifinder/lx200_pifinder.h
@@ -49,20 +49,4 @@ class LX200_PIFINDER : public LX200Telescope
         int setStandardProcedureWithoutRead(int fd, const char *data);
         int setStandardProcedureAndExpectChar(int fd, const char *data, const char *expect);
         int setStandardProcedureAndReturnResponse(int fd, const char *data, char *response, int max_response_length);
-
-        // #118/#139: a dead TCP connection (e.g. pos_server.py restarting
-        // under us) previously went undetected forever - ReadScopeStatus()
-        // kept returning false every tick with no visible consequence, while
-        // CONNECTION stayed On and the last successfully-read RA/Dec sat
-        // frozen, silently lying about being live. After this many
-        // consecutive read failures, force a full reconnect through the same
-        // setConnected()/updateProperties() sequence the CONNECTION property
-        // handler itself uses (see #139's analysis: calling the raw
-        // Connect()/Disconnect() virtuals alone does NOT work - Connect()
-        // early-returns true if isConnected() is still (wrongly) true, and
-        // only setConnected() - which only the property handler normally
-        // calls - ever flips that flag).
-        int m_consecutiveReadFailures = 0;
-        static constexpr int MAX_CONSECUTIVE_READ_FAILURES = 3;
-        bool handleReadFailure();
 };


### PR DESCRIPTION
## Summary

- PR #146 (README wordmark footer + disclaimer) was accidentally branched from `fix/139-lx200-indriver-reconnect` instead of `dev` - a preceding `git checkout dev` had silently failed (uncommitted changes at the time), and the following `git checkout -b docs/wortmarke-footer-disclaimer` created the new branch from whatever was currently checked out instead, without that being noticed.
- This brought commit `5951b9e` ("Fix #139: corrected in-driver LX200 reconnect after connection loss") into `dev`'s history - the **first, since-superseded** attempt at #139's in-driver fix, which live testing confirmed has a real bug (permanent stall after one failed reconnect attempt). It was never meant to reach `dev` - #139 remains unresolved and unmerged on its own branch.
- This PR reverts that one commit. Verified the reverted `indi_pifinder/lx200_pifinder.cpp`/`.h` are byte-identical to the pre-#139 baseline (diffed against the last known-good commit, and confirmed the rebuilt binary's md5sum matches exactly).
- Nothing else from PR #146 (the actual README footer changes) is touched - those commits didn't modify these files, so the revert applied with zero conflicts.

## Test plan

- [x] Diffed reverted files against pre-#139 baseline commit - byte-identical.
- [x] Rebuilt and confirmed the binary's md5sum matches the known-good baseline exactly.
- [x] `dev`'s live-deployed driver was already manually restored to this same clean state during troubleshooting, ahead of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)