### PR TITLE
Fix: stack PiFinder status + system load lines instead of side-by-side

### DIFF
--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -239,6 +239,11 @@
     gap: 1rem;
     margin-bottom: 0.7rem;
   }
+  #pifinder-glance-status-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
   #pifinder-status-line { font-weight: bold; }
   .status-dot {
     display: inline-block;
@@ -902,8 +907,10 @@
       <h3 class="tile-heading" title="Direct links to PiFinder's own remote page, its INDI/mount setup wizard, and this Control Center - plus the project's documentation, and a quick hardware glance.">PiFinder<a class="help-link" href="/help.html#quick-links" target="_blank" rel="noopener" title="Help">i</a></h3>
       <div id="pifinder-glance-row">
         <img id="pifinder-screen" src="/pifinder_welcome.png" alt="PiFinder screen" title="PiFinder OLED screen (live once running)">
-        <div id="pifinder-status-line" title="Reflects the web server/OLED mirror answering - PiFinder can be &quot;running&quot; on the software side even with hardware missing (see PiFinder Mode, Test and Power below)."><span class="status-dot dot-white" id="pifinder-status-dot"></span><span id="pifinder-status-text">PiFinder not detected yet</span></div>
-        <div id="system-load-line" title="CPU load average relative to core count - not an error, just a heads-up: a genuinely busy Pi can make PiFinder's own position server briefly slow to answer (see the LX200/Mount Bridge docs for details)."><span class="status-dot dot-white" id="system-load-dot"></span><span id="system-load-text">Checking system load…</span></div>
+        <div id="pifinder-glance-status-stack">
+          <div id="pifinder-status-line" title="Reflects the web server/OLED mirror answering - PiFinder can be &quot;running&quot; on the software side even with hardware missing (see PiFinder Mode, Test and Power below)."><span class="status-dot dot-white" id="pifinder-status-dot"></span><span id="pifinder-status-text">PiFinder not detected yet</span></div>
+          <div id="system-load-line" title="CPU load average relative to core count - not an error, just a heads-up: a genuinely busy Pi can make PiFinder's own position server briefly slow to answer (see the LX200/Mount Bridge docs for details)."><span class="status-dot dot-white" id="system-load-dot"></span><span id="system-load-text">Checking system load…</span></div>
+        </div>
       </div>
       <!-- Compact, always-visible hardware summary - same visual language
            as the Mount Bridge diagram's icon nodes (bordered box, currentColor


### PR DESCRIPTION
## Summary
- PR #150's system load indicator and PR #152's GUI restructure both touched the same area of `gui_installer/status_page.html`; resolving that merge conflict left `#system-load-line` as a third flex child of `#pifinder-glance-row`, so it rendered next to `#pifinder-status-line` in one horizontal row instead of stacked underneath it.
- Reported live via screenshot right after the PR #152 merge deployed.
- Wraps both status lines in a new `#pifinder-glance-status-stack` column (flex, column direction) so they stack vertically next to the OLED mirror image, as originally intended in both source PRs.
- No behavior change to either status line's own logic/content, purely a layout fix.

## Test plan
- [x] HTML tag-balance check (custom parser) - clean
- [x] Embedded JS extracted + `node --check`ed - clean
- [ ] Visual confirmation in browser (user)