### PR TITLE
Network resilience / CPU-load handling batch (found investigating #139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,12 @@ All notable changes to this project are documented in this file. Format loosely 
 - `pifinder.service` now runs with `Nice=5`/`CPUWeight=50` - a coarse, PFSM-side mitigation for the
   same finding (favors the Control Center/`indiserver`/the OS itself under CPU contention, without
   capping PiFinder below full-core use whenever the CPU isn't actually contended). The more precise
-  fix (capping/renicing PiFinder's own solver worker pool) is tracked upstream in #148.
+  fix (capping/renicing PiFinder's own solver worker pool) is tracked upstream in #148. Applied
+  everywhere `pifinder.service` gets (re)started - the setup script's own Update flow now
+  `restart`s rather than `start`s an already-running instance, the Control Center's direct service
+  button and the Real/Fake Mode toggle both `daemon-reload` first, and the Control Center logs a
+  one-time note at its own startup if the currently-running process's priority doesn't match what's
+  actually configured (never auto-restarts on its own).
 - `indi_pifinder`: the LX200 driver now enables TCP keepalive on its connection to `pos_server.py`
   (a truly-dead peer is now detected within ~11s instead of relying only on read()/write() to
   eventually notice) and retries a slow (not dead) `:GR#`/`:GD#` read up to 3 times at a shorter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,11 @@ All notable changes to this project are documented in this file. Format loosely 
   Control Center's web page is even open. Runs for the Control Center's whole lifetime, retrying
   every ~20s until PiFinder itself has finished restarting. An in-driver alternative (fixing this at
   the `LX200_PIFINDER` driver level directly) was attempted and found not to self-heal live; that
-  approach is tracked separately for future investigation (#139).
+  approach was closed as wontfix (#139) - from inside the driver there's no reliable way to tell
+  "connection genuinely dead" apart from "Pi is just CPU-busy" (routine on this project's actual
+  target hardware, not an edge case), so an in-driver reconnect would risk disrupting healthy
+  connections during normal use. This Control-Center-side watchdog already covers the real-world
+  case without that false-positive risk.
 - Control Center: the project's own logo (`docs/images/logo/PiFinder-Stellarmate_Wortmarke_Negativ_fuer-dunklen-hg.png`)
   now appears in the page footer alongside the existing HeyApos/AVVP logos, at the same height.
 - Control Center: a new system load indicator (green "Normal"/red "High", next to the existing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project are documented in this file. Format loosely 
 
 ## [Unreleased]
 
+### Added
+
 - Control Center: automatic recovery from #118's "PiFinder LX200" stale-connection bug. When
   `pifinder.service` restarts (deploy, crash-recovery, manual restart), the already-open TCP
   connection between the `LX200_PIFINDER` INDI driver and `pos_server.py` used to die silently -
@@ -19,8 +21,26 @@ All notable changes to this project are documented in this file. Format loosely 
   approach is tracked separately for future investigation (#139).
 - Control Center: the project's own logo (`docs/images/logo/PiFinder-Stellarmate_Wortmarke_Negativ_fuer-dunklen-hg.png`)
   now appears in the page footer alongside the existing HeyApos/AVVP logos, at the same height.
+- Control Center: a new system load indicator (green "Normal"/red "High", next to the existing
+  PiFinder-reachability row in Quick Links) - found live investigating #139 that a contended Pi
+  (PiFinder's own solver worker pool, KStars, ...) can make `pos_server.py`'s LX200 socket genuinely
+  unresponsive for several seconds without anything being actually broken; this at least makes that
+  a visible, explained condition instead of unexplained slowness elsewhere on the page.
+- `pifinder.service` now runs with `Nice=5`/`CPUWeight=50` - a coarse, PFSM-side mitigation for the
+  same finding (favors the Control Center/`indiserver`/the OS itself under CPU contention, without
+  capping PiFinder below full-core use whenever the CPU isn't actually contended). The more precise
+  fix (capping/renicing PiFinder's own solver worker pool) is tracked upstream in #148.
+- `indi_pifinder`: the LX200 driver now enables TCP keepalive on its connection to `pos_server.py`
+  (a truly-dead peer is now detected within ~11s instead of relying only on read()/write() to
+  eventually notice) and retries a slow (not dead) `:GR#`/`:GD#` read up to 3 times at a shorter
+  2s timeout each, instead of blocking the whole polling cycle for one 5s attempt.
 
 ### Changed
+
+- Timeout values used for the various background INDI polls (`gui_installer/indi_client.py`) are
+  now named tiers (`TIMEOUT_BACKGROUND_POLL`, `TIMEOUT_FAST_POLL`, `TIMEOUT_QUICK_RETRY`, ...)
+  instead of bare literals scattered across `server.py`/`indi_client.py` - no behavior change, just
+  one shared place to see why a given call is timed the way it is.
 
 - README.md/README_de.md's hero photo (`docs/images/readme/PiFinder.jpg`/`PiFinder_thumb.jpg`) replaced with a new
   real-world photo (with the project's wordmark composited in), converted from the uploaded PNG at

--- a/bin/functions.sh
+++ b/bin/functions.sh
@@ -12,6 +12,20 @@ kstarsrc_source="${pifinder_config_dir}/kstarsrc"
 kstarsrc_target="${pifinder_config_dir}/kstarsrc"
 indi_pifinder_dir="${pifinder_stellarmate_dir}/indi_pifinder"
 
+#####################################
+# pifinder.service scheduling priority
+#####################################
+# Nice=/CPUWeight= live directly in pi_config_files/pifinder.service - not
+# duplicated as a variable here. Deliberately: nothing else needs to KNOW
+# the actual number - the Control Center's own staleness check
+# (_pifinder_service_settings_stale() in gui_installer/server.py) compares
+# the unit's currently-*configured* value against the *actually-running*
+# process's real priority, so it keeps working correctly no matter what
+# that number is changed to in the future, without a second copy to keep
+# in sync. Change the number in pi_config_files/pifinder.service itself if
+# it ever needs tuning (found live 2026-08-03 investigating #139 - see that
+# file's own comment for the underlying finding).
+
 
 
 # The files need to be patched for Pi4

--- a/gui_installer/indi_client.py
+++ b/gui_installer/indi_client.py
@@ -34,7 +34,22 @@ from xml.sax.saxutils import escape as _xml_escape
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 7624
-DEFAULT_TIMEOUT = 3.0
+
+# Named timeout tiers, consolidated here instead of scattered ad hoc literals
+# across server.py/indi_client.py (each value already existed somewhere before
+# this - this only gives them one shared name and place, not new numbers).
+# Pick the tier that matches *why* a call is timed the way it is, not just
+# "whatever number happened to work":
+DEFAULT_TIMEOUT = 3.0        # interactive: a user just clicked something and is watching for a result
+TIMEOUT_BACKGROUND_POLL = 7.0        # passive, periodic UI polling - indiserver occasionally answers slowly
+                                      # under load, and flapping the UI over that is worse than a slow number
+                                      # (see /api/mount_bridge_status's own long-standing comment)
+DEVICE_TIMEOUT_BACKGROUND_POLL = 3.0  # the extra per-device lookups nested inside that same background poll
+TIMEOUT_FAST_POLL = 2.0        # tight-cadence, best-effort readouts where a single miss just skips one
+                                # update (e.g. mount_bridge_drift()) - never gates a button's enabled state
+TIMEOUT_QUICK_RETRY = 1.0      # short-lived polling loop with its own retry/backoff already built around it
+                                # (e.g. waiting for a just-restarted driver to answer) - a slow individual
+                                # attempt should fail fast so the loop can just try again
 
 _VECTOR_TAGS = {
     "defTextVector": "text",
@@ -294,7 +309,7 @@ def mount_bridge_status(
 def mount_bridge_drift(
     host: str = DEFAULT_HOST,
     port: int = DEFAULT_PORT,
-    timeout: float = 2.0,
+    timeout: float = TIMEOUT_FAST_POLL,
 ) -> dict:
     """
     Lightweight companion to mount_bridge_status(): only "PiFinder Mount

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -948,6 +948,46 @@ def _system_load_status() -> dict:
     }
 
 
+def _pifinder_service_settings_stale():
+    """True if pifinder.service's actually-running process's scheduling
+    priority doesn't match what's currently configured for the unit -
+    meaning it was started before the config last changed (e.g. an Update
+    run that left an already-running instance untouched before
+    pifinder_stellarmate_setup.sh's own start->restart fix - see that
+    change's own comment) and needs a restart to pick up the current
+    settings. Compares against the unit's OWN currently-loaded value
+    rather than a hardcoded expected number, so this keeps working no
+    matter what Nice= (or any future scheduling directive) is actually set
+    to - nothing here needs to know the number itself.
+    Returns None if pifinder.service isn't running or the check itself
+    failed (nothing to report, not a mismatch)."""
+    try:
+        shown = subprocess.run(
+            ["systemctl", "show", "pifinder.service", "--property=Nice,MainPID"],
+            capture_output=True, text=True, timeout=5,
+        ).stdout
+        # Deliberately NOT --value with a comma-separated property list -
+        # found live: systemctl does not guarantee returning --value output
+        # in the order the properties were requested in, so a positional
+        # unpack silently paired the wrong values together. Self-labeled
+        # "Key=Value" lines (systemctl's default format) sidestep that
+        # entirely regardless of what order they come back in.
+        values = dict(line.split("=", 1) for line in shown.strip().splitlines() if "=" in line)
+        configured_nice = values.get("Nice")
+        main_pid = values.get("MainPID")
+        if configured_nice is None or main_pid is None or int(main_pid) <= 0:
+            return None
+        actual_nice = subprocess.run(
+            ["ps", "-o", "ni=", "-p", main_pid],
+            capture_output=True, text=True, timeout=5,
+        ).stdout.strip()
+        if not actual_nice:
+            return None
+        return int(actual_nice) != int(configured_nice)
+    except (subprocess.TimeoutExpired, OSError, ValueError):
+        return None
+
+
 # #118: pos_server.py restarting (PiFinder service restart/crash-recovery/
 # redeploy) silently breaks "PiFinder LX200"'s already-open TCP connection -
 # CONNECTION stays On but ReadScopeStatus() keeps serving the frozen
@@ -2248,6 +2288,16 @@ class Handler(BaseHTTPRequestHandler):
                     )
                     return
             try:
+                # daemon-reload first: systemd caches a unit's parsed config
+                # in memory and does NOT re-read a changed file on disk on
+                # its own before start/restart (only warns "Unit file
+                # changed on disk" in its log) - without this, a button
+                # click right after an update could restart the OLD,
+                # already-loaded config instead of whatever's actually in
+                # /etc/systemd/system/pifinder.service right now (found live
+                # investigating #139's Nice=/CPUWeight= rollout - see that
+                # change's own commit for the underlying finding).
+                subprocess.run(["sudo", "systemctl", "daemon-reload"], capture_output=True, text=True, timeout=10)
                 result = subprocess.run(
                     ["sudo", "systemctl", action, "pifinder.service"],
                     capture_output=True, text=True, timeout=30,
@@ -2760,6 +2810,19 @@ def main():
     # pifinder.service restart - see _pifinder_lx200_reconnect_watchdog()'s
     # own docstring.
     threading.Thread(target=_pifinder_lx200_reconnect_watchdog, daemon=True).start()
+    # One-time check, not a watchdog: an already-running pifinder.service
+    # left over from before this Control Center's own start (e.g. surviving
+    # an Update run from before the setup script's start->restart fix, or a
+    # manual `systemctl start` from outside this GUI) won't self-correct on
+    # its own - just log it once so it's visible instead of silently stale.
+    # Deliberately not auto-restarted: this only reports, it never
+    # interrupts a possibly-active observing session on its own initiative.
+    if _pifinder_service_settings_stale():
+        _mb_log(
+            "pifinder.service is running with a stale scheduling priority (doesn't match the "
+            "currently configured Nice=/CPUWeight=) - restart it (Mode tile or the Control Center "
+            "itself) to apply the current settings."
+        )
     _server.serve_forever()
 
 

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -880,6 +880,48 @@ def _mb_log(line: str):
         _mb_lines.append(f"{time.strftime('%H:%M:%S')} {line}")
 
 
+class _BackgroundRetrier:
+    """Fire-and-forget 'run this in a background thread, but never run two
+    attempts at once' helper - extracted from #118's original hand-rolled
+    in-flight-flag + threading.Thread pattern so a future feature needing
+    the same shape ("keep retrying an action from a polling loop without
+    stacking concurrent attempts") can reuse it instead of reimplementing
+    the guard by hand. Deliberately minimal: it does not schedule its own
+    retries - the caller's own polling loop (e.g. a watchdog's `while True:
+    time.sleep(interval)`) is what re-triggers a fresh attempt each tick;
+    this only guards against overlapping ones."""
+
+    def __init__(self):
+        self._in_flight = False
+        self._lock = threading.Lock()
+
+    @property
+    def in_flight(self) -> bool:
+        return self._in_flight
+
+    def trigger(self, action_fn) -> bool:
+        """Starts action_fn() in a background daemon thread unless an
+        earlier call's thread is still running. Returns True if a new
+        attempt was started, False if one was already in flight (the
+        caller's own next polling tick will just call trigger() again).
+        action_fn takes no arguments; any exception it raises is swallowed
+        (log inside action_fn if you want to know about failures)."""
+        with self._lock:
+            if self._in_flight:
+                return False
+            self._in_flight = True
+
+        def _run():
+            try:
+                action_fn()
+            finally:
+                with self._lock:
+                    self._in_flight = False
+
+        threading.Thread(target=_run, daemon=True).start()
+        return True
+
+
 # #118: pos_server.py restarting (PiFinder service restart/crash-recovery/
 # redeploy) silently breaks "PiFinder LX200"'s already-open TCP connection -
 # CONNECTION stays On but ReadScopeStatus() keeps serving the frozen
@@ -890,7 +932,7 @@ def _mb_log(line: str):
 # the same disconnect/connect cycle already confirmed live by hand via
 # indi_setprop (#118's documented workaround).
 _pifinder_lx200_healed_for_start = None  # pifinder.service start time we last confirmed LX200 connected against
-_pifinder_lx200_reconnect_in_flight = False
+_pifinder_lx200_reconnect_retrier = _BackgroundRetrier()
 
 
 def _pifinder_service_start_monotonic():
@@ -924,10 +966,11 @@ def _pifinder_lx200_auto_reconnect(status: dict) -> None:
     would then never retry again. Once _pifinder_lx200_healed_for_start
     catches up to the current start time, this goes quiet again; only a
     genuinely new restart (a further-advanced start time) reawakens it.
-    Runs the actual attempt in a background thread so a detected restart
-    never blocks the watchdog loop; the in-flight guard means a still-
-    pending attempt is left alone rather than stacking a second one."""
-    global _pifinder_lx200_healed_for_start, _pifinder_lx200_reconnect_in_flight
+    Runs the actual attempt in a background thread (via _BackgroundRetrier)
+    so a detected restart never blocks the watchdog loop; its in-flight
+    guard means a still-pending attempt is left alone rather than stacking
+    a second one."""
+    global _pifinder_lx200_healed_for_start
     if status.get("active_pifinder") != "PiFinder LX200":
         return
     current_start = _pifinder_service_start_monotonic()
@@ -942,18 +985,10 @@ def _pifinder_lx200_auto_reconnect(status: dict) -> None:
         return
     if current_start == _pifinder_lx200_healed_for_start:
         return
-    if _pifinder_lx200_reconnect_in_flight:
-        return
-    _pifinder_lx200_reconnect_in_flight = True
     was_connected = status.get("pifinder_connected") is True
-    _mb_log(
-        f"pifinder.service restarted (monotonic start {_pifinder_lx200_healed_for_start} -> "
-        f"{current_start}) - PiFinder LX200 {'still showed connected' if was_connected else 'not connected yet'}, "
-        "attempting reconnect (#118)"
-    )
 
-    def _do_reconnect(start_seen, was_connected):
-        global _pifinder_lx200_healed_for_start, _pifinder_lx200_reconnect_in_flight
+    def _do_reconnect():
+        global _pifinder_lx200_healed_for_start
         try:
             if was_connected:
                 # Frozen-stale case: CONNECTION was already On, so DISCONNECT
@@ -965,7 +1000,7 @@ def _pifinder_lx200_auto_reconnect(status: dict) -> None:
             fresh = indi_client.get_properties(device="PiFinder LX200").get("PiFinder LX200", {})
             now_connected = fresh.get("CONNECTION", {}).get("elements", {}).get("CONNECT") == "On"
             if now_connected:
-                _pifinder_lx200_healed_for_start = start_seen
+                _pifinder_lx200_healed_for_start = current_start
                 _mb_log("PiFinder LX200 auto-reconnect after pifinder.service restart succeeded")
             else:
                 _mb_log(
@@ -974,10 +1009,14 @@ def _pifinder_lx200_auto_reconnect(status: dict) -> None:
                 )
         except indi_client.INDIClientError as e:
             _mb_log(f"PiFinder LX200 auto-reconnect after pifinder.service restart failed: {e}")
-        finally:
-            _pifinder_lx200_reconnect_in_flight = False
 
-    threading.Thread(target=_do_reconnect, args=(current_start, was_connected), daemon=True).start()
+    started = _pifinder_lx200_reconnect_retrier.trigger(_do_reconnect)
+    if started:
+        _mb_log(
+            f"pifinder.service restarted (monotonic start {_pifinder_lx200_healed_for_start} -> "
+            f"{current_start}) - PiFinder LX200 {'still showed connected' if was_connected else 'not connected yet'}, "
+            "attempting reconnect (#118)"
+        )
 
 
 def _pifinder_lx200_reconnect_watchdog(interval=20):

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -922,6 +922,32 @@ class _BackgroundRetrier:
         return True
 
 
+# Found live investigating #139: a 4-core Pi 4 at or above this 1-minute-
+# load-average-per-core ratio was observed making PiFinder's own position
+# server (pos_server.py) genuinely unresponsive to LX200 queries for several
+# seconds at a time - not a bug anywhere, just a busy CPU. Deliberately
+# coarse: a signal for a human to notice, not a claim that anything is
+# actually broken (see /api/system_load and #139's own writeup).
+_SYSTEM_LOAD_HIGH_RATIO = 1.5
+
+
+def _system_load_status() -> dict:
+    """CPU load average (1/5/15 min, from os.getloadavg()) relative to core
+    count. "high" only means "worth a human glancing at" - see
+    _SYSTEM_LOAD_HIGH_RATIO's own comment."""
+    load1, load5, load15 = os.getloadavg()
+    cpu_count = os.cpu_count() or 1
+    ratio1 = load1 / cpu_count
+    return {
+        "load1": round(load1, 2),
+        "load5": round(load5, 2),
+        "load15": round(load15, 2),
+        "cpu_count": cpu_count,
+        "ratio1": round(ratio1, 2),
+        "high": ratio1 >= _SYSTEM_LOAD_HIGH_RATIO,
+    }
+
+
 # #118: pos_server.py restarting (PiFinder service restart/crash-recovery/
 # redeploy) silently breaks "PiFinder LX200"'s already-open TCP connection -
 # CONNECTION stays On but ReadScopeStatus() keeps serving the frozen
@@ -1792,6 +1818,10 @@ class Handler(BaseHTTPRequestHandler):
                     "uninstall_running": uninstall_running,
                 }
             )
+            return
+
+        if parsed.path == "/api/system_load":
+            self._send_json(_system_load_status())
             return
 
         if parsed.path == "/api/pifinder_mode":

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -1812,7 +1812,10 @@ class Handler(BaseHTTPRequestHandler):
                 # correcting the mount at the same moment this poll came back
                 # empty). Not a real disconnect, just this poll's own
                 # patience being too short for an otherwise-healthy system.
-                status = indi_client.mount_bridge_status(timeout=7.0, device_timeout=3.0)
+                status = indi_client.mount_bridge_status(
+                    timeout=indi_client.TIMEOUT_BACKGROUND_POLL,
+                    device_timeout=indi_client.DEVICE_TIMEOUT_BACKGROUND_POLL,
+                )
             except indi_client.INDIClientError as e:
                 status = {"running": False, "error": str(e)}
                 _mb_log(f"status check failed: {e}")
@@ -2519,7 +2522,7 @@ class Handler(BaseHTTPRequestHandler):
                 # of a flat sleep.
                 deadline = time.monotonic() + 5.0
                 while time.monotonic() < deadline:
-                    if indi_client.get_properties(device=device, timeout=1.0).get(device):
+                    if indi_client.get_properties(device=device, timeout=indi_client.TIMEOUT_QUICK_RETRY).get(device):
                         break
                     time.sleep(0.3)
                 _mb_log(f"  restarted. retrying...")

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -892,6 +892,7 @@
       <div id="quick-links-tile">
         <h3 class="tile-heading" title="Direct links to PiFinder's own remote page, its INDI/mount setup wizard, and this Control Center - plus the project's documentation.">Quick Links<a class="help-link" href="/help.html#quick-links" target="_blank" rel="noopener" title="Help">i</a></h3>
         <div id="pifinder-status-line" title="Reflects the web server/OLED mirror answering - PiFinder can be &quot;running&quot; on the software side even with hardware missing (see PiFinder Mode, Test and Power below)."><span class="status-dot dot-white" id="pifinder-status-dot"></span><span id="pifinder-status-text">PiFinder not detected yet</span></div>
+        <div id="system-load-line" title="CPU load average relative to core count - not an error, just a heads-up: a genuinely busy Pi can make PiFinder's own position server briefly slow to answer (see the LX200/Mount Bridge docs for details)."><span class="status-dot dot-white" id="system-load-dot"></span><span id="system-load-text">Checking system load…</span></div>
         <div class="collapsible-toggle" onclick="toggleCollapsibleSection('ql-links', 'ql-links-chevron')">
           <span>Links</span>
           <span id="ql-links-chevron">&#9660; show</span>
@@ -1457,6 +1458,28 @@ function updatePiFinderStatusAndWizardLink() {
     wizardEl.textContent = 'not available yet';
   }
   refreshDebugSolve();
+}
+
+// Found live investigating #139: a contended Pi (PiFinder's own solver
+// worker pool, KStars, ...) can make pos_server.py's LX200 socket genuinely
+// unresponsive for several seconds at a time - not a bug, just a busy CPU.
+// This row exists so that shows up as a visible, explained state instead of
+// unexplained slowness elsewhere on the page. "High" mirrors _system_load_
+// status()'s own deliberately coarse threshold in server.py - a nudge to
+// look, not a claim that anything is actually broken.
+function refreshSystemLoad() {
+  fetch('/api/system_load').then(r => r.json()).then(data => {
+    const dotEl = document.getElementById('system-load-dot');
+    const textEl = document.getElementById('system-load-text');
+    const cores = data.cpu_count;
+    if (data.high) {
+      dotEl.className = 'status-dot dot-red';
+      textEl.textContent = `High (load ${data.load1}, ${cores} core${cores === 1 ? '' : 's'}) - PiFinder/INDI may respond slowly`;
+    } else {
+      dotEl.className = 'status-dot dot-green';
+      textEl.textContent = `Normal (load ${data.load1}, ${cores} core${cores === 1 ? '' : 's'})`;
+    }
+  }).catch(() => {});
 }
 
 // PiFinder's own "Tools -> Test Mode" (callbacks.activate_debug() ->
@@ -4510,6 +4533,9 @@ setTimeout(watchForNewRun, 3000);
 
 refreshMode();
 setInterval(refreshMode, 5000);
+
+refreshSystemLoad();
+setInterval(refreshSystemLoad, 30000);
 
 refreshDisplayBridge();
 setInterval(refreshDisplayBridge, 5000);

--- a/indi_pifinder/lx200_pifinder.cpp
+++ b/indi_pifinder/lx200_pifinder.cpp
@@ -45,8 +45,16 @@
 #include <memory>
 #include <termios.h>
 #include <libnova/libnova.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
 
-#define LX200_TIMEOUT 5 /* FD timeout in seconds */
+// See #139's investigation: pos_server.py can take several seconds to
+// answer under CPU load without the connection actually being dead. Retry
+// a handful of times with this much shorter per-attempt timeout instead of
+// one long LX200_TIMEOUT-second block per read (see readWithRetry()).
+static constexpr int LX200_READ_ATTEMPT_TIMEOUT = 2;
+static constexpr int LX200_READ_MAX_ATTEMPTS = 3;
 
 // Standalone driver executable: no multi-driver Loader/fat-binary needed.
 // Links directly against the system's libindilx200/libindidriver.
@@ -84,6 +92,21 @@ bool LX200_PIFINDER::Handshake()
         LOG_INFO("Simulate Connect.");
         return true;
     }
+
+    // #139-adjacent: enable TCP keepalive so a truly-dead connection (peer
+    // process gone without a clean close - the original #118 symptom) gets
+    // detected by the OS itself within ~11s, instead of relying purely on
+    // read()/write() to eventually notice. Tuned short deliberately - this
+    // is always a loopback connection to pos_server.py on the same Pi, not
+    // a real network link, so aggressive probing costs nothing.
+    int keepalive = 1;
+    setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &keepalive, sizeof(keepalive));
+    int keepidle = 5;   // start probing after 5s idle
+    int keepintvl = 3;  // probe every 3s
+    int keepcnt = 3;    // give up (fail reads/writes) after 3 missed probes
+    setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &keepidle, sizeof(keepidle));
+    setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &keepintvl, sizeof(keepintvl));
+    setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &keepcnt, sizeof(keepcnt));
 
     // The base classes perform an ACK check that PiFinder does not support.
     // Since PiFinder always answers plain reads like :GR#/:GD# below, we
@@ -184,7 +207,7 @@ bool LX200_PIFINDER::ReadScopeStatus()
     double ra_val, dec_val;
 
     // Get RA
-    if (setStandardProcedureAndReturnResponse(fd, "#:GR#", ra_response, sizeof(ra_response)) != 0)
+    if (readWithRetry("#:GR#", ra_response, sizeof(ra_response)) != 0)
     {
         LOG_ERROR("Failed to get RA from PiFinder.");
         return false;
@@ -197,7 +220,7 @@ bool LX200_PIFINDER::ReadScopeStatus()
     }
 
     // Get Dec
-    if (setStandardProcedureAndReturnResponse(fd, "#:GD#", dec_response, sizeof(dec_response)) != 0)
+    if (readWithRetry("#:GD#", dec_response, sizeof(dec_response)) != 0)
     {
         LOG_ERROR("Failed to get Dec from PiFinder.");
         return false;
@@ -218,6 +241,21 @@ bool LX200_PIFINDER::ReadScopeStatus()
     setPierSide(INDI::Telescope::PIER_EAST); // Default to East for now
 
     return true;
+}
+
+// See the header's own comment and this file's LX200_READ_ATTEMPT_TIMEOUT/
+// LX200_READ_MAX_ATTEMPTS for why this retries instead of using one long
+// LX200_TIMEOUT-second block per read.
+int LX200_PIFINDER::readWithRetry(const char *data, char *response, int max_response_length)
+{
+    int rc = -1;
+    for (int attempt = 0; attempt < LX200_READ_MAX_ATTEMPTS; ++attempt)
+    {
+        rc = setStandardProcedureAndReturnResponse(fd, data, response, max_response_length, LX200_READ_ATTEMPT_TIMEOUT);
+        if (rc == 0)
+            return 0;
+    }
+    return rc;
 }
 
 // PiFinder has no motor: "Goto" reuses PiFinder's existing SkySafari push-to
@@ -306,7 +344,8 @@ int LX200_PIFINDER::setStandardProcedureAndExpectChar(int fd, const char *data, 
     return 0;
 }
 
-int LX200_PIFINDER::setStandardProcedureAndReturnResponse(int fd, const char *data, char *response, int max_response_length)
+int LX200_PIFINDER::setStandardProcedureAndReturnResponse(int fd, const char *data, char *response, int max_response_length,
+                                                            int timeoutSec)
 {
     int error_type;
     int nbytes_write = 0, nbytes_read = 0;
@@ -320,9 +359,9 @@ int LX200_PIFINDER::setStandardProcedureAndReturnResponse(int fd, const char *da
     }
     // PiFinder terminates every response with '#' and then sends nothing
     // more - tty_read() would block until max_response_length bytes arrive
-    // (i.e. until LX200_TIMEOUT expires) instead of returning as soon as the
+    // (i.e. until timeoutSec expires) instead of returning as soon as the
     // short reply is complete. Read up to the terminator instead.
-    error_type = tty_nread_section(fd, response, max_response_length, '#', LX200_TIMEOUT, &nbytes_read);
+    error_type = tty_nread_section(fd, response, max_response_length, '#', timeoutSec, &nbytes_read);
     tcflush(fd, TCIFLUSH);
 
     if (nbytes_read < 1)

--- a/indi_pifinder/lx200_pifinder.h
+++ b/indi_pifinder/lx200_pifinder.h
@@ -22,6 +22,8 @@
 
 #include "lx200telescope.h"
 
+#define LX200_TIMEOUT 5 /* FD timeout in seconds - moved here (was in the .cpp) so it's visible as a default parameter value below */
+
 class LX200_PIFINDER : public LX200Telescope
 {
     public:
@@ -48,5 +50,15 @@ class LX200_PIFINDER : public LX200Telescope
 
         int setStandardProcedureWithoutRead(int fd, const char *data);
         int setStandardProcedureAndExpectChar(int fd, const char *data, const char *expect);
-        int setStandardProcedureAndReturnResponse(int fd, const char *data, char *response, int max_response_length);
+        int setStandardProcedureAndReturnResponse(int fd, const char *data, char *response, int max_response_length,
+                                                   int timeoutSec = LX200_TIMEOUT);
+
+        // Found live investigating #139: pos_server.py can occasionally take
+        // several seconds to answer under CPU load without the connection
+        // actually being dead (see that issue's own writeup). Retrying a few
+        // times with a shorter per-attempt timeout - instead of one long
+        // LX200_TIMEOUT-second block - keeps ReadScopeStatus() from stalling
+        // the whole polling cycle on a merely-slow (not dead) reply, while
+        // tolerating roughly the same total worst-case wait as before.
+        int readWithRetry(const char *data, char *response, int max_response_length);
 };

--- a/pi_config_files/pifinder.service
+++ b/pi_config_files/pifinder.service
@@ -32,7 +32,9 @@ RestartSec=2
 # #148 for the more precise upstream fix this doesn't replace). Nice=5 and a
 # below-default CPUWeight ask the scheduler to favor everything else (Control
 # Center, indiserver, the OS itself) when the CPU is actually contended,
-# without capping PiFinder below full-core use whenever it isn't.
+# without capping PiFinder below full-core use whenever it isn't. Tune the
+# numbers here directly if needed - see bin/functions.sh's own comment on
+# why they're not duplicated as a shell variable there.
 Nice=5
 CPUWeight=50
 

--- a/pi_config_files/pifinder.service
+++ b/pi_config_files/pifinder.service
@@ -24,6 +24,17 @@ SupplementaryGroups=kmem gpio spi i2c video input
 # of staying "failed" until someone notices and restarts it by hand.
 Restart=on-failure
 RestartSec=2
+# Mild deprioritization, not a hard cap: PiFinder's own solver spawns a CPU-
+# hungry worker pool (found live 2026-08-03 investigating #139 - a 4-core
+# Pi 4 hit load average 9+ with 10+ solver workers running, and pos_server.py's
+# LX200 socket went genuinely unresponsive to :GR#/:GD# for several seconds
+# at a time as a result, independent of anything the INDI driver does - see
+# #148 for the more precise upstream fix this doesn't replace). Nice=5 and a
+# below-default CPUWeight ask the scheduler to favor everything else (Control
+# Center, indiserver, the OS itself) when the CPU is actually contended,
+# without capping PiFinder below full-core use whenever it isn't.
+Nice=5
+CPUWeight=50
 
 [Install]
 WantedBy=basic.target

--- a/pifinder_stellarmate_setup.sh
+++ b/pifinder_stellarmate_setup.sh
@@ -916,7 +916,16 @@ sudo systemctl enable pifinder-fake-mode-autostart
 
 echo "🔧 Starting PiFinder services ..."
 sudo systemctl start pifinder-setup
-sudo systemctl start pifinder
+# restart, not start: on an Update run (as opposed to a fresh install),
+# pifinder.service is very likely already active from before this run - a
+# plain `start` on an already-active unit is a no-op, silently leaving the
+# OLD process running under whatever config was loaded before this run's
+# daemon-reload above, even though the just-copied pi_config_files/
+# pifinder.service (e.g. its Nice=/CPUWeight=, or any future change) is
+# already on disk and loaded into systemd. `restart` makes an update
+# actually take effect on an already-running instance too, same as a fresh
+# start does for a first install.
+sudo systemctl restart pifinder
 sudo systemctl start pifinder_splash
 
 # pifinder-control-center.service is deliberately not enabled by default

--- a/test_tools/fake_mode.sh
+++ b/test_tools/fake_mode.sh
@@ -72,6 +72,13 @@ case "${1:-}" in
             echo "Fake-hardware mode isn't running."
         fi
         echo "Starting the real pifinder.service ..."
+        # systemd caches a unit's parsed config in memory and does not
+        # re-read a changed file on disk on its own before start/restart -
+        # without this, switching back to Real Mode right after an update
+        # could start pifinder.service with whatever config was loaded
+        # BEFORE the update instead of what's actually on disk now (found
+        # live investigating #139's Nice=/CPUWeight= rollout).
+        sudo systemctl daemon-reload
         if ! sudo systemctl start pifinder.service; then
             echo "ERROR: could not start pifinder.service - aborting." >&2
             exit 1


### PR DESCRIPTION
## Summary

All found investigating #139's oscillation (root cause: a contended Pi can make `pos_server.py`'s LX200 socket genuinely unresponsive for several seconds - see that issue for the full writeup). Bundled per explicit request rather than five separate PRs.

- **Nice/CPUWeight**: `pifinder.service` now runs with `Nice=5`/`CPUWeight=50` - favors the Control Center/`indiserver`/the OS under contention without capping PiFinder otherwise. Live-verified (`ps -o ni`/`systemctl show`).
- **System load indicator**: new `GET /api/system_load` + a status row in the Quick Links tile (green "Normal"/red "High (load X, N cores)"), polled every 30s. Live-verified against this device's actual currently-elevated load (10.0 on 4 cores → correctly reports high).
- **Named timeout tiers**: consolidated scattered bare-literal timeouts in `gui_installer/indi_client.py`/`server.py` into named constants (`TIMEOUT_BACKGROUND_POLL`, `TIMEOUT_FAST_POLL`, `TIMEOUT_QUICK_RETRY`, ...) - no behavior change, every value already existed somewhere.
- **`_BackgroundRetrier`**: extracted #118's hand-rolled in-flight-guard + background-thread pattern into a small reusable class, and refactored #118's own watchdog to use it - no behavior change.
- **LX200 driver resilience**: TCP keepalive (SO_KEEPALIVE + short KEEPIDLE/KEEPINTVL/KEEPCNT) enabled in `Handshake()`, and `ReadScopeStatus()`'s `:GR#`/`:GD#` reads now retry up to 3 times at a shorter 2s timeout instead of one 5s block. Independent of #139's own (still unresolved) reconnect-on-failure branch - only touches read-path responsiveness. Live-verified: `ss -tnpo` shows the keepalive timer active; driver connects/reads normally.
- Fixed a CHANGELOG formatting slip (missing `### Added` header under `[Unreleased]`) found while documenting this batch.

Related, filed separately (not part of this PR):
- #148 - upstream PiFinder issue: cap/renice the solver's own worker pool (the more precise fix this PR's Nice/CPUWeight change doesn't replace).
- #149 - proposal for a pytest suite covering this kind of pure decision logic.

## Test plan

- [x] `python3 -m py_compile` on both touched Python files.
- [x] `node --check` on the extracted embedded JS.
- [x] C++ driver rebuilt and deployed; connects/reads normally under real `pos_server.py`.
- [x] `ss -tnpo` confirms TCP keepalive timer active on the LX200↔pos_server.py socket.
- [x] `/api/system_load`'s logic verified directly against this device's real (elevated) load average.
- [x] `Nice=5`/`CPUWeight=50` confirmed applied via `ps -o ni` and `systemctl show` after a restart.
- [ ] Not yet re-tested: whether the Nice/CPUWeight change measurably reduces how often #139's oscillation recurs under real sustained load (would need a longer live observation window than this session had left).

🤖 Generated with [Claude Code](https://claude.com/claude-code)