### PR TITLE
fix: Auto-correct (Goto & Track) never converged on the commanded target

### DIFF
--- a/indi_pifinder_bridge/pifinder_mount_bridge.cpp
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.cpp
@@ -341,7 +341,14 @@ void PiFinderMountBridge::TimerHit()
     }
     else if (BridgeModeS[MODE_AUTO_CORRECT].s == ISS_ON)
     {
-        if (exceeded && !isPiFinderSolveFresh(SolveFreshnessMaxAgeN[0].value))
+        if (CorrectionActionS[ACTION_GOTO].s == ISS_ON)
+        {
+            // Goto/Track correction: needs arrival-verify-and-refine, not a
+            // one-shot fire-and-forget - see handleAutoCorrectGoto()'s
+            // header comment for why (#170).
+            handleAutoCorrectGoto(exceeded, piRA, piDec, drift, DriftThresholdN[0].value);
+        }
+        else if (exceeded && !isPiFinderSolveFresh(SolveFreshnessMaxAgeN[0].value))
         {
             // Found live (#79): correcting off a continuously
             // IMU-interpolated position (no real solve backing it, or one
@@ -364,34 +371,12 @@ void PiFinderMountBridge::TimerHit()
         }
         else if (exceeded)
         {
-            // Actually correcting this tick (or the Goto-in-progress guard
-            // below is letting a prior one finish) - IPS_BUSY, distinct from
-            // both IPS_OK (within threshold) and the IPS_ALERT gated case
-            // above.
+            // Sync path: instantaneous, no physical motion to verify/refine.
             DriftStatusNP.s = IPS_BUSY;
-            const bool useGoto = CorrectionActionS[ACTION_GOTO].s == ISS_ON;
-
-            // A Goto correction takes far longer than one 2s tick to
-            // complete, and "drift still exceeds threshold" stays true for
-            // the whole time the mount is slewing toward it. Without this
-            // guard, every tick re-issued a fresh Goto to the (slightly
-            // updated) target, which most mount drivers handle by aborting
-            // the in-progress slew and starting over - visible as the mount
-            // repeatedly stopping/restarting, plus an "aborted" alert from
-            // the client on every abort. Sync is instantaneous (no physical
-            // motion to interrupt), so it doesn't need this guard.
-            if (useGoto && m_client->isMountSlewing())
-            {
-                // Already correcting from a previous tick - let it finish.
-            }
+            if (m_client->sendMountCoords(piRA, piDec, "SYNC"))
+                LOGF_INFO("Drift %.1f arcmin exceeded threshold - sent SYNC to mount.", drift);
             else
-            {
-                const char *coordSet = useGoto ? "TRACK" : "SYNC";
-                if (m_client->sendMountCoords(piRA, piDec, coordSet))
-                    LOGF_INFO("Drift %.1f arcmin exceeded threshold - sent %s to mount.", drift, coordSet);
-                else
-                    LOG_ERROR("Failed to send correction to mount.");
-            }
+                LOG_ERROR("Failed to send correction to mount.");
         }
         // else: not exceeded - DriftStatusNP.s already set to IPS_OK by the
         // baseline computation above.
@@ -536,6 +521,130 @@ void PiFinderMountBridge::handleGotoForward()
     }
 }
 
+void PiFinderMountBridge::handleAutoCorrectGoto(bool exceeded, double piRA, double piDec, double drift, double threshold)
+{
+    switch (m_correctState)
+    {
+        case CorrectState::IDLE:
+        {
+            if (!exceeded)
+                return;
+
+            if (!isPiFinderSolveFresh(SolveFreshnessMaxAgeN[0].value))
+            {
+                DriftStatusNP.s = IPS_ALERT;
+                LOGF_DEBUG(
+                    "Drift %.1f arcmin exceeded threshold, but PiFinder's position isn't backed by a solve "
+                    "within the last %.1fs - skipping correction.",
+                    drift, SolveFreshnessMaxAgeN[0].value);
+                return;
+            }
+
+            DriftStatusNP.s = IPS_BUSY;
+            if (m_client->sendMountCoords(piRA, piDec, "TRACK"))
+            {
+                LOGF_INFO("Drift %.1f arcmin exceeded threshold - sent Goto to mount.", drift);
+                m_correctTargetRA = piRA;
+                m_correctTargetDec = piDec;
+                m_correctSettleRetriesRemaining = MAX_SETTLE_RETRIES;
+                m_correctState = CorrectState::SLEWING;
+            }
+            else
+            {
+                LOG_ERROR("Failed to send correction to mount.");
+            }
+            break;
+        }
+
+        case CorrectState::SLEWING:
+        {
+            // A Goto correction takes far longer than one poll tick to
+            // complete, and "drift still exceeds threshold" stays true for
+            // the whole time the mount is slewing toward it - stay BUSY and
+            // just wait for it to finish rather than re-issuing (which most
+            // mount drivers handle by aborting the in-progress slew and
+            // starting over).
+            DriftStatusNP.s = IPS_BUSY;
+            if (!m_client->isMountSlewing())
+            {
+                m_correctSettleTicksRemaining = SETTLE_TICKS;
+                m_correctFreshnessWaitTicksRemaining = MAX_FRESHNESS_WAIT_TICKS;
+                m_correctState = CorrectState::SETTLING;
+                LOG_INFO("Auto-correct Goto finished slewing - waiting for a fresh PiFinder solve to verify arrival.");
+            }
+            break;
+        }
+
+        case CorrectState::SETTLING:
+        {
+            DriftStatusNP.s = IPS_BUSY;
+            if (m_correctSettleTicksRemaining > 0)
+            {
+                --m_correctSettleTicksRemaining;
+                break;
+            }
+
+            if (!isPiFinderSolveFresh(SolveFreshnessMaxAgeN[0].value))
+            {
+                // See m_freshnessWaitTicksRemaining's comment on ForwardState
+                // - same reasoning applies here: trusting an IMU-interpolated
+                // "arrival" position would Sync the mount to a guessed
+                // position instead of a verified one.
+                if (--m_correctFreshnessWaitTicksRemaining <= 0)
+                {
+                    LOG_WARN("Gave up waiting for a fresh PiFinder solve after auto-correct Goto - resuming normal monitoring.");
+                    m_correctState = CorrectState::IDLE;
+                }
+                break;
+            }
+
+            // drift/threshold reflect this tick's freshly-computed
+            // separation (passed in from TimerHit), i.e. the actual residual
+            // now that the mount has stopped and PiFinder has a fresh solve.
+            if (drift > threshold && m_correctSettleRetriesRemaining > 0)
+            {
+                // The mount already physically arrived via the Goto above,
+                // but a residual this size usually means its own alignment
+                // model was slightly off at this sky position - blindly
+                // re-issuing Goto to a corrected RA/Dec never fixes that (see
+                // #170: drift kept climbing right back up after each
+                // "correction"). Sync first to fix the model with PiFinder's
+                // verified solve, then re-issue the Goto so it benefits from
+                // the corrected model. Bounded so a genuinely noisy solve
+                // can't loop forever chasing it.
+                --m_correctSettleRetriesRemaining;
+                if (!m_client->sendMountCoords(piRA, piDec, "SYNC"))
+                {
+                    LOG_ERROR("Failed to send verification sync to mount.");
+                    m_correctState = CorrectState::IDLE;
+                    break;
+                }
+                if (!m_client->sendMountCoords(m_correctTargetRA, m_correctTargetDec, "TRACK"))
+                {
+                    LOG_ERROR("Failed to re-issue Goto to mount after sync.");
+                    m_correctState = CorrectState::IDLE;
+                    break;
+                }
+                LOGF_INFO("Auto-correct arrival verified by PiFinder solve: residual %.1f arcmin exceeds threshold %.1f -"
+                          " synced and re-issued Goto (%d attempt(s) left).",
+                          drift, threshold, m_correctSettleRetriesRemaining);
+                m_correctState = CorrectState::SLEWING;
+            }
+            else
+            {
+                if (drift > threshold)
+                    LOGF_WARN("Auto-correct gave up refining after %d attempt(s): residual %.1f arcmin still exceeds threshold %.1f.",
+                              MAX_SETTLE_RETRIES, drift, threshold);
+                else
+                    LOGF_INFO("Auto-correct arrival verified by PiFinder solve: residual %.1f arcmin, within threshold %.1f.",
+                              drift, threshold);
+                m_correctState = CorrectState::IDLE;
+            }
+            break;
+        }
+    }
+}
+
 bool PiFinderMountBridge::ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
@@ -553,6 +662,12 @@ bool PiFinderMountBridge::ISNewSwitch(const char *dev, const char *name, ISState
             m_lastForwardedRA = std::nan("");
             m_lastForwardedDec = std::nan("");
 
+            // Same idea for Auto-Correct's Goto-refine state machine - don't
+            // let an in-progress settle/retry cycle from a previous mode
+            // silently keep running (or resume stale) after switching away
+            // and back.
+            m_correctState = CorrectState::IDLE;
+
             // Persist so the chosen mode actually survives a reconnect -
             // see m_connectedConfigLoaded's comment. Without this, the
             // saved config just keeps replaying whatever was last actively
@@ -568,6 +683,11 @@ bool PiFinderMountBridge::ISNewSwitch(const char *dev, const char *name, ISState
             IUUpdateSwitch(&CorrectionActionSP, states, names, n);
             CorrectionActionSP.s = IPS_OK;
             IDSetSwitch(&CorrectionActionSP, nullptr);
+
+            // Switching Sync<->Goto mid-correction shouldn't leave a stale
+            // settle/retry cycle running for the action that's no longer
+            // selected.
+            m_correctState = CorrectState::IDLE;
             return true;
         }
 

--- a/indi_pifinder_bridge/pifinder_mount_bridge.cpp
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.cpp
@@ -451,6 +451,7 @@ void PiFinderMountBridge::handleGotoForward()
             if (!m_client->isMountSlewing())
             {
                 m_settleTicksRemaining = SETTLE_TICKS;
+                m_freshnessWaitTicksRemaining = MAX_FRESHNESS_WAIT_TICKS;
                 m_forwardState = ForwardState::SETTLING;
                 LOG_INFO("Mount finished slewing - waiting for a fresh PiFinder solve to verify arrival.");
             }
@@ -462,6 +463,19 @@ void PiFinderMountBridge::handleGotoForward()
             if (m_settleTicksRemaining > 0)
             {
                 --m_settleTicksRemaining;
+                break;
+            }
+
+            if (!isPiFinderSolveFresh(SolveFreshnessMaxAgeN[0].value))
+            {
+                // PiFinder hasn't produced a real camera solve since arrival
+                // yet - see the header comment on m_freshnessWaitTicksRemaining.
+                // Keep waiting rather than verifying/correcting off a guess.
+                if (--m_freshnessWaitTicksRemaining <= 0)
+                {
+                    LOG_WARN("Gave up waiting for a fresh PiFinder solve after arrival - skipping this settle attempt.");
+                    m_forwardState = ForwardState::IDLE;
+                }
                 break;
             }
 

--- a/indi_pifinder_bridge/pifinder_mount_bridge.h
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.h
@@ -160,4 +160,27 @@ class PiFinderMountBridge : public INDI::DefaultDevice
         static constexpr int MAX_SETTLE_RETRIES = 3;
 
         void handleGotoForward();
+
+        // MODE_AUTO_CORRECT with CorrectionActionS[ACTION_GOTO]: mirrors
+        // handleGotoForward()'s arrival-verify-and-refine pattern (#170 -
+        // blindly re-issuing a Goto to wherever PiFinder currently reports,
+        // every single tick drift exceeds threshold, never corrects the
+        // mount's own alignment-model error, so each Goto lands off by
+        // roughly that same fixed error and drift climbs straight back up
+        // right after - never actually converges on the target). Kept as a
+        // separate state machine rather than reusing ForwardState/
+        // handleGotoForward(): that one is driven by a discrete *new*
+        // PiFinder push-to target event; this one is driven by continuous
+        // drift-exceeds-threshold and needs to hand control back to normal
+        // per-tick monitoring once a correction settles, not wait for a
+        // "new target" event that may never come.
+        enum class CorrectState { IDLE, SLEWING, SETTLING };
+        CorrectState m_correctState = CorrectState::IDLE;
+        double m_correctTargetRA = std::nan("");
+        double m_correctTargetDec = std::nan("");
+        int m_correctSettleTicksRemaining = 0;
+        int m_correctFreshnessWaitTicksRemaining = 0;
+        int m_correctSettleRetriesRemaining = 0;
+
+        void handleAutoCorrectGoto(bool exceeded, double piRA, double piDec, double drift, double threshold);
 };

--- a/indi_pifinder_bridge/pifinder_mount_bridge.h
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.h
@@ -136,7 +136,20 @@ class PiFinderMountBridge : public INDI::DefaultDevice
         double m_lastForwardedRA = std::nan("");
         double m_lastForwardedDec = std::nan("");
         int m_settleTicksRemaining = 0;
-        static constexpr int SETTLE_TICKS = 3; // poll cycles to wait for a fresh PiFinder solve after slew
+        static constexpr int SETTLE_TICKS = 3; // poll cycles to wait before even checking for a fresh solve
+
+        // SETTLE_TICKS alone doesn't guarantee PiFinder has actually produced
+        // a new camera solve by then - it may still be reporting an
+        // IMU-interpolated position left over from before/during the slew.
+        // Trusting that as arrival truth would Sync the mount to a guessed
+        // position instead of a verified one, corrupting its model instead
+        // of correcting it. Found live (2026-08-07): this caused PiFinder's
+        // own reported position to overshoot the target and the mount to
+        // never converge across retries - same failure class #79 already
+        // guards against for Auto-Correct, just missing here. Bounded so a
+        // stuck/slow solver can't stall a settle attempt forever.
+        int m_freshnessWaitTicksRemaining = 0;
+        static constexpr int MAX_FRESHNESS_WAIT_TICKS = 10;
 
         // A residual after arrival usually means the mount's own model was
         // slightly off at this sky position - Sync corrects that model with


### PR DESCRIPTION
## Summary
- Auto-correct (Goto & Track) blindly re-issued Goto to PiFinder's current position every tick drift exceeded threshold, never correcting the mount's own alignment-model error - drift climbed straight back up after each "correction" (#170).
- Adds `handleAutoCorrectGoto()`, an arrival-verify-and-refine state machine mirroring `handleGotoForward()`'s pattern (Sync to fix the model, then re-Goto, bounded retries) but driven by continuous drift monitoring rather than a discrete new-target event.
- Also includes the already-committed Goto-Forward settle freshness-gate fix (`06668dc`).

Closes #170.

## Test plan
- [x] Built and installed the updated Mount Bridge driver
- [x] Live-tested against real mount (LX200 OnStep) + real sky: GoTo Vega, M57, Altair, Saturn all landed correctly and held - see [#173](https://github.com/apos/PiFinder_Stellarmate/issues/173) / [#174](https://github.com/apos/PiFinder_Stellarmate/issues/174)