### PR TITLE
Mount Bridge: reposition detection, mount-reject safety, mode readiness, GUI consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,37 @@ All notable changes to this project are documented in this file. Format loosely 
     anchored to independent ground truth instead of PiFinder's own estimate) and split into dedicated
     per-section headings matching the page's per-section help icons, instead of one flat `Mode &
     Power` section.
+- Mount Bridge's connection diagram (PiFinder → Bridge → Mount icons, drift badge) and its mode-caption
+  and mount-reject warning rows moved out of the "INDI Mount Bridge" tile into the "PiFinder" tile,
+  directly under the Cam/Solve/IMU/GPS badges - both were pure status/info displays, grouped with the
+  rest of the page's own status info instead of living apart from the settings/actions the Mount Bridge
+  tile keeps (Coupling presets, Sync/Stop, Threshold, Role). Mode-caption and reject-warning each used
+  to reflow the whole page whenever their text length changed (a red warning box appearing/disappearing,
+  or the caption switching between a short and a long sentence) - both now use a fixed-height dot+
+  short-label row with an opt-in "Details" toggle for the full sentence instead, matching the page's
+  `.status-dot` ampel convention (no icons, per the project's UI guideline).
+- Mount Bridge's drift readout (`formatDrift()` in `status_page.html`) now shows degrees+arcmin past
+  60' (e.g. `65'` → `1° 5'`) instead of an awkward `65.0'`, applied consistently to the drift badge and
+  every caption/status line that shows it.
+- Quick Links: an **OnStep Web UI** row, its IP read live from the mount driver's own `DEVICE_ADDRESS`
+  (`indi_client.py`'s `mount_bridge_status()` now also returns `mount_web_ip`, populated only when the
+  mount is TCP-connected - a serial/USB mount has no IP to show here, and this reuses the property
+  lookup the connection-state check already made, no extra INDI round-trip). Every IP-list row (This
+  page/INDI Web Manager/StellarMate Dashboard/StellarMate Web VNC/OnStep Web UI) now renders as a small
+  button (last two octets, full `ip:port` as the tooltip) instead of a wall of plain-text links. A new
+  **"Open all links"** button opens all of them plus PiFinder Remote in one click; each `window.open()`
+  call happens synchronously in the click handler so browser popup blockers allow it, and any tab the
+  blocker still ate is detected (via `window.open()`'s `null` return) and reported inline instead of
+  silently missing. The old single crowded "GitHub:" line split into three rows (PFSM GitHub/PiFinder/
+  StellarMate), with PiFinder's and StellarMate's own Discord invites added; the "PiFinder Remote Page"/
+  "INDI driver setup" rows dropped their redundant label text now that the link text alone already says
+  what it is.
+- Quick keys D-pad: a press that actually failed (PiFinder screen mirror not discovered yet, or the
+  proxied `/api/pifinder_key` call itself failing/rejected) now flashes red instead of flashing the same
+  "pressed" look a successful press gets - found live investigating "the D-pad just doesn't work", which
+  turned out to be exactly this: a silent no-op with zero visible difference from success. The Quick
+  keys A layout's LONG button was also sized down (95px → 47px square) and moved closer to the D-pad
+  per live feedback that it was oversized/too far away.
 
 ### Changed
 
@@ -186,6 +217,24 @@ All notable changes to this project are documented in this file. Format loosely 
 
 ### Fixed
 
+- Fix #194: Goto-Forward silently ignored the first Goto after any BridgeMode switch (or a driver
+  restart while it was already the active mode) - `ISNewSwitch()`'s reset of the forwarding baseline
+  to a NaN sentinel made `handleGotoForward()` treat the very next observed target, even a brand new
+  one just picked in KStars, as "first observation, just baseline it, don't forward" (the same handling
+  meant to protect against re-firing a stale, already-present target). Found live: select M31 in
+  KStars, click "PiFinder Goto" - nothing happens; click again - the mount slews. Now snapshots the
+  existing target as the baseline instead of blanking it, so a genuinely different target fires
+  immediately on the first press, while the original stale-target protection still holds.
+- Fix #195: `DriftThresholdNP`, `MaxSyncDriftNP` (direct-edit handler), and `SolveFreshnessMaxAgeNP`
+  never called `saveConfig()` after updating, unlike their sibling properties in the same `ISNewNumber()`
+  handler - none of the three survived a driver restart. Found live: "Threshold keeps resetting to 5
+  after every reload."
+- Fix #187: the OLED-mirror tile looked dead for 3-60+s after a real Pi reboot, before PiFinder's own
+  web server was even reachable to probe - added a `#pifinder-screen-waiting` overlay ("Waiting for
+  PiFinder…") explicit about the wait instead of just showing the dark static splash fallback.
+- Fix #188 (duplicate: #167): `_startup_hardware_test()`'s Cam/GPS check could leave a stale
+  "unreachable" result after a full system reboot slower than its original 120s window - now retries
+  indefinitely (every 15s) instead of giving up after one bounded attempt.
 - The Control Center's static OLED-mirror placeholder (shown before the live `/image` probe
   succeeds) showed PiFinder's original full-color/blue splash image instead of the documented
   red-converted version matching real hardware's actual red-channel-only rendering (see

--- a/docs/concepts/mount_bridge_multistar_alignment.md
+++ b/docs/concepts/mount_bridge_multistar_alignment.md
@@ -1,0 +1,243 @@
+# Concept: Automatic Multi-Point Alignment via Mount Bridge
+
+> **Status: concept — not yet implemented.** Written via this project's `cpt` (concept)
+> convention — see `basic-memory/basic-memory/00020_bm-cpt-command-system.md` and
+> `00021_bm-documentation-depth-standard.md` for the standard this document follows. Tracked as
+> [GitHub issue #191](https://github.com/apos/PiFinder_Stellarmate/issues/191) on
+> [Project #15](https://github.com/users/apos/projects/15) — update that issue if this concept is
+> promoted, revised, or dropped.
+>
+> **Builds on two existing concepts, read both first:**
+> - [`pifinder_mount_model_cloud_tracking.md`](pifinder_mount_model_cloud_tracking.md) §4 already
+>   proposes an **Align** LX200 command ("here is a verified position, incorporate it into your
+>   alignment model" — distinct from a plain Sync's "reset your current pointing to this"). This
+>   concept is the first concrete, motivating use case for actually building that primitive — see
+>   §8.
+> - [`mount_bridge_reposition_detection.md`](mount_bridge_reposition_detection.md) §3.5/§4 already
+>   established the freshness-gating and settle-detection discipline ("never adopt a position
+>   confirmed only by IMU-interpolated data") this concept reuses point-by-point, and its own §8
+>   already flagged the overlap with the cloud-tracking document — this concept is the third
+>   document in that same overlapping cluster, not a fresh, unrelated idea.
+
+## 1. Overview
+
+A button that performs an automated multi-point alignment: instead of the user manually centering
+several known stars in an eyepiece/reticle and confirming each one at the mount's hand controller
+(classic 2-/3-star align), PiFinder's own plate-solving determines where the mount is *actually*
+pointing at several sky positions in sequence, and each verified position is sent directly to the
+mount over INDI — the same generic, mount-agnostic `EQUATORIAL_EOD_COORD`/`ON_COORD_SET` path Mount
+Bridge already uses everywhere else (`pifinder_bridge_client.cpp`'s `sendMountCoords()`).
+
+Motivation: a single Sync (today's only "teach the mount a true position" mechanism) only refines
+the mount's model at one point in the sky. Real GoTo accuracy across the whole sky depends on the
+mount's alignment model having several verified reference points spread across different
+sky regions — normally built by a human doing exactly that, star by star, by hand. Nothing here is
+architecturally new; it automates a workflow astronomers already do manually, using PiFinder's
+plate-solving instead of human eyeballing/centering as the "is this the true position" judge.
+
+## 2. Use Cases
+
+| # | User action | System behavior |
+|---|---|---|
+| UC1 | Click "Multi-Point Alignment", accept defaults (radius, point count, etc.) | Runs the full sequence from PiFinder's current pointing, Sync-ing the mount at each verified point |
+| UC2 | Configure radius (30°/60°/100° presets), point count (1–10), median-solve count, minimum altitude, before starting | Candidate points are drawn only from within the configured radius of PiFinder's *current* view, above the configured minimum altitude |
+| UC3 | Enable "also feed KStars/Ekos alignment model" | Each verified point is additionally handed to Ekos's own alignment subsystem, not just the mount's firmware (see §4.5 — open question, not just a checkbox) |
+| UC4 | Click Stop Movement mid-sequence | Sequence aborts immediately (reuses the existing `abortMount()` panic-button path, #179) — mount stops where it is, no further points attempted, no automatic resume |
+| UC5 | A candidate point fails to solve (cloud, too dim, camera obstruction) | Point is skipped (not retried indefinitely — see §4.3), sequence continues with the next candidate; a point skipped past the configured count is not silently replaced by an extra one — user sees fewer completed points than requested rather than the sequence running longer than expected |
+
+## 3. Configuration Parameters (User, 2026-08-09)
+
+| Parameter | Type | Notes |
+|---|---|---|
+| Search radius | degrees, preset choices (30° / 60° / 100°, free entry also allowed) | Centered on PiFinder's *current* solved/reported position at the moment the button is clicked — not a fixed catalog position, not the mount's own reported position (those two can disagree, see §4.2) |
+| Number of points | integer, 1–10 | How many verified alignment points to collect before finishing |
+| Solves per point (median) | integer | Each point's final RA/Dec is the **median** of this many independent camera solves at that position, not a single solve — reduces sensitivity to one noisy/wrong solve. Needs its own settle-then-sample loop, see §4.3 |
+| Minimum altitude | degrees above horizon | Candidate points below this are excluded from selection entirely (not attempted-then-skipped) |
+| Candidate source | "KStars catalog" or "PiFinder Bright Stars catalog" | See §4.2 — which catalog actually supplies candidate coordinates within the radius/altitude constraints |
+| Feed KStars/Ekos alignment model too | boolean, off by default | See §4.5 — open question on how this interacts with the mount's own model, not yet resolved enough to default it on |
+
+## 4. Architecture
+
+### 4.1 Context
+
+```mermaid
+flowchart LR
+    subgraph Candidate source
+        KSC[KStars star catalog]
+        PFC["PiFinder \"Bright Stars\" catalog"]
+    end
+    UI[Control Center: Multi-Point Alignment button] -- radius/count/altitude/median params --> SEQ[Alignment sequencer]
+    KSC -.one of the two.-> SEQ
+    PFC -.one of the two.-> SEQ
+    SEQ -- blind GoTo per point --> MB[Mount Bridge]
+    MB -- EQUATORIAL_EOD_COORD + ON_COORD_SET=SLEW --> LX[Mount's INDI driver]
+    PF[PiFinder camera] -- N solves per point, median taken --> SEQ
+    SEQ -- verified position --> MB
+    MB -- ON_COORD_SET=SYNC/ALIGN --> LX
+    SEQ -. optional (UC3, open question) .-> EKA[Ekos alignment module]
+```
+
+### 4.2 Candidate point selection
+
+Two concrete sourcing options were named (User), not a bespoke new star list:
+
+- **KStars's own star catalog** — Ekos/KStars already has a full sky catalog with magnitude data;
+  querying "bright stars within radius R of point X, above altitude A" is exactly the kind of query
+  KStars's own scripting/DBus interface is built for. Advantage: already includes proper
+  magnitude-based filtering and is the same catalog the user already sees on the sky map.
+- **PiFinder's own "Bright Stars" catalog** — PiFinder already ships a bright-star catalog for its
+  own UI (needs verification: which file/table exactly, under `astro_data/` or the catalogs DB —
+  not yet confirmed which one is meant here). Advantage: no KStars/Ekos dependency at all, works
+  even in a PiFinder-only ("PiFinder host") role setup with no mount-side KStars session — see the
+  existing Role concept (All-in-one / PiFinder host / Control host, `Readme_PiFinder_LX200.md`).
+
+The center of the search radius is **PiFinder's current solved position**, not the mount's current
+reported position — the two can disagree (that disagreement is exactly what an ordinary Mount
+Bridge Coupling mode corrects, and is *also* likely why the user wants to realign in the first
+place). Using PiFinder's own view keeps the alignment run anchored to what the user is actually
+looking at through the finder right now, not wherever the mount's (possibly wrong) internal model
+currently believes it's pointing.
+
+### 4.3 Per-point sequence flow
+
+```mermaid
+flowchart TD
+    Start[Start sequence] --> Candidates[Select up to N candidate points\nwithin radius, above min altitude,\nfrom the chosen catalog]
+    Candidates --> NextPoint{Points remaining\nand not aborted?}
+    NextPoint -- no --> Done[Sequence complete - report N verified / M attempted]
+    NextPoint -- yes --> Goto[Blind GoTo to candidate point\n- mount's current, possibly imperfect model]
+    Goto --> Settled{Mount finished slewing?\nisMountSlewing==false}
+    Settled -- no --> Settled
+    Settled -- yes --> SolveLoop[Collect solves until median-count\nreached or a bounded attempt limit expires]
+    SolveLoop --> Enough{Median-count solves\nsuccessfully collected?}
+    Enough -- no, limit expired --> Skip[Skip this point - log why,\ndoes not count toward N]
+    Skip --> NextPoint
+    Enough -- yes --> Median[Compute median RA/Dec\nacross the collected solves]
+    Median --> Sync["Sync (or Align, see §4.5)\nmount to the median position"]
+    Sync --> KStarsFeed{Feed KStars model too?\n(UC3, opt-in)}
+    KStarsFeed -- yes --> EkosAdd[Hand the same verified point\nto Ekos's alignment module]
+    KStarsFeed -- no --> NextPoint
+    EkosAdd --> NextPoint
+    Start -.Stop Movement.-> Abort[Abort - mount stops where it is,\nno further points, no auto-resume]
+```
+
+The settle-then-median-sample step directly reuses the same discipline `handleGotoForward()`
+already applies for a single point (wait for `isMountSlewing()==false`, then wait for a **fresh**
+PiFinder solve — `isPiFinderSolveFresh()`, `solve_source=="CAM"` — before trusting it, exactly the
+#79 freshness-gate pattern used everywhere else in Mount Bridge). What's new here, not present
+anywhere else in this project yet, is collecting **several** solves per point and taking their
+**median** rather than trusting the first fresh one — a genuinely new aggregation step, not a
+reuse of existing code.
+
+### 4.4 Skip vs. retry vs. abort
+
+- **A single failed solve attempt** at a point: retry (bounded — needs its own attempt cap, e.g. a
+  handful of tries with a short pause between, mirroring `MAX_FRESHNESS_WAIT_TICKS`'s existing
+  bounded-wait pattern elsewhere in this file) before giving up on that specific solve sample.
+- **A point that never accumulates enough solves** for its median within a reasonable bound (cloud
+  cover sitting right on that patch of sky, camera obstruction, ...): skipped entirely (UC5) — the
+  sequence moves on to the next candidate rather than stalling the whole run on one bad point.
+- **User-triggered abort** (UC4): the existing `abortMount()`/Stop Movement path already covers
+  this cleanly — immediately stops any in-flight motion and (per its existing behavior) also sets
+  Coupling to Off, so nothing else tries to act on the half-finished sequence's state afterward. No
+  new abort mechanism needed, matching the user's own direct confirmation.
+
+### 4.5 Open question: Sync vs. the proposed "Align" primitive, and the KStars-model interaction
+
+Two things flagged as genuinely unresolved, not just left as vague future work:
+
+- **Sync today only ever resets the mount's *current pointing* to a given coordinate** — whether
+  repeated Syncs at different points actually accumulate into a real multi-point alignment model,
+  or whether each new Sync simply overwrites the last one's contribution, is **firmware-dependent**.
+  Confirmed for the primary target mount: **OnStep does build a real multi-point model from
+  repeated Syncs** (User, 2026-08-09) — so for OnStep specifically, the simple "just Sync N times"
+  sequence in §4.3 is sufficient, no `ALIGNMENT_POINTSET_*`-style INDI Alignment Subsystem
+  properties or a dedicated Align command are strictly required to make this concept work. For any
+  *other* mount driver this feature might later target, that assumption needs re-verifying — not
+  guaranteed to generalize. Building the "Align" primitive `pifinder_mount_model_cloud_tracking.md`
+  §4 already proposes remains worth doing regardless (it's the semantically correct operation this
+  concept is actually performing — "here is a verified position, learn it" — even where a plain
+  Sync happens to produce the same practical effect on OnStep today), but is not a hard blocker for
+  a first OnStep-only implementation.
+- **Feeding Ekos's own alignment module in addition to the mount's firmware model** (UC3): raised
+  by the user with an explicit caveat — "hoffentlich kommen die sich nicht ins Gehege" (hopefully
+  they don't get in each other's way). Genuinely open: does KStars/Ekos apply its own alignment
+  correction *on top of* the mount's already-corrected pointing (double-correcting), or does
+  enabling a KStars alignment model change how Ekos itself interprets/forwards GoTo commands in a
+  way that could conflict with Mount Bridge's own direct INDI Sync calls? Needs actual research
+  into Ekos's alignment-module behavior (and likely a live test on real hardware, in the same style
+  as tonight's Fall-2 live verification) before this defaults to anything other than off. Not
+  resolved by this document — flagged here so it isn't quietly implemented without that research
+  first.
+
+## 5. ADR: Sync-only for a first OnStep-scoped implementation, revisit Align primitive if generalized
+
+**Context**: §4.5 identified that whether repeated Syncs actually build a multi-point model is
+firmware-dependent, and that `pifinder_mount_model_cloud_tracking.md` already separately proposes a
+more semantically correct "Align" primitive for exactly this kind of "teach a verified position"
+operation.
+
+**Decision**: build the first version of this feature using plain `ON_COORD_SET=SYNC` (already
+confirmed sufficient for OnStep, the primary/only currently-verified target), rather than blocking
+this concept's implementation on first building a new INDI Align command. Explicitly revisit this
+once/if the feature is generalized to other mount drivers, or once the cloud-tracking concept's own
+Align primitive gets built for its own reasons — at that point, this feature should switch to using
+it too rather than maintaining two separate "teach a verified position" code paths long-term.
+
+**Consequences**:
+- Positive: unblocks a working first implementation now, using infrastructure (Sync,
+  freshness-gating, settle-detection, abort) that already exists and is already live-verified
+  tonight (#178's Fall-2 work).
+- Negative: if this feature is later used against a mount driver where repeated Sync does *not*
+  build a real multi-point model, the alignment run would silently produce no better accuracy than
+  a single-point Sync, despite appearing to complete N points successfully — worth a clear
+  driver-compatibility caveat in the GUI/docs once implemented, not just in this concept document.
+
+## 6. Installation / Test
+
+Not yet implemented — no installation/test surface exists yet. Once built, this inherits Mount
+Bridge's existing test surface (INDI Control Panel, `indi_getprop`/`indi_setprop`, the Control
+Center GUI, live verification under real sky) rather than introducing a new one. Given tonight's
+live-testing experience (`basic-memory/pifinder-stellarmate/00089` §7), testing methodology notes
+worth carrying forward:
+- Prefer real, continuous camera solving over synthetic `/api/fake_solve` injection when verifying
+  the median-of-N-solves step — synthetic injections showed non-deterministic drift under repeated
+  rapid calls tonight, which would confound testing an aggregation step specifically designed to
+  smooth out solve noise.
+- `/api/fake_solve`'s RA is in degrees, not hours — convert before any INDI property use (a real
+  ~23° mis-slew happened tonight from exactly this mistake).
+
+## 7. Effort / Priority
+
+- **Size**: M–L. The core sequence (§4.3) reuses existing settle/freshness/abort building blocks
+  almost entirely — the genuinely new pieces are candidate-point selection (§4.2, needs picking and
+  wiring up one of the two catalog sources), the median-of-N-solves aggregation (§4.3, not present
+  anywhere else in this codebase), and the new sequencing/progress UI. The KStars-model-feed
+  option (§4.5) is a separate, larger, research-first piece that could reasonably ship later than
+  the core feature.
+- **Priority**: high (per the user, 2026-08-09) — backlog, not yet "Ready" (needs the §4.2 catalog
+  decision and §4.5 research resolved, or at least a scoping decision to defer §4.5 to a follow-up,
+  before implementation can start).
+
+## 8. Relationship to the other two documents in this cluster
+
+- **`pifinder_mount_model_cloud_tracking.md`**: this concept is the first concrete use case that
+  would actually benefit from that document's proposed Align primitive (§4 there), even though
+  §4.5/§5 above conclude a first OnStep-only implementation doesn't strictly need it yet. If that
+  primitive gets built (for either concept's sake), this concept should switch to using it rather
+  than keeping a separate plain-Sync path indefinitely (see the ADR, §5 above).
+- **`mount_bridge_reposition_detection.md`**: this concept's per-point settle-then-solve step
+  (§4.3) is the same "wait for genuine stop, then wait for a fresh solve before trusting a new
+  position" discipline that document's UC2 already established for a single external reposition
+  event — same underlying primitive, applied here repeatedly across a planned sequence of points
+  instead of reactively to one unplanned external move. No new detection logic needed from that
+  document; this concept only *initiates* the moves (via its own sequencer), it doesn't need to
+  *detect* them as external, since Mount Bridge itself is the one commanding each GoTo.
+
+## Related
+
+- [GitHub issue #191](https://github.com/apos/PiFinder_Stellarmate/issues/191)
+- [`pifinder_mount_model_cloud_tracking.md`](pifinder_mount_model_cloud_tracking.md)
+- [`mount_bridge_reposition_detection.md`](mount_bridge_reposition_detection.md)
+- `basic-memory/pifinder-stellarmate/00089_indi-debugging-werkzeugkasten-auf-diesem-pi4.md` §7
+  (tonight's live-testing methodology notes, directly relevant to §6 above)

--- a/docs/concepts/mount_bridge_reposition_detection.md
+++ b/docs/concepts/mount_bridge_reposition_detection.md
@@ -6,6 +6,10 @@
 > [GitHub issue #178](https://github.com/apos/PiFinder_Stellarmate/issues/178) on
 > [Project #15](https://github.com/users/apos/projects/15) — update that issue if this concept is
 > promoted, revised, or dropped. Design context: `basic-memory/pifinder-stellarmate/00093`.
+>
+> **Overlaps with [`pifinder_mount_model_cloud_tracking.md`](pifinder_mount_model_cloud_tracking.md)**
+> - found late while writing this, see §8 for how the two relate. Read that document's §4-§5
+> before implementing either.
 
 ## 1. Overview
 
@@ -33,7 +37,7 @@ classification exists, the two-button split becomes unnecessary - a single mode 
 | UC1 | Push-to on PiFinder (on-device menu, or KStars Goto on "PiFinder LX200") | Only reacts if `MODE_GOTO_FORWARD` is active | Always forwards to the mount and becomes the new held target |
 | UC2 | GoTo commanded on the mount side - KStars on "LX200 OnStep", SkySafari, the OnStep app, or a hand-paddle/handbox connected directly to the OnStep controller over its own TCP/WiFi link (**not** through INDI at all - confirmed live 2026-08-08, IP `192.168.0.142`) | Only reacts if `MODE_AUTO_CORRECT`+Goto is active, and only reactively once drift already exceeds Threshold | Detected as soon as the mount's own `EQUATORIAL_EOD_COORD`/`ON_COORD_SET` change without Mount Bridge itself having issued the command; once settled and confirmed by a fresh PiFinder solve, becomes the new held target |
 | UC3 | Ordinary uncorrected sidereal drift (tracking intentionally off, see `00093`) | Corrected in `MODE_GOTO_FORWARD`'s `HOLDING` state (fixed tonight - see `00093` §1) | Unchanged: Sync+re-Goto back to the held target |
-| UC4 | Mechanical disturbance with the mount's clutch open (OTA moved by hand without the motor/encoders registering it - live-observed 2026-08-08, ~92° real drift from an eyepiece swap) | `MaxSyncDriftNP` already refuses to auto-Sync above its sanity limit (120', see `00093` §2) - but the driver has no way to explain *why* it's refusing | Same refusal, but explicitly classified and reported as "likely mechanical disturbance, not GoTo/paddle" rather than a generic "drift too large" warning - still requires a manual confirmation before Mount Bridge will trust the new position |
+| UC4 | Manual repositioning with the mount's clutch open - **a normal, deliberate workflow on friction-clutch mounts** (User's own equipment: an old Lichtenknecker mount built exactly this way, also used occasionally on the EQ-6; historically standard practice, not an edge case), indistinguishable in the data from an unintentional disturbance (bumped, wind, eyepiece caught) - live-observed 2026-08-08 as an *unintentional* instance, ~92° real drift from an eyepiece swap | `MaxSyncDriftNP` already refuses to auto-Sync above its sanity limit (120', see `00093` §2) | **Corrected 2026-08-08** (was: auto-refuse with just a warning): since intentional clutch-repositioning is common and this can't be told apart from an accidental disturbance by data alone, surface a single, low-friction confirmation ("Adopt new position?") instead of requiring a full manual Sync workflow - accept -> treated like UC2 (new held target); decline/no response -> stays held at the old target |
 
 ## 3. Architecture
 
@@ -180,6 +184,41 @@ Center GUI) rather than introducing a new one.
    2026-08-07 (see the issue's original direction).
 3. **Depends on this**: none currently identified - this is the terminal item in the Goto-Forward/
    Auto-Correct-Goto redesign chain that started with #170/#171 tonight.
+
+## 8. Relationship to `pifinder_mount_model_cloud_tracking.md`
+
+Found late while writing this document (should have been checked first, per the `cpt` procedure's
+own step 1 - corrected here rather than left as an undisclosed gap). Real, substantive overlap:
+
+- That document's §4 proposes an **Align** command - a Sync variant meaning "here is a verified
+  position, incorporate it into your model," explicitly distinct from a plain Sync's "reset your
+  current pointing to this." This concept's UC2/UC4 "adopt the new position as the held target"
+  step is the same underlying pattern, just in the opposite data-flow direction: that document is
+  about the **mount teaching PiFinder** (so PiFinder can keep tracking through cloud gaps using the
+  mount's own model as a fallback); this concept is about **Mount Bridge deciding what to hold**
+  once an external reposition is confirmed. Both need the same underlying primitive - "a verified
+  position update, not a blind reset" - so implementing one should produce a primitive reusable by
+  the other, not two independent Align-like mechanisms.
+- That document's §5 discusses reusing **#130 ("Mount is source")** for a mount-model role. #130 was
+  built, found buggy, and surgically removed (`basic-memory/basic-memory/00089_bm-git-development-workflow.md`
+  §2 - a 6-file, ~194-line removal because the feature wasn't isolated cleanly). This concept's UC2
+  does **not** revive #130 or make the mount an unconditional position source - it only ever adopts
+  a mount-side position after (a) an explicit, attributable command signal (§3.2 row 2) or (b) an
+  explicit user confirmation (§3.2 row 4, corrected), never silently or continuously. Worth being
+  explicit about this distinction given #130's history, so this isn't mistaken for the same failed
+  approach revisited.
+- That document's §7 references `complete_position_simulator.md`'s existing settle-detection
+  mechanism (movement stops -> a solve lands on the settled position, #106) as a precedent for
+  "detect motion has genuinely stopped before trusting a new position." This concept's UC2 needs the
+  same kind of settle detection (wait for the mount to actually finish moving, confirmed via
+  `isMountSlewing()`, before adopting) - same principle, already implemented once (#106) and once
+  more tonight (`isMountSlewing()`-gated `HOLDING`, see `00093` §1), should be the same shared
+  primitive a third time here, not a fourth bespoke implementation.
+
+**Practical consequence for sequencing**: before implementing this concept, revisit
+`pifinder_mount_model_cloud_tracking.md` and decide whether the "Align" primitive should be built
+once, shared by both concepts, rather than implementing this concept's UC2/UC4 adoption logic in a
+way that would need to be redone once the cloud-tracking concept is eventually tackled too.
 
 ## Related
 

--- a/docs/concepts/mount_bridge_reposition_detection.md
+++ b/docs/concepts/mount_bridge_reposition_detection.md
@@ -1,0 +1,189 @@
+# Concept: Mount Bridge Reposition Detection (Unifying "Follow mount's goto" / "Follow PiFinder's push to")
+
+> **Status: concept — not yet implemented.** Written via this project's `cpt` (concept)
+> convention — see `basic-memory/basic-memory/00020_bm-cpt-command-system.md` and
+> `00021_bm-documentation-depth-standard.md` for the standard this document follows. Tracked as
+> [GitHub issue #178](https://github.com/apos/PiFinder_Stellarmate/issues/178) on
+> [Project #15](https://github.com/users/apos/projects/15) — update that issue if this concept is
+> promoted, revised, or dropped. Design context: `basic-memory/pifinder-stellarmate/00093`.
+
+## 1. Overview
+
+Mount Bridge currently exposes two separate Coupling presets that both ultimately do the same
+kind of work (forward a new target, then hold it) but only react to one specific trigger each:
+**"Follow PiFinder's push to"** (`MODE_GOTO_FORWARD`, reacts only to a PiFinder push-to) and
+**"Follow mount's goto"** (`MODE_AUTO_CORRECT` + `CorrectionActionS[ACTION_GOTO]`, reacts only to
+drift exceeding Threshold, regardless of cause). Requiring the user to pre-select which side will
+initiate a GoTo does not match how these sessions actually unfold: a target might be pushed-to on
+PiFinder, then fine-corrected by hand at the eyepiece, then re-centered via SkySafari a few minutes
+later — real usage crosses both "sides" freely within the same observing run.
+
+Live testing (2026-08-07/08, see `basic-memory/pifinder-stellarmate/00093`) surfaced the concrete
+failure mode this concept fixes: after a PiFinder push-to, deliberate hand-paddle fine-centering
+(routine at high magnification) was actively fought by the automatic correction, which pulled the
+mount back toward the original catalog coordinate instead of accepting the newly, manually
+centered position. The fix generalizes past both existing modes: instead of asking "which side
+initiated this," classify **what kind of event just happened** and react accordingly. Once that
+classification exists, the two-button split becomes unnecessary - a single mode covers both.
+
+## 2. Use Cases
+
+| # | Trigger | Today's behavior | Wanted behavior |
+|---|---|---|---|
+| UC1 | Push-to on PiFinder (on-device menu, or KStars Goto on "PiFinder LX200") | Only reacts if `MODE_GOTO_FORWARD` is active | Always forwards to the mount and becomes the new held target |
+| UC2 | GoTo commanded on the mount side - KStars on "LX200 OnStep", SkySafari, the OnStep app, or a hand-paddle/handbox connected directly to the OnStep controller over its own TCP/WiFi link (**not** through INDI at all - confirmed live 2026-08-08, IP `192.168.0.142`) | Only reacts if `MODE_AUTO_CORRECT`+Goto is active, and only reactively once drift already exceeds Threshold | Detected as soon as the mount's own `EQUATORIAL_EOD_COORD`/`ON_COORD_SET` change without Mount Bridge itself having issued the command; once settled and confirmed by a fresh PiFinder solve, becomes the new held target |
+| UC3 | Ordinary uncorrected sidereal drift (tracking intentionally off, see `00093`) | Corrected in `MODE_GOTO_FORWARD`'s `HOLDING` state (fixed tonight - see `00093` §1) | Unchanged: Sync+re-Goto back to the held target |
+| UC4 | Mechanical disturbance with the mount's clutch open (OTA moved by hand without the motor/encoders registering it - live-observed 2026-08-08, ~92° real drift from an eyepiece swap) | `MaxSyncDriftNP` already refuses to auto-Sync above its sanity limit (120', see `00093` §2) - but the driver has no way to explain *why* it's refusing | Same refusal, but explicitly classified and reported as "likely mechanical disturbance, not GoTo/paddle" rather than a generic "drift too large" warning - still requires a manual confirmation before Mount Bridge will trust the new position |
+
+## 3. Architecture
+
+### 3.1 Context
+
+```mermaid
+flowchart LR
+    subgraph External clients
+        SS[SkySafari]
+        App[OnStep App]
+        HB["Hand-paddle (direct TCP/WiFi\nto OnStep controller, bypasses INDI)"]
+        KS[KStars]
+    end
+    OS[OnStep controller]
+    LX[INDI driver: LX200 OnStep]
+    MB[Mount Bridge]
+    PF[PiFinder LX200 / PiFinder camera]
+
+    SS -- TCP/WiFi, direct --> OS
+    App -- TCP/WiFi, direct --> OS
+    HB -- TCP/WiFi, direct --> OS
+    KS -- INDI --> LX
+    LX -- polls real state --> OS
+    MB -- watches via INDI --> LX
+    MB -- watches via INDI --> PF
+    MB -- Sync/Goto commands --> LX
+    KS -- INDI, push-to --> PF
+```
+
+The key architectural fact this concept relies on (confirmed live 2026-08-08): SkySafari, the
+OnStep app, and the physical hand-paddle all talk **directly** to the OnStep controller over its
+own TCP/WiFi interface - none of them go through INDI or Mount Bridge. But because the
+`LX200 OnStep` INDI driver polls the controller's real, authoritative state, any motion those
+clients cause is still visible to Mount Bridge indirectly, as a change to `EQUATORIAL_EOD_COORD`/
+`ON_COORD_SET` that Mount Bridge did not itself originate - the driver doesn't need to know *which*
+external client caused it, only that it wasn't Mount Bridge's own `sendMountCoords()` call.
+
+The one motion type genuinely invisible at every layer is UC4 (clutch open) - the OTA moves without
+driving the motors/encoders at all, so neither OnStep nor its INDI driver ever see it as a change.
+It only becomes visible indirectly, as a sudden disagreement between the mount's (now stale) belief
+about its own position and PiFinder's independently-solved, physically-true position.
+
+### 3.2 Decision matrix
+
+| # | Observable signal | Magnitude check | Classification | Action |
+|---|---|---|---|---|
+| 1 | `TARGET_EOD_COORD` (PiFinder) changes | - | PushTo (UC1) | Forward immediately, becomes new held target |
+| 2 | Mount's `ON_COORD_SET`/`EQUATORIAL_EOD_COORD` changes, **not** self-originated | - | External mount-side command (UC2) | Wait for settle + a fresh PiFinder solve confirms it, then becomes new held target |
+| 3 | No signal, PiFinder-vs-mount disagree | Within the physically possible sidereal drift rate (~0.25-0.3 arcmin/s, measured live) for the elapsed time | Ordinary uncorrected drift (UC3) | Sync+re-Goto back to the held target (today's `HOLDING`, unchanged) |
+| 4 | No signal, PiFinder-vs-mount disagree | Exceeds the physically possible drift rate | Likely mechanical disturbance (UC4) | Refuse to auto-Sync (`MaxSyncDriftNP` already does this) - explicitly reported as such, requires manual confirmation |
+
+Row 2 vs. row 4 is the crux of the whole design: both can produce an arbitrarily large, sudden
+position disagreement, but only row 2 has **evidence of an intentional command** (something told
+the mount to move, even if Mount Bridge doesn't know what). Row 4 has no such evidence - the mount
+itself has no idea it moved. That distinction, not the disagreement's size, is what decides
+"trust and adopt" vs. "refuse and ask."
+
+### 3.3 Runtime view: classification flow
+
+```mermaid
+flowchart TD
+    Tick[Timer tick] --> HasTarget{PiFinder TARGET_EOD_COORD changed?}
+    HasTarget -- yes --> UC1[UC1: PushTo - forward immediately]
+    HasTarget -- no --> SelfCmd{Mount state changed,\nself-originated by Mount Bridge?}
+    SelfCmd -- yes --> Ongoing[Our own in-flight correction - wait for isMountSlewing()==false, unchanged from tonight's HOLDING fix]
+    SelfCmd -- no, but mount state changed anyway --> UC2[UC2: external mount command - wait settle + fresh solve, adopt new position]
+    SelfCmd -- no change observed --> Drift{PiFinder vs mount drift > Threshold?}
+    Drift -- no --> Idle[Nothing to do - holding correctly]
+    Drift -- yes --> RateCheck{Disagreement within\nphysical drift-rate bound?}
+    RateCheck -- yes --> UC3[UC3: ordinary drift - Sync+re-Goto to held target]
+    RateCheck -- no --> UC4[UC4: likely mechanical disturbance - refuse auto-Sync, report, await manual confirmation]
+```
+
+### 3.4 Building blocks: consolidating `ForwardState`/`CorrectState`
+
+Found live 2026-08-08 while designing this: `ForwardState` (`indi_pifinder_bridge/pifinder_mount_bridge.h`,
+today's "Follow PiFinder's push to") and `CorrectState` (today's "Follow mount's goto") are two
+independently-maintained state machines implementing nearly the same Sync+re-Goto refine loop, with
+separate parallel variables (`m_settleRetriesRemaining`/`m_correctSettleRetriesRemaining`,
+`m_settleTicksRemaining`/`m_correctSettleTicksRemaining`, ...). Tonight's `HOLDING` refinement (no
+artificial settle delay for ongoing corrections, gated on `isMountSlewing()` instead - see `00093`
+§1) was applied to `ForwardState::HOLDING` only; `CorrectState` still carries the old fixed-delay
+behavior. This concept's implementation is the natural point to merge both into one shared
+mechanism (one state enum, one set of retry/settle variables, one `applySlewRateForDrift()`/
+`MaxSyncDriftNP` gate - both already shared today) rather than perpetuating two copies.
+
+### 3.5 Cross-cutting concerns
+
+- **Freshness gating (#79 pattern)**: UC2's "adopt new position" step must wait for a genuinely
+  fresh PiFinder camera solve before committing, same discipline already used everywhere else in
+  Mount Bridge - never adopt a position confirmed only by IMU-interpolated data.
+- **`MaxSyncDriftNP` safety cap**: unchanged, still the hard backstop for UC4 - this concept adds a
+  *classification* on top of the existing refusal, it doesn't relax the refusal itself.
+- **Distinguishing our own commands**: requires Mount Bridge to track "did I just issue this
+  `sendMountCoords()` call" (a short in-flight flag/timestamp set at the call site, cleared once
+  the resulting slew completes) so an external change can be told apart from our own in-progress
+  correction.
+
+## 4. ADR: classify by signal + magnitude, not by which button was pressed
+
+**Context**: the original two-button design (#178, decided 2026-08-07) required the user to
+pre-select which side (mount or PiFinder) would initiate GoTos. Live testing showed this doesn't
+match real usage, and additionally fights legitimate manual fine-centering.
+
+**Decision**: instead of a mode selector, classify every observed reposition event by (a) whether
+an intentional command signal was observed at all, and (b) if not, whether the magnitude of the
+resulting disagreement is physically explainable by passive sidereal drift alone. This works
+uniformly across PushTo, mount-side GoTo, SkySafari, the OnStep app, and a hand-paddle wired
+directly to the OnStep controller (all of which are invisible to Mount Bridge as *distinct*
+sources, but all show up as "the mount moved, and I didn't do it") - without needing to know which
+one actually happened.
+
+**Consequences**:
+- Positive: no manual mode switch to get wrong or forget (same "just works" principle already
+  applied to Shadow Sync auto-arming tonight, see `00093` §5's predecessor discussion); a single
+  mechanism replaces two GUI presets and two parallel state machines.
+- Negative: UC4 (clutch-open) and "a very large but genuine GoTo" (row 2) can only be told apart if
+  row 2's command signal was actually observed - if the mount's own state polling has any gap
+  (e.g., a dropped INDI connection during the exact window a GoTo was issued), a legitimate GoTo
+  could be misclassified as UC4 and require manual confirmation it wouldn't otherwise need. Judged
+  an acceptable, safety-conservative trade-off ("ask when unsure" beats "silently trust a
+  disturbance").
+
+## 5. Installation / Test
+
+Not yet implemented - no installation/test surface exists yet. Once built, this inherits Mount
+Bridge's existing test surface (INDI Control Panel, `indi_getprop`/`indi_setprop`, the Control
+Center GUI) rather than introducing a new one.
+
+## 6. Effort / Priority
+
+- **Size**: L (state-machine consolidation + new classification logic + live verification across
+  all 4 use cases with real hardware).
+- **Priority**: medium (queued, unblocked - #171 merged, no longer a dependency).
+
+## 7. Strategic roadmap
+
+1. **Prerequisite (done)**: #171 (on-device PushTo detection) - merged via
+   [PR #182](https://github.com/apos/PiFinder_Stellarmate/pull/182).
+2. **This concept's implementation** (not started): consolidate `ForwardState`/`CorrectState` into
+   one shared state machine (§3.4), add the "self-originated vs. external" command tracking (§3.5),
+   add the drift-rate classification (§3.2 row 3 vs. 4), replace the two-button GUI split with the
+   single "GoTo" button + read-only "Following: Mount"/"Following: PiFinder" badge already decided
+   2026-08-07 (see the issue's original direction).
+3. **Depends on this**: none currently identified - this is the terminal item in the Goto-Forward/
+   Auto-Correct-Goto redesign chain that started with #170/#171 tonight.
+
+## Related
+
+- [GitHub issue #178](https://github.com/apos/PiFinder_Stellarmate/issues/178)
+- `basic-memory/pifinder-stellarmate/00093_goto-forward-holding-architektur-und-solve-kadenz-flaschenhals.md`
+- `basic-memory/pifinder-stellarmate/00009_indi-mount-bridge-concept.md` (original Mount Bridge concept)
+- [PR #182](https://github.com/apos/PiFinder_Stellarmate/pull/182), [PR #183](https://github.com/apos/PiFinder_Stellarmate/pull/183)

--- a/docs/concepts/mount_bridge_reposition_detection.md
+++ b/docs/concepts/mount_bridge_reposition_detection.md
@@ -37,7 +37,7 @@ classification exists, the two-button split becomes unnecessary - a single mode 
 | UC1 | Push-to on PiFinder (on-device menu, or KStars Goto on "PiFinder LX200") | Only reacts if `MODE_GOTO_FORWARD` is active | Always forwards to the mount and becomes the new held target |
 | UC2 | GoTo commanded on the mount side - KStars on "LX200 OnStep", SkySafari, the OnStep app, or a hand-paddle/handbox connected directly to the OnStep controller over its own TCP/WiFi link (**not** through INDI at all - confirmed live 2026-08-08, IP `192.168.0.142`) | Only reacts if `MODE_AUTO_CORRECT`+Goto is active, and only reactively once drift already exceeds Threshold | Detected as soon as the mount's own `EQUATORIAL_EOD_COORD`/`ON_COORD_SET` change without Mount Bridge itself having issued the command; once settled and confirmed by a fresh PiFinder solve, becomes the new held target |
 | UC3 | Ordinary uncorrected sidereal drift (tracking intentionally off, see `00093`) | Corrected in `MODE_GOTO_FORWARD`'s `HOLDING` state (fixed tonight - see `00093` §1) | Unchanged: Sync+re-Goto back to the held target |
-| UC4 | Manual repositioning with the mount's clutch open - **a normal, deliberate workflow on friction-clutch mounts** (User's own equipment: an old Lichtenknecker mount built exactly this way, also used occasionally on the EQ-6; historically standard practice, not an edge case), indistinguishable in the data from an unintentional disturbance (bumped, wind, eyepiece caught) - live-observed 2026-08-08 as an *unintentional* instance, ~92° real drift from an eyepiece swap | `MaxSyncDriftNP` already refuses to auto-Sync above its sanity limit (120', see `00093` §2) | **Corrected 2026-08-08** (was: auto-refuse with just a warning): since intentional clutch-repositioning is common and this can't be told apart from an accidental disturbance by data alone, surface a single, low-friction confirmation ("Adopt new position?") instead of requiring a full manual Sync workflow - accept -> treated like UC2 (new held target); decline/no response -> stays held at the old target |
+| UC4 | Manual repositioning with the mount's clutch open - **a normal, deliberate workflow on friction-clutch mounts** (User's own equipment: an old Lichtenknecker mount built exactly this way, also used occasionally on the EQ-6; historically standard practice, not an edge case), indistinguishable in the data from an unintentional disturbance (bumped, wind, eyepiece caught) - live-observed 2026-08-08 as an *unintentional* instance, ~92° real drift from an eyepiece swap | `MaxSyncDriftNP` already refuses to auto-Sync above its sanity limit (120', see `00093` §2) | **Corrected 2026-08-08** (was: auto-refuse with just a warning): since intentional clutch-repositioning is common and this can't be told apart from an accidental disturbance by data alone, surface a single, low-friction confirmation ("Adopt new position?"). **Yes** -> treated like UC2, new position becomes the held target. **No, or no response within a timeout** -> this was a slip, not intentional - actively Sync+re-Goto the mount back to the still-correct held target (a one-time, explicitly user-authorized override of `MaxSyncDriftNP`'s normal refusal, not a silent bypass of it - without this, the mount would otherwise sit at the wrong position indefinitely, since the sanity cap would keep blocking any *future* automatic correction of the same gap too) |
 
 ## 3. Architecture
 
@@ -87,7 +87,7 @@ about its own position and PiFinder's independently-solved, physically-true posi
 | 1 | `TARGET_EOD_COORD` (PiFinder) changes | - | PushTo (UC1) | Forward immediately, becomes new held target |
 | 2 | Mount's `ON_COORD_SET`/`EQUATORIAL_EOD_COORD` changes, **not** self-originated | - | External mount-side command (UC2) | Wait for settle + a fresh PiFinder solve confirms it, then becomes new held target |
 | 3 | No signal, PiFinder-vs-mount disagree | Within the physically possible sidereal drift rate (~0.25-0.3 arcmin/s, measured live) for the elapsed time | Ordinary uncorrected drift (UC3) | Sync+re-Goto back to the held target (today's `HOLDING`, unchanged) |
-| 4 | No signal, PiFinder-vs-mount disagree | Exceeds the physically possible drift rate | Likely mechanical disturbance (UC4) | Refuse to auto-Sync (`MaxSyncDriftNP` already does this) - explicitly reported as such, requires manual confirmation |
+| 4 | No signal, PiFinder-vs-mount disagree | Exceeds the physically possible drift rate | Deliberate clutch-reposition or accidental disturbance (UC4) - indistinguishable from data alone | Refuse to auto-Sync (`MaxSyncDriftNP` already does this), surface a low-friction "Adopt new position?" confirmation - Yes -> adopt; No/timeout -> actively correct back to the held target |
 
 Row 2 vs. row 4 is the crux of the whole design: both can produce an arbitrarily large, sudden
 position disagreement, but only row 2 has **evidence of an intentional command** (something told
@@ -108,7 +108,10 @@ flowchart TD
     Drift -- no --> Idle[Nothing to do - holding correctly]
     Drift -- yes --> RateCheck{Disagreement within\nphysical drift-rate bound?}
     RateCheck -- yes --> UC3[UC3: ordinary drift - Sync+re-Goto to held target]
-    RateCheck -- no --> UC4[UC4: likely mechanical disturbance - refuse auto-Sync, report, await manual confirmation]
+    RateCheck -- no --> UC4["UC4: clutch-reposition or accidental disturbance -\nrefuse auto-Sync, ask 'Adopt new position?'"]
+    UC4 --> UC4Yes{User response}
+    UC4Yes -- yes --> UC4Adopt[Adopt new position as held target]
+    UC4Yes -- no / timeout --> UC4Revert[Actively Sync+re-Goto back to the held target]
 ```
 
 ### 3.4 Building blocks: consolidating `ForwardState`/`CorrectState`

--- a/gui_installer/help.html
+++ b/gui_installer/help.html
@@ -78,8 +78,7 @@
         <li><a href="#coupling">Coupling &amp; Autoconnect</a>
           <ul>
             <li><a href="#coupling-visual">Visual group</a></li>
-            <li><a href="#coupling-goto-mount">Goto Mount group</a></li>
-            <li><a href="#coupling-goto-pifinder">Goto PiFinder group</a></li>
+            <li><a href="#coupling-goto">GoTo group</a></li>
           </ul>
         </li>
         <li><a href="#drift-badge">Drift readout</a></li>
@@ -192,27 +191,23 @@
 <p>Connects (or disconnects) each device's own <code>CONNECTION</code> property. <strong>Connect all (available)</strong> connects everything that's ready and not yet connected in one click - it turns green and becomes <strong>Disconnect all</strong> once everything is already connected. "PiFinder LX200" is a special case: it's automatically pointed at PiFinder's own internal position server (<code>127.0.0.1:4030</code>, fixed on every install) before connecting, since left on its default it would otherwise try to use a serial port - which is what your real mount's own driver usually needs instead.</p>
 
 <h3 id="coupling">Coupling &amp; Autoconnect</h3>
-<p>Four one-click presets, applied to the Mount Bridge driver:</p>
+<p>Three one-click presets, applied to the Mount Bridge driver:</p>
 <ul>
   <li><strong>Verify/Alert only</strong>: watches the drift between PiFinder's solved position and the mount's reported position. Never moves the mount - just a passive "is my mount still aligned?" check.</li>
   <li><strong>Auto-correct (Sync)</strong>: same watching, but corrects the mount by syncing it to PiFinder's solved position once drift exceeds the Threshold - an instant position update, no slewing, works on any mount.</li>
-  <li><strong>Follow mount's goto</strong> (internally "Auto-correct (Goto &amp; Track)"): same watching, but corrects by slewing the mount to PiFinder's solved position once drift exceeds the Threshold - actually moves the mount, needs a Goto-capable mount.</li>
-  <li><strong>Follow PiFinder's push to</strong> (internally "Goto-Forward"): forwards every push-to/goto target sent to PiFinder - from its own on-device menu, or KStars' Goto on the "PiFinder LX200" device - straight through to the real mount too, keeping them moving together. Threshold doesn't decide whether a Goto happens (every new PiFinder target is forwarded regardless) - but it does decide whether the arrival needs refining, and, once settled, whether the mount is <strong>held</strong> there afterward: if the mount later drifts past Threshold (ordinary tracking imperfection, or someone bumping it), it's synced (correcting its model) and sent the Goto again to pull it back - repeating as needed, exactly like Auto-correct, until a new push-to target replaces the held one.</li>
+  <li><strong>GoTo</strong> (internally "Goto-Forward" plus Reposition Detection, #178): holds whichever target was most recently, deliberately set - no need to pick a side. Reacts automatically to <em>either</em> a PiFinder push-to (its own on-device menu, or KStars' Goto on "PiFinder LX200") <em>or</em> a mount-side reposition (KStars' Goto on the mount, SkySafari, the mount's own app/hand controller, or a manual correction at the eyepiece) - whichever happens most recently becomes the new held target. A small "Following: PiFinder"/"Following: Mount" badge next to the button shows which one, read-only. Threshold governs whether an arrival needs refining, and, once settled, whether the mount is <strong>held</strong> there afterward: ordinary tracking drift is corrected automatically; a sudden, unexplained jump too large to be passive drift (e.g. a mount clutch released) asks for a quick confirmation instead of guessing.</li>
 </ul>
 <p>The active mode is highlighted green.</p>
 
 <h4 id="coupling-visual">Visual group</h4>
 <p><strong>Verify/Alert only</strong> and <strong>Auto-correct (Sync)</strong> never slew the mount - a Sync is an instant position update, not a physical move - so both work on any mount, Goto-capable or not. This matches two of this project's original use cases: astrophotography's passive "is my mount still correctly aligned?" sanity check (Verify/Alert), and a manual push-to-then-correct workflow where you slew by hand until PiFinder shows on-target, and Auto-correct (Sync) straightens out whatever drift results afterward.</p>
 
-<h4 id="coupling-goto-mount">Goto Mount group</h4>
-<p><strong>Follow mount's goto</strong> physically slews the mount, so it needs a real Goto-capable mount. The mount is the one that moves to correct drift - you (or the mount's own controls/KStars) drive the mount directly, and this preset continuously corrects any resulting drift by slewing it back onto PiFinder's solved position.</p>
-
-<h4 id="coupling-goto-pifinder">Goto PiFinder group</h4>
-<p><strong>Follow PiFinder's push to</strong> also physically slews the mount, so it too needs a real Goto-capable mount - but the direction is reversed from the group above: PiFinder is the one you drive (a push-to on its own menu, or KStars' Goto on the "PiFinder LX200" device), and every new PiFinder target is forwarded to the mount regardless of Threshold. This matches this project's standalone-visual-use case - PiFinder becomes the single GoTo interface. Threshold still governs whether the arrival needs refining afterward (see above).</p>
+<h4 id="coupling-goto">GoTo group</h4>
+<p><strong>GoTo</strong> physically slews the mount, so it needs a real Goto-capable mount. Unlike the two-button split this replaced (2026-08-07/08, see #178), you don't pre-select whether PiFinder or the mount drives - drive either one, and GoTo picks it up: a PiFinder push-to gets forwarded to the mount immediately; a mount-side reposition (GoTo, hand controller, SkySafari, ...) gets adopted as the new held target once it settles and PiFinder confirms it with a fresh solve. Either way, the result is then <strong>held</strong> - ordinary drift gets corrected automatically, and a jump too sudden to be passive sky motion asks for confirmation rather than assuming it was a mistake (useful on mounts where releasing the clutch to reposition by hand is normal practice).</p>
 
 <p><strong>Setup</strong>: runs steps 1-4/6 above in one click (start profile, add drivers, connect - pausing for you to link your mount, the one step it can't decide for you) without applying any Coupling preset at the end. Use this to get everything ready first, then pick a mode deliberately once it's all connected.</p>
 <p><strong>Autoconnect</strong>: clicking any preset before steps 1-6 are actually finished doesn't just fail - it runs the exact same setup as the Setup button above automatically, then applies the coupling mode you originally clicked once it's done. The Setup button exists so you're not only discovering this by clicking a preset and seeing setup start unexpectedly.</p>
-<p><strong>Manual: Sync mount from PiFinder</strong>: a one-shot action, works regardless of which Coupling preset (or none) is active. Syncs the mount to PiFinder's current solved position right now - no Goto, no drift comparison, just an instant correction. Useful specifically after moving the mount by hand: none of the Coupling presets react to that on their own (Auto-correct and, once it has settled onto a held target, "Follow PiFinder's push to" both only react on their next poll if drift already exceeds Threshold - Verify/Alert only warns, never corrects at all).</p>
+<p><strong>Manual: Sync mount from PiFinder</strong>: a one-shot action, works regardless of which Coupling preset (or none) is active. Syncs the mount to PiFinder's current solved position right now - no Goto, no drift comparison, just an instant correction. Auto-correct (Sync) and Verify/Alert still only react to a manual mount move on their next poll if drift already exceeds Threshold (Verify/Alert only warns, never corrects) - GoTo is the one mode that reacts to a manual move directly, as described above.</p>
 
 <h3 id="drift-badge">Drift readout</h3>
 <p>The large number top-right of the tile is the current angular drift between PiFinder's solved position and the mount's reported position, in arcminutes:</p>

--- a/gui_installer/help.html
+++ b/gui_installer/help.html
@@ -88,7 +88,8 @@
 </div>
 
 <h2 id="quick-links">Quick Links</h2>
-<p>Direct links to things you'd otherwise have to look up: PiFinder's own remote page (its web UI), the INDI/mount setup wizard running on PiFinder itself, this Control Center's own address (useful if you're bookmarking it or opening it on another device), and the project's documentation on GitHub. The status line at the top reflects whether PiFinder's web server is answering at all - it can say "running" even if a piece of hardware (camera, IMU, GPS) is missing, since that's a separate check (see Mode &amp; Power below).</p>
+<p>Direct links to things you'd otherwise have to look up: PiFinder's own remote page (its web UI), the INDI/mount setup wizard running on PiFinder itself, this Control Center's own address (useful if you're bookmarking it or opening it on another device), the INDI Web Manager, the StellarMate Dashboard/Web VNC, the connected mount's own web UI (only shown once it's known - see below), and the project's documentation/community links on GitHub/readthedocs/Discord. The status line at the top reflects whether PiFinder's web server is answering at all - it can say "running" even if a piece of hardware (camera, IMU, GPS) is missing, since that's a separate check (see Mode &amp; Power below).</p>
+<p>Rows that list one entry per IP (This page, INDI Web Manager, StellarMate Dashboard, StellarMate Web VNC, OnStep Web UI) show each as a small button labeled with just the last two octets - hover or long-press for the full address. <strong>OnStep Web UI</strong>'s address isn't guessed: it's read live from the mount driver's own INDI connection settings, so it only appears once the mount is actually connected via TCP (a serial/USB-connected mount has no IP to show here). <strong>Open all links</strong> opens PiFinder Remote, INDI Web Manager, StellarMate Dashboard, and OnStep Web UI (whichever are currently known) each in a new tab in one click - most browsers only allow the first of several tabs opened this way through by default and silently block the rest, so a note appears next to the button if any were blocked; allow popups for this page in that case and click again.</p>
 <p><strong>Quick keys</strong>, next to the OLED mirror, drive PiFinder's own on-screen menu without switching to its separate Remote page. Three layouts, switched top-right and remembered per browser: <strong>A</strong> (a D-pad cross), <strong>B</strong> (a 2x4 grid) - both send the same Left/Up/Down/Right/Enter/Long presses PiFinder's Remote page does - and <strong>C</strong>, which isn't a keypad at all but one button per PiFinder found on the network (labeled by its last two IP octets), opening that PiFinder's full Remote page directly for whenever the compact keypad isn't enough. A keypad briefly dims after each press while it's in flight - PiFinder's own web server only handles one request at a time, so rapid clicks queue up rather than getting lost.</p>
 
 <h2 id="mode-power">Mode &amp; Power</h2>
@@ -166,7 +167,7 @@
 </ul>
 
 <h2 id="mount-bridge">Mount Bridge</h2>
-<p>Couples PiFinder's own solved sky position with a real telescope mount, via the <strong>PiFinder Mount Bridge</strong> INDI driver - so you don't need to open the separate INDI Control Panel for the common cases. The tile is organized as a numbered setup checklist (below the divider line) plus a live status/operate area (above it): connection diagram, Coupling presets, and the drift readout.</p>
+<p>Couples PiFinder's own solved sky position with a real telescope mount, via the <strong>PiFinder Mount Bridge</strong> INDI driver - so you don't need to open the separate INDI Control Panel for the common cases. The live connection diagram and drift readout live in the <strong>PiFinder</strong> tile (directly under the Cam/Solve/IMU/GPS badges - both are status displays, grouped with the rest of the page's own status info). This tile itself is organized as a numbered setup checklist (below the divider line) plus the actual operate area above it: Coupling presets, Sync/Stop, Threshold, and Role.</p>
 <p>Each numbered step shows a green checkmark once it's actually satisfied, and a yellow spinning symbol while its own action is running.</p>
 
 <h3 id="step1-profile">1. Profile</h3>
@@ -210,13 +211,13 @@
 <p><strong>Manual: Sync mount from PiFinder</strong>: a one-shot action, works regardless of which Coupling preset (or none) is active. Syncs the mount to PiFinder's current solved position right now - no Goto, no drift comparison, just an instant correction. Auto-correct (Sync) and Verify/Alert still only react to a manual mount move on their next poll if drift already exceeds Threshold (Verify/Alert only warns, never corrects) - GoTo is the one mode that reacts to a manual move directly, as described above.</p>
 
 <h3 id="drift-badge">Drift readout</h3>
-<p>The large number top-right of the tile is the current angular drift between PiFinder's solved position and the mount's reported position, in arcminutes:</p>
+<p>In the <strong>PiFinder</strong> tile's connection diagram (see above), the number between the Bridge and Mount icons is the current angular drift between PiFinder's solved position and the mount's reported position, in arcminutes - shown as degrees+arcmin past 60' (e.g. <code>1&deg; 5'</code> instead of <code>65'</code>):</p>
 <ul>
   <li><span class="dot dot-green"></span><strong>Green</strong>: within the Threshold you've set.</li>
   <li><span class="dot dot-yellow"></span><strong>Yellow</strong>: past the Threshold.</li>
   <li><span class="dot dot-red"></span><strong>Red</strong>: past roughly 0.5&deg; (about the diameter of a full moon) - a generic placeholder for "probably out of your eyepiece's field of view," not a measurement of your actual eyepiece/camera.</li>
 </ul>
-<p>Only shown while coupling is actively watching drift (Verify/Alert or Auto-correct) and connected - hidden otherwise.</p>
+<p>Only shown while coupling is actively watching drift (Verify/Alert or Auto-correct) and connected - hidden otherwise. The short status line below the diagram (a colored dot plus a one-line label) reflects the same state in words; click "Details" next to it for the full explanation instead of it being shown inline, which used to change the row's height and shift the rest of the page around every time the text changed length.</p>
 
 <p class="close-note">This help page is a static file served alongside the Control Center - it isn't kept open or polled by the main page, so it's safe to leave it in its own tab while you work.</p>
 </body>

--- a/gui_installer/indi_client.py
+++ b/gui_installer/indi_client.py
@@ -241,6 +241,16 @@ def mount_bridge_status(
         default) - a quick "is Mount Bridge pointed at the right things"
         sanity check, surfaced in the tile per user request rather than
         only being visible via the INDI Control Panel.
+      - "mount_web_ip": str or None - the mount device's own DEVICE_ADDRESS.
+        ADDRESS, i.e. the IP the mount driver itself connects to, but only
+        when CONNECTION_MODE says that connection is CONNECTION_TCP (a
+        serial/USB-connected mount has no IP at all here). This is the same
+        IP the mount's own onboard web UI listens on (OnStep's WiFi module
+        serves both its LX200 command port and its web interface from the
+        same address) - added 2026-08-09 for the Control Center's "open all
+        the important links at once" button, no separate INDI round-trip
+        needed since mt_props below already has the mount's full property
+        set from the connection-state lookup just above it.
     All fields besides "running" are None (or False for settings_correct)
     if the device isn't running/known. `device_timeout` is shorter than
     `timeout` for the two extra per-device lookups (kept modest since this
@@ -267,6 +277,7 @@ def mount_bridge_status(
             "target_source": None,
             "mount_reject_active": False,
             "mount_reject_message": None,
+            "mount_web_ip": None,
         }
 
     active_devices = device_props.get("ACTIVE_DEVICES", {}).get("elements", {})
@@ -313,9 +324,15 @@ def mount_bridge_status(
         pifinder_connected = _connection_state(pf_props.get(active_pifinder))
 
     mount_connected = None
+    mount_web_ip = None
     if active_mount:
         mt_props = get_properties(device=active_mount, host=host, port=port, timeout=device_timeout)
-        mount_connected = _connection_state(mt_props.get(active_mount))
+        mt_device_props = mt_props.get(active_mount)
+        mount_connected = _connection_state(mt_device_props)
+        if mt_device_props:
+            mount_connection_mode = mt_device_props.get("CONNECTION_MODE", {}).get("elements", {})
+            if mount_connection_mode.get("CONNECTION_TCP") == "On":
+                mount_web_ip = mt_device_props.get("DEVICE_ADDRESS", {}).get("elements", {}).get("ADDRESS") or None
 
     return {
         "running": True,
@@ -336,6 +353,7 @@ def mount_bridge_status(
         "target_source": target_source,
         "mount_reject_active": mount_reject_active,
         "mount_reject_message": mount_reject_message,
+        "mount_web_ip": mount_web_ip,
     }
 
 

--- a/gui_installer/indi_client.py
+++ b/gui_installer/indi_client.py
@@ -265,6 +265,8 @@ def mount_bridge_status(
             "settings_port": None,
             "settings_correct": False,
             "target_source": None,
+            "mount_reject_active": False,
+            "mount_reject_message": None,
         }
 
     active_devices = device_props.get("ACTIVE_DEVICES", {}).get("elements", {})
@@ -281,6 +283,12 @@ def mount_bridge_status(
     target_source_elements = device_props.get("TARGET_SOURCE", {}).get("elements", {})
     target_source_raw = next((name for name, val in target_source_elements.items() if val == "On"), None)
     target_source = {"TARGET_SOURCE_PIFINDER": "pifinder", "TARGET_SOURCE_MOUNT": "mount"}.get(target_source_raw)
+    # Mount refused a Goto/Sync outright (elevation/cable-wrap/axis limit) -
+    # distinct from ordinary drift, see MOUNT_REJECT's own comment in
+    # pifinder_mount_bridge.cpp. IPS_ALERT means still active.
+    mount_reject_prop = device_props.get("MOUNT_REJECT", {})
+    mount_reject_active = mount_reject_prop.get("state") == "Alert"
+    mount_reject_message = mount_reject_prop.get("elements", {}).get("MESSAGE") or None
     correction_action_elements = device_props.get("CORRECTION_ACTION", {}).get("elements", {})
     correction_action_raw = next((name for name, val in correction_action_elements.items() if val == "On"), None)
     correction_action = {"ACTION_SYNC": "sync", "ACTION_GOTO": "goto"}.get(correction_action_raw)
@@ -326,6 +334,8 @@ def mount_bridge_status(
         "settings_port": settings_port,
         "settings_correct": settings_correct,
         "target_source": target_source,
+        "mount_reject_active": mount_reject_active,
+        "mount_reject_message": mount_reject_message,
     }
 
 
@@ -352,7 +362,14 @@ def mount_bridge_drift(
     props = get_properties(device="PiFinder Mount Bridge", host=host, port=port, timeout=timeout)
     device_props = props.get("PiFinder Mount Bridge")
     if not device_props:
-        return {"running": False, "coupling_mode": None, "correction_action": None, "drift_arcmin": None}
+        return {
+            "running": False,
+            "coupling_mode": None,
+            "correction_action": None,
+            "drift_arcmin": None,
+            "mount_reject_active": False,
+            "mount_reject_message": None,
+        }
 
     bridge_mode = device_props.get("BRIDGE_MODE", {}).get("elements", {})
     drift_status_prop = device_props.get("DRIFT_STATUS", {})
@@ -362,11 +379,16 @@ def mount_bridge_drift(
     correction_action_raw = next((name for name, val in correction_action_elements.items() if val == "On"), None)
     correction_action = {"ACTION_SYNC": "sync", "ACTION_GOTO": "goto"}.get(correction_action_raw)
     drift_raw = drift_status.get("DRIFT_ARCMIN")
+    mount_reject_prop = device_props.get("MOUNT_REJECT", {})
+    mount_reject_active = mount_reject_prop.get("state") == "Alert"
+    mount_reject_message = mount_reject_prop.get("elements", {}).get("MESSAGE") or None
 
     return {
         "running": True,
         "coupling_mode": coupling_mode,
         "correction_action": correction_action,
+        "mount_reject_active": mount_reject_active,
+        "mount_reject_message": mount_reject_message,
         # DRIFT_STATUS's own INDI state (Ok/Busy/Alert/Idle) - in
         # MODE_AUTO_CORRECT specifically, the driver sets Busy while
         # actually sending a correction vs. Alert when drift exceeds the

--- a/gui_installer/indi_client.py
+++ b/gui_installer/indi_client.py
@@ -264,6 +264,7 @@ def mount_bridge_status(
             "settings_host": None,
             "settings_port": None,
             "settings_correct": False,
+            "target_source": None,
         }
 
     active_devices = device_props.get("ACTIVE_DEVICES", {}).get("elements", {})
@@ -274,6 +275,12 @@ def mount_bridge_status(
     bridge_settings = device_props.get("BRIDGE_SETTINGS", {}).get("elements", {})
 
     coupling_mode = next((name for name, val in bridge_mode.items() if val == "On"), None)
+    # #178 unified GoTo button: read-only "who does the held target come
+    # from" badge (TARGET_SOURCE_PIFINDER/TARGET_SOURCE_MOUNT) - see
+    # docs/concepts/mount_bridge_reposition_detection.md.
+    target_source_elements = device_props.get("TARGET_SOURCE", {}).get("elements", {})
+    target_source_raw = next((name for name, val in target_source_elements.items() if val == "On"), None)
+    target_source = {"TARGET_SOURCE_PIFINDER": "pifinder", "TARGET_SOURCE_MOUNT": "mount"}.get(target_source_raw)
     correction_action_elements = device_props.get("CORRECTION_ACTION", {}).get("elements", {})
     correction_action_raw = next((name for name, val in correction_action_elements.items() if val == "On"), None)
     correction_action = {"ACTION_SYNC": "sync", "ACTION_GOTO": "goto"}.get(correction_action_raw)
@@ -318,6 +325,7 @@ def mount_bridge_status(
         "settings_host": settings_host,
         "settings_port": settings_port,
         "settings_correct": settings_correct,
+        "target_source": target_source,
     }
 
 

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -1264,7 +1264,7 @@ def _run_hardware_test():
             _hwtest_running = False
 
 
-def _startup_hardware_test(timeout=120, interval=2):
+def _startup_hardware_test(timeout=120, interval=2, extended_retry_interval=15):
     """Runs at Control Center startup (see main()). pifinder-control-center.
     service has no ordering dependency on pifinder.service (deliberately -
     the Control Center must be able to start standalone, e.g. before PiFinder
@@ -1276,13 +1276,41 @@ def _startup_hardware_test(timeout=120, interval=2):
     clicked the button by hand (live-reproduced across two reboots - see
     basic-memory pifinder-stellarmate/00048). Poll for PiFinder to answer
     first, then run the real test - if it never comes up within `timeout`,
-    run anyway (accurately reports "not running" rather than waiting forever)."""
+    run anyway (accurately reports "not running" rather than waiting forever).
+
+    Found live (2026-08-09, #188) after a full Pi reboot (not just a Control
+    Center restart): PiFinder can take noticeably longer than this initial
+    `timeout` to become reachable, competing with everything else the whole
+    system is starting at once (X11, KStars, indiserver, ...) - the original
+    design's own tradeoff ("run anyway, accurately reports not-running") then
+    left a stale "PiFinder API unreachable" result sitting there with nothing
+    to self-correct it once PiFinder actually did come up moments later,
+    same symptom as before the 00048 fix just with a longer boot this time.
+    Self-heals now: if the first attempt still couldn't reach PiFinder, keep
+    quietly re-running the test every extended_retry_interval seconds,
+    indefinitely, stopping as soon as PiFinder answers - each check is cheap
+    (one HTTP call plus, once reachable, the same lightweight camera/imu/gps
+    checks the button itself triggers) and this loop's whole purpose is
+    stopping itself the moment it succeeds, so there's no real cost to not
+    giving up after some arbitrary window - the alternative (silently
+    staying stale forever after a slow-but-real boot) is worse than a few
+    more harmless checks."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if _pifinder_status_snapshot(ports=("80", "8080")) is not None or _fake_mode_up():
             break
         time.sleep(interval)
     _run_hardware_test()
+
+    while True:
+        with _lock:
+            still_unreachable = _hwtest_result.get("gps") is None
+        if not still_unreachable:
+            break
+        time.sleep(extended_retry_interval)
+        if _pifinder_status_snapshot(ports=("80", "8080")) is None and not _fake_mode_up():
+            continue  # still not reachable - no point re-running the test yet
+        _run_hardware_test()
 
 
 def _pifinder_solve_status(port: str):

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -224,6 +224,15 @@
     vertical-align: middle;
   }
   .help-link:hover { color: #ccc; border-color: #999; }
+  /* Pinned to the OLED thumbnail's own corner (2026-08-09, direct feedback)
+     rather than sitting inline with the tile heading like the other
+     .help-link uses - this one specifically documents the OLED screen
+     itself, so it stays visually attached to it. #pifinder-screen-wrap is
+     already position:relative (see #pifinder-screen-waiting above it). */
+  .pifinder-screen-help {
+    position: absolute; top: 3px; right: 3px;
+    background: rgba(0, 0, 0, 0.55);
+  }
   .refresh-link {
     display: inline-block;
     margin-left: 0.4rem;
@@ -355,7 +364,6 @@
     min-width: 180px;
     justify-content: center;
   }
-  #pifinder-status-line { font-weight: bold; }
   #pf-keypad-style-switch { display: flex; flex-shrink: 0; }
   .pf-keypad-style-btn {
     background: #2a2a2a;
@@ -373,7 +381,7 @@
   #pf-keypad-a {
     display: flex;
     align-items: center;
-    gap: 2.6rem;
+    gap: 1rem;
   }
   .pf-key {
     background: #232323;
@@ -393,6 +401,16 @@
     transform: scale(0.92);
     filter: brightness(1.4);
   }
+  /* Distinct from the plain press-flash above (2026-08-09, direct feedback:
+     the D-pad "just doesn't work") - pfSendKey() used to fail completely
+     silently (PiFinder unreachable, wrong ?port=, login rejected, etc) while
+     still flashing the ordinary "pressed" look, so a press that did nothing
+     looked identical to one that worked. This red flash only fires on an
+     actual failure, held longer than the press-flash so it's clearly seen. */
+  .pf-key.pf-key-error, .pf-key-long-square.pf-key-error {
+    background: #5c1f1f;
+    border-color: #e53935;
+  }
   #pf-keypad-a .pf-key { height: 46px; }
   .pf-arrow { width: 28px; height: 28px; fill: currentColor; }
   #pf-keypad-a .pf-arrow { width: 23px; height: 23px; }
@@ -410,9 +428,9 @@
     border: 1px solid #3a3a3a;
     border-radius: 8px;
     color: #ccc;
-    width: 95px;
-    height: 95px;
-    font-size: 0.8rem;
+    width: 47px;
+    height: 47px;
+    font-size: 0.6rem;
     cursor: pointer;
     flex-shrink: 0;
     transition: transform 0.08s ease, filter 0.08s ease;
@@ -468,6 +486,26 @@
   .status-dot.dot-unconfirmed { background: #f5a623; border-color: #f5a623; animation: mb-status-pulse 1.1s ease-in-out infinite; }
   .ql-section { margin-top: 0.4rem; }
   .ql-label { color: #888; margin-right: 0.4rem; }
+  /* Plain-text "ip:port  ip:port  ip:port" rows read as a wall of digits and
+     wrap unpredictably (2026-08-09, direct feedback: "als Button wie oben in
+     der PiFinder Kachel") - same small-button look already used for Quick
+     keys layout C's per-IP buttons (.pf-keypad-c-btn), just sized for this
+     denser list. Full "ip:port" only in the tooltip; the button itself shows
+     just the last two octets, same reasoning as lastTwoOctets()'s own
+     comment (first two rarely differ on one LAN). */
+  .ql-ip-btn {
+    display: inline-block;
+    background: #232323;
+    border: 1px solid #3a3a3a;
+    border-radius: 6px;
+    color: #ccc;
+    font-size: 0.74rem;
+    padding: 0.15rem 0.5rem;
+    text-decoration: none;
+  }
+  .ql-ip-btn:hover { border-color: #777; color: #fff; }
+  .ql-section a { margin-right: 0.6rem; }
+  .ql-section a:last-child { margin-right: 0; }
   #ql-links a {
     color: #7ec8ff;
     text-decoration: none;
@@ -563,6 +601,12 @@
   .ql-small-btn:disabled { background: #1a1a1a; color: #666; border-color: #333; cursor: default; }
   .ql-small-btn:not(:disabled):hover { border-color: #777; color: #fff; }
   .ql-small-btn.mb-btn-active { border-color: #4caf50; background: #1c2a1c; color: #4caf50; }
+  /* Browsers only let one window.open() through per click by default and
+     silently block the rest (2026-08-09, found live: "Open all links" only
+     ever opened the first tab, PiFinder Remote) - openAllQuickLinks() below
+     now checks each call's return value and surfaces this instead of
+     leaving the missing tabs unexplained. */
+  #ql-open-all-note { color: #f5a623; font-size: 0.72rem; margin-left: 0.5rem; }
   /* Shared sizing for Sync/Stop (2026-08-09, direct feedback: these two are
      frequent, important, mode-independent actions and need the same visual
      weight as the coupling presets) - a self-contained base rather than
@@ -783,15 +827,18 @@
   .mb-role-card-title { font-weight: bold; color: #ddd; font-size: 0.8rem; }
   .mb-role-card.mb-role-active .mb-role-card-title { color: #4caf50; }
   .mb-role-card-sub { color: #999; font-size: 0.72rem; margin-top: 2px; line-height: 1.35; }
+  /* Column, not row (2026-08-09, direct feedback: the blue action-status
+     banner used to sit inline next to the status line via space-between,
+     which shoved/reflowed the status line sideways whenever the banner
+     appeared. Stacking it on its own line below keeps the status line's
+     position fixed regardless of whether an action is in flight. */
   #mb-status-row {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 0.6rem;
+    flex-direction: column;
+    gap: 0.3rem;
     margin-bottom: 0.6rem;
   }
   #mb-status-line {
-    font-weight: bold;
     white-space: nowrap;
   }
   #mount-bridge-unconfirmed {
@@ -820,8 +867,6 @@
     border-radius: 6px;
     padding: 0.4rem 0.7rem;
     font-size: 0.8rem;
-    flex-shrink: 0;
-    max-width: 60%;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -933,14 +978,35 @@
   .mb-arrow.mb-arrow-read { color: #5b9bd5; }
   .mb-arrow.mb-arrow-write { color: #f5a623; font-weight: bold; }
   .mb-arrow.mb-arrow-goto { color: #4caf50; font-weight: bold; }
-  #mb-mode-caption-row { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.6rem; }
-  #mb-mode-caption { color: #888; font-size: 0.76rem; }
-  /* Same danger palette as .mb-abort-btn - the mount's own driver refused a
-     Goto/Sync (elevation/cable-wrap/axis limit), distinct from ordinary
-     drift (yellow/red badge above). */
-  #mb-reject-warning-row {
-    display: flex; align-items: center; gap: 0.4rem; margin-bottom: 0.6rem;
-    padding: 0.4rem 0.6rem; border-radius: 6px;
+  /* Fixed-height row, deliberately short caption text (2026-08-09, direct
+     feedback: the previous long, variable-length sentence directly in this
+     row reflowed the whole page every time drift/mode changed - "das macht
+     alles sehr unruhig"). Dot+short-label follows the same ampel convention
+     every other status line on this page already uses (see basic-memory
+     00017) - no bespoke badge/icon. The full explanatory sentence moves to
+     #mb-mode-details, an ordinary collapsible section (opt-in, touch-
+     friendly, doesn't reflow anything unless the user actually opens it). */
+  #mb-mode-caption-row { display: flex; align-items: center; gap: 0.4rem; height: 1.3rem; margin-bottom: 0.6rem; }
+  /* Dot+text share ONE flex item on purpose (2026-08-09, direct feedback:
+     dot/text baseline mismatch) - as two separate flex items, align-items:
+     center centers each by its own box height, which does not match the
+     dot's vertical-align:middle look used everywhere else on this page
+     (#pifinder-status-line, #mb-status-line, etc). Keeping them in a single
+     non-flex inline wrapper lets vertical-align do the same job here too. */
+  #mb-mode-caption-dot-text { min-width: 0; overflow: hidden; }
+  #mb-mode-caption { color: #ccc; font-size: 0.78rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  #mb-mode-details-toggle { color: #777; font-size: 0.72rem; cursor: pointer; margin-left: auto; flex: none; white-space: nowrap; }
+  #mb-mode-details-toggle:hover { color: #ccc; }
+  #mb-mode-details { color: #999; font-size: 0.76rem; line-height: 1.4; margin: -0.2rem 0 0.6rem 0; }
+  /* Small inline toggle appended to #mb-status-line (2026-08-09, direct
+     feedback - see updateMountRejectWarning()'s own comment for why this
+     replaced the old always-reflowing standalone warning row). Same danger
+     color as .mb-abort-btn, but text-only/no background - it's a small
+     addition to an existing line, not its own alert box. */
+  #mb-reject-warning-toggle { margin-left: 0.6rem; color: #ff8a80; cursor: pointer; white-space: nowrap; }
+  #mb-reject-warning-toggle:hover { color: #ffb3ab; }
+  #mb-reject-warning-details {
+    margin: 0.4rem 0 0.6rem 0; padding: 0.4rem 0.6rem; border-radius: 6px;
     background: #3a1414; color: #ff8a80; border: 1px solid #e53935;
     font-size: 0.8rem;
   }
@@ -1171,7 +1237,6 @@
     margin: 0.3rem 0 0.8rem;
     font-size: 0.85rem;
   }
-  #mb-role-line .role-name { font-weight: bold; }
   #mb-role-line .role-detail { color: #999; }
   #mb-role-line .role-warn { color: #e0a030; }
 </style>
@@ -1212,6 +1277,7 @@
         <div id="pifinder-screen-wrap">
           <img id="pifinder-screen" src="/pifinder_welcome.png" alt="PiFinder screen" title="PiFinder OLED screen (live once running)">
           <div id="pifinder-screen-waiting">Waiting for<br>PiFinder&hellip;</div>
+          <a class="help-link pifinder-screen-help" href="https://pifinder.readthedocs.io/en/release/user_guide.html" target="_blank" rel="noopener" title="PiFinder User Guide">i</a>
         </div>
         <!-- Quick keys: same LEFT/UP/DOWN/RIGHT/SQUARE(+LNG_ Long-combo) codes
              PiFinder's own remote.html sends to /key_callback, proxied
@@ -1305,18 +1371,16 @@
             <div id="system-load-line" title="CPU load average relative to core count - not an error, just a heads-up: a genuinely busy Pi can make PiFinder's own position server briefly slow to answer (see the LX200/Mount Bridge docs for details)."><span class="status-dot dot-white" id="system-load-dot"></span><span id="system-load-text">Checking system load…</span></div>
           </div>
         </div>
-      </div>
-    <div id="mount-bridge-tile">
-      <!-- Current status first: connection diagram, Coupling, Threshold -
-           the "operate it" workflow, always visible. The one-time "set it
-           up" rows (Profile/Drivers/Mount/Connect) plus Ekos status, bridge
-           settings, and the log collapse behind #mb-details-toggle - see
-           its own CSS comment. -->
-      <div class="tile-heading-row" onclick="toggleTileBody('mount-bridge-body', 'mount-bridge-tile-chevron')">
-        <h3 class="tile-heading" title="Couples PiFinder's solved position with your mount via the Mount Bridge INDI driver - connect the pieces, then pick a coupling mode.">INDI Mount Bridge<a class="help-link" href="/help.html#mount-bridge" target="_blank" rel="noopener" title="Help" onclick="event.stopPropagation()">i</a></h3>
-        <span class="tile-chevron" id="mount-bridge-tile-chevron">&#9650;</span>
-      </div>
-      <div id="mount-bridge-body">
+      <!-- Mount Bridge diagram/status moved here (2026-08-09, direct
+           feedback: "das ist ja auch eine Infogruppe von Icons... gehören
+           direkt unter die Cam, Solve... Gruppe") - both are pure info/
+           status displays, unlike the Mount Bridge tile's own remaining
+           content (Coupling presets, Sync/Stop, Threshold, Role), which is
+           all settings/actions, not status. IDs/onclick handlers unchanged,
+           only their position moved - see updateProfileRoleLine() for the
+           "PiFinder host" role hiding this whole group too. -->
+      <div class="hgroup-divider"></div>
+      <div class="group-label">Mount Bridge<a class="help-link" href="/help.html#mount-bridge" target="_blank" rel="noopener" title="Help">i</a></div>
       <div id="mb-diagram">
         <div class="mb-node" id="mb-node-lx200" title="PiFinder">
           <svg class="mb-icon" id="mb-icon-lx200" viewBox="0 0 24 24" aria-hidden="true">
@@ -1350,15 +1414,27 @@
         </div>
       </div>
       <div id="mb-mode-caption-row">
-        <span id="mb-mode-caption">Not coupled yet</span>
+        <span id="mb-mode-caption-dot-text"><span class="status-dot dot-white" id="mb-mode-caption-dot"></span><span id="mb-mode-caption">Not coupled yet</span></span>
+        <span id="mb-mode-details-toggle" style="display:none;" onclick="toggleCollapsibleSection('mb-mode-details', 'mb-mode-details-chevron')">Details <span id="mb-mode-details-chevron">&#9660;</span></span>
       </div>
-      <div id="mb-reject-warning-row" style="display:none;" title="The mount's own driver reported that it refused the last Goto/Sync - most likely an elevation or cable-wrap/axis limit. Not retrying the same command automatically - check the mount and its limit settings.">
-        <span>&#9888;</span><span id="mb-reject-warning-text"></span>
-      </div>
+      <div id="mb-mode-details" style="display:none;"></div>
       <div id="mb-status-row">
-        <div id="mb-status-line"><span class="status-dot dot-white" id="mount-bridge-dot"></span><span id="mount-bridge-text">checking&hellip;</span><span id="mount-bridge-unconfirmed" style="display:none;" title="Our own status check couldn't reach Mount Bridge just now - this is very likely just that check's own timing, not a real disconnect (see Help). Showing the last confirmed state below; interactive buttons are paused until we can confirm again."> (unconfirmed)</span></div>
+        <div id="mb-status-line"><span class="status-dot dot-white" id="mount-bridge-dot"></span><span id="mount-bridge-text">checking&hellip;</span><span id="mount-bridge-unconfirmed" style="display:none;" title="Our own status check couldn't reach Mount Bridge just now - this is very likely just that check's own timing, not a real disconnect (see Help). Showing the last confirmed state below; interactive buttons are paused until we can confirm again."> (unconfirmed)</span><span id="mb-reject-warning-toggle" style="display:none;" onclick="toggleCollapsibleSection('mb-reject-warning-details', 'mb-reject-warning-chevron')" title="The mount's own driver reported that it refused the last Goto/Sync - most likely an elevation or cable-wrap/axis limit. Not retrying the same command automatically - check the mount and its limit settings.">&#9888; Warning - Details <span id="mb-reject-warning-chevron">&#9660;</span></span></div>
         <div id="mb-action-status"></div>
       </div>
+      <div id="mb-reject-warning-details" style="display:none;"><span id="mb-reject-warning-text"></span></div>
+      </div>
+    <div id="mount-bridge-tile">
+      <!-- Current status first: connection diagram, Coupling, Threshold -
+           the "operate it" workflow, always visible. The one-time "set it
+           up" rows (Profile/Drivers/Mount/Connect) plus Ekos status, bridge
+           settings, and the log collapse behind #mb-details-toggle - see
+           its own CSS comment. -->
+      <div class="tile-heading-row" onclick="toggleTileBody('mount-bridge-body', 'mount-bridge-tile-chevron')">
+        <h3 class="tile-heading" title="Couples PiFinder's solved position with your mount via the Mount Bridge INDI driver - connect the pieces, then pick a coupling mode.">INDI Mount Bridge<a class="help-link" href="/help.html#mount-bridge" target="_blank" rel="noopener" title="Help" onclick="event.stopPropagation()">i</a></h3>
+        <span class="tile-chevron" id="mount-bridge-tile-chevron">&#9650;</span>
+      </div>
+      <div id="mount-bridge-body">
       <div class="hgroup-divider"></div>
       <!-- Everything from coupling presets to manual sync is meaningless in
            the "PiFinder host" role (no Mount Bridge in the profile) - this
@@ -1587,17 +1663,21 @@ sudo systemctl start pifinder</pre>
           </div>
         </div>
         <div class="collapsible-toggle" onclick="toggleCollapsibleSection('ql-links', 'ql-links-chevron')">
-          <span>Links<a class="help-link" href="/help.html#quick-links" target="_blank" rel="noopener" title="Help" onclick="event.stopPropagation()">i</a></span>
+          <span>Links<a class="help-link" href="/help.html#quick-links" target="_blank" rel="noopener" title="Help" onclick="event.stopPropagation()">i</a><button class="ql-small-btn" onclick="event.stopPropagation(); openAllQuickLinks();" title="Opens PiFinder Remote, INDI Web Manager, StellarMate Dashboard and (if known) the OnStep Web UI, each in a new tab">Open all links</button><span id="ql-open-all-note" style="display:none;"></span></span>
           <span id="ql-links-chevron">&#9660; show</span>
         </div>
         <div id="ql-links" style="display:none;">
-          <div class="ql-section"><span class="ql-label">PiFinder Remote Page:</span><span id="pifinder-remote-link">not available yet</span></div>
-          <div class="ql-section"><span class="ql-label">INDI driver setup on PiFinder:</span><span id="wizard-link">not available yet</span></div>
+          <div class="ql-section"><span id="pifinder-remote-link">PiFinder Remote Page: not available yet</span></div>
+          <div class="ql-section"><span id="wizard-link">INDI driver setup on PiFinder: not available yet</span></div>
           <div class="ql-section"><span class="ql-label">This page:</span><span id="remote-links"></span></div>
           <div class="ql-section"><span class="ql-label">INDI Web Manager:</span><span id="indi-webmanager-links"></span></div>
           <div class="ql-section"><span class="ql-label">StellarMate Dashboard:</span><span id="sm-dashboard-links"></span></div>
           <div class="ql-section"><span class="ql-label">StellarMate Web VNC:</span><span id="sm-vnc-links"></span> (password: <code>smate</code>)</div>
-          <div class="ql-section"><span class="ql-label">GitHub:</span><a href="https://github.com/apos/PiFinder_Stellarmate#readme" target="_blank" rel="noopener">Project docs</a><a href="https://github.com/apos/PiFinder_Stellarmate/blob/main/Readme_PiFinder_LX200.md" target="_blank" rel="noopener">INDI / LX200 docs</a></div>
+          <div class="ql-section" id="onstep-web-row" style="display:none;"><span class="ql-label">OnStep Web UI:</span><span id="onstep-web-link"></span></div>
+          <div class="hgroup-divider"></div>
+          <div class="ql-section"><span class="ql-label">PFSM GitHub:</span><a href="https://github.com/apos/PiFinder_Stellarmate#readme" target="_blank" rel="noopener">Project docs</a><a href="https://github.com/apos/PiFinder_Stellarmate/blob/main/Readme_PiFinder_LX200.md" target="_blank" rel="noopener">INDI / LX200 docs</a></div>
+          <div class="ql-section"><span class="ql-label">PiFinder:</span><a href="https://pifinder.readthedocs.io/en/release/user_guide.html" target="_blank" rel="noopener">User Guide</a><a href="https://www.pifinder.io/support" target="_blank" rel="noopener">Support</a><a href="https://discord.gg/PFhduXzv5" target="_blank" rel="noopener">Discord</a></div>
+          <div class="ql-section"><span class="ql-label">StellarMate:</span><a href="https://stellarmate.com/" target="_blank" rel="noopener">stellarmate.com</a><a href="https://discord.gg/6ptpCwGUF" target="_blank" rel="noopener">Discord</a></div>
         </div>
       </div>
       </div>
@@ -1832,7 +1912,9 @@ function renderServiceLinks(elId, ips, port) {
     el.innerHTML = 'n/a';
     return;
   }
-  el.innerHTML = ips.map(ip => `<a href="http://${ip}:${port}/" target="_blank" rel="noopener">${ip}:${port}</a>`).join('');
+  el.innerHTML = ips.map(ip =>
+    `<a class="ql-ip-btn" href="http://${ip}:${port}/" target="_blank" rel="noopener" title="${ip}:${port}">${lastTwoOctets(ip)}</a>`
+  ).join('');
 }
 
 function renderRemoteLinks(ips, port) {
@@ -1841,7 +1923,9 @@ function renderRemoteLinks(ips, port) {
     el.innerHTML = 'n/a';
     return;
   }
-  el.innerHTML = ips.map(ip => `<a href="http://${ip}:${port}/">${ip}:${port}</a>`).join('');
+  el.innerHTML = ips.map(ip =>
+    `<a class="ql-ip-btn" href="http://${ip}:${port}/" title="${ip}:${port}">${lastTwoOctets(ip)}</a>`
+  ).join('');
 }
 
 // Reflects whether PiFinder itself is currently reachable (same probe that
@@ -2195,10 +2279,11 @@ let pfLongArmed = false;
 // too brief to register on a fast click/tap. This flash keeps the pressed
 // look for a fixed short moment instead, so every press gets visible
 // feedback regardless of how quickly the click completes.
-function pfFlashKey(el) {
+function pfFlashKey(el, error) {
   if (!el) return;
-  el.classList.add('pf-key-pressed');
-  setTimeout(() => el.classList.remove('pf-key-pressed'), 150);
+  const cls = error ? 'pf-key-error' : 'pf-key-pressed';
+  el.classList.add(cls);
+  setTimeout(() => el.classList.remove(cls), error ? 500 : 150);
 }
 
 function pfToggleLong(btn) {
@@ -2222,13 +2307,18 @@ async function pfSendKey(code, btn) {
   pfKeyBusy = true;
   document.getElementById('pf-keypad-a').classList.add('pf-keypad-busy');
   document.getElementById('pf-keypad-b').classList.add('pf-keypad-busy');
-  pfFlashKey(btn);
   if (!pifinderScreenUrl) {
+    // Screen mirror hasn't been discovered (yet) - _pifinder_send_key() has
+    // no host/port to send to at all. Used to fall through silently here,
+    // which is indistinguishable from a working press from the pressed-flash
+    // alone - flash red instead so a dead keypad actually looks dead.
+    pfFlashKey(btn, true);
     pfKeyBusy = false;
     document.getElementById('pf-keypad-a').classList.remove('pf-keypad-busy');
     document.getElementById('pf-keypad-b').classList.remove('pf-keypad-busy');
     return;
   }
+  pfFlashKey(btn);
   const port = new URL(pifinderScreenUrl).port || '80';
   if (pfLongArmed) {
     code = `LNG_${code}`;
@@ -2237,20 +2327,28 @@ async function pfSendKey(code, btn) {
     document.getElementById('pf-key-long-b').classList.remove('pf-armed');
   }
   try {
-    await fetch(`/api/pifinder_key?port=${port}&key=${code}`, { method: 'POST' });
-    // The normal OLED mirror only ticks once a second (refreshPiFinderScreen's
-    // own setTimeout chain) - after a press, force one extra fetch right now
-    // instead of waiting up to a second for that chain's next tick, so the
-    // screen visibly reacts to the press instead of looking like it needs a
-    // manual page reload to catch up. A plain one-off src update, not a call
-    // to refreshPiFinderScreen() itself - that function reschedules its own
-    // next tick via onload/onerror, so calling it again here would spawn a
-    // second parallel polling chain instead of just refreshing once.
-    if (pifinderScreenUrl) {
+    const resp = await fetch(`/api/pifinder_key?port=${port}&key=${code}`, { method: 'POST' });
+    // _pifinder_send_key() (server.py) returns false - without raising -
+    // for a bad ?port=, a rejected login (default Remote-page password
+    // changed), or PiFinder just not answering. That used to be swallowed
+    // here entirely; check it explicitly now so those failures are visible
+    // instead of looking exactly like a successful press.
+    const result = await resp.json().catch(() => ({ success: false }));
+    if (!result.success) {
+      pfFlashKey(btn, true);
+    } else if (pifinderScreenUrl) {
+      // The normal OLED mirror only ticks once a second (refreshPiFinderScreen's
+      // own setTimeout chain) - after a press, force one extra fetch right now
+      // instead of waiting up to a second for that chain's next tick, so the
+      // screen visibly reacts to the press instead of looking like it needs a
+      // manual page reload to catch up. A plain one-off src update, not a call
+      // to refreshPiFinderScreen() itself - that function reschedules its own
+      // next tick via onload/onerror, so calling it again here would spawn a
+      // second parallel polling chain instead of just refreshing once.
       document.getElementById('pifinder-screen').src = pifinderScreenUrl + '?t=' + Date.now();
     }
   } catch (e) {
-    // best-effort - the OLED mirror image below will just not have moved
+    pfFlashKey(btn, true);
   } finally {
     pfKeyBusy = false;
     document.getElementById('pf-keypad-a').classList.remove('pf-keypad-busy');
@@ -3599,6 +3697,8 @@ function restoreCollapsibleSections() {
     ['ext-hw-status', 'ext-hw-chevron', 'block'],
     ['mode-power-groups', 'mode-power-chevron', 'flex'],
     ['mb-details', 'mb-details-chevron', 'block'],
+    ['mb-mode-details', 'mb-mode-details-chevron', 'block'],
+    ['mb-reject-warning-details', 'mb-reject-warning-chevron', 'block'],
   ];
   for (const [contentId, chevronId, openDisplay] of sections) {
     let saved = null;
@@ -3719,6 +3819,19 @@ function updateTargetSourceBadge(mode, targetSource) {
 
 const MB_FOV_LIMIT_ARCMIN = 30;  // 0.5 degrees (full-moon diameter) - generic assumption, not measured; see CSS comment on #mb-drift-badge
 
+// Arcminutes read awkwardly once they cross 60' (e.g. "65.3'") - switch to
+// degrees+arcmin past that point (2026-08-09, direct feedback: "65 dann 1°
+// 5'"). Below 60' keeps the existing one-decimal arcmin display unchanged.
+function formatDrift(driftArcmin) {
+  if (driftArcmin >= 60) {
+    const totalMin = Math.round(driftArcmin);
+    const deg = Math.floor(totalMin / 60);
+    const min = totalMin % 60;
+    return `${deg}° ${min}'`;
+  }
+  return `${driftArcmin.toFixed(1)}'`;
+}
+
 function updateDriftBadge(driftArcmin, threshold) {
   const badge = document.getElementById('mb-drift-badge');
   if (driftArcmin === null || driftArcmin === undefined) {
@@ -3726,7 +3839,7 @@ function updateDriftBadge(driftArcmin, threshold) {
     return;
   }
   badge.style.display = '';
-  badge.textContent = `${driftArcmin.toFixed(1)}'`;
+  badge.textContent = formatDrift(driftArcmin);
   badge.classList.remove('mb-drift-green', 'mb-drift-yellow', 'mb-drift-red');
   if (driftArcmin >= MB_FOV_LIMIT_ARCMIN) badge.classList.add('mb-drift-red');
   else if (driftArcmin > threshold) badge.classList.add('mb-drift-yellow');
@@ -3798,10 +3911,29 @@ function readThresholdInputRaw() {
   return document.getElementById('wm-threshold-input').value.replace(',', '.');
 }
 
+// Sets the fixed-height caption (dot + short label) and, separately, the
+// opt-in #mb-mode-details text - see #mb-mode-caption-row's own CSS comment
+// for why these are split (2026-08-09, direct feedback: the previous single
+// long/variable-length caption reflowed the whole page on every drift/mode
+// change).
+function setMbCaption(dotClass, shortLabel, longDetails) {
+  document.getElementById('mb-mode-caption-dot').className = 'status-dot ' + dotClass;
+  document.getElementById('mb-mode-caption').textContent = shortLabel;
+  const toggleEl = document.getElementById('mb-mode-details-toggle');
+  const detailsEl = document.getElementById('mb-mode-details');
+  if (longDetails) {
+    toggleEl.style.display = '';
+    detailsEl.textContent = longDetails;
+  } else {
+    toggleEl.style.display = 'none';
+    detailsEl.style.display = 'none';
+    detailsEl.textContent = '';
+  }
+}
+
 let wmLastCouplingMode = null;
 function applyMbDriftAndMode(couplingMode, correctionAction, driftArcmin, driftState) {
   wmLastCouplingMode = couplingMode;
-  const captionEl = document.getElementById('mb-mode-caption');
   const threshold = parseFloat(readThresholdInputRaw()) || 5;
   updateDriftBadge(driftArcmin, threshold);
   updateCouplingButtons(couplingMode, correctionAction);
@@ -3815,7 +3947,7 @@ function applyMbDriftAndMode(couplingMode, correctionAction, driftArcmin, driftS
   if (!couplingMode || couplingMode === 'MODE_OFF') {
     setMbArrow('mb-arrow-left', 'off');
     setMbArrow('mb-arrow-right', 'off');
-    captionEl.textContent = 'Not coupled - PiFinder and mount move independently';
+    setMbCaption('dot-white', 'Not coupled', null);
     decoupleBtnEl.disabled = true;
     return false;
   }
@@ -3829,9 +3961,13 @@ function applyMbDriftAndMode(couplingMode, correctionAction, driftArcmin, driftS
     // looked identical to being well within it - nothing on the tile said
     // so except the small numeric badge's own color.
     const exceeded = driftArcmin !== null && driftArcmin > threshold;
-    captionEl.textContent = exceeded
-      ? `Drift ${driftArcmin.toFixed(1)}' exceeds ${threshold}' - warning only, never moves the mount`
-      : 'Watching for drift - warns only, never moves the mount';
+    setMbCaption(
+      exceeded ? 'dot-yellow' : 'dot-green',
+      exceeded ? 'Drift exceeds threshold' : 'Watching for drift',
+      exceeded
+        ? `Drift ${formatDrift(driftArcmin)} exceeds ${threshold}' - warning only, never moves the mount`
+        : 'Watching for drift - warns only, never moves the mount'
+    );
   } else if (couplingMode === 'MODE_AUTO_CORRECT') {
     setMbArrow('mb-arrow-left', 'read');
     const exceeded = driftArcmin !== null && driftArcmin > threshold;
@@ -3844,11 +3980,15 @@ function applyMbDriftAndMode(couplingMode, correctionAction, driftArcmin, driftS
     // 2026-08-05, PiFinder's last solve was several minutes old).
     const gated = exceeded && driftState === 'Alert';
     setMbArrow('mb-arrow-right', exceeded && !gated ? 'write' : 'read');
-    captionEl.textContent = gated
-      ? `Drift ${driftArcmin.toFixed(1)}' exceeds ${threshold}', but PiFinder's last solve isn't fresh enough to correct from yet`
-      : exceeded
-      ? `Correcting the mount now - drift ${driftArcmin.toFixed(1)}' exceeds ${threshold}'`
-      : `Watching for drift - will correct the mount past ${threshold}'`;
+    setMbCaption(
+      gated ? 'dot-unconfirmed' : exceeded ? 'dot-yellow' : 'dot-green',
+      gated ? 'Waiting on fresh solve' : exceeded ? 'Correcting now' : 'Watching for drift',
+      gated
+        ? `Drift ${formatDrift(driftArcmin)} exceeds ${threshold}', but PiFinder's last solve isn't fresh enough to correct from yet`
+        : exceeded
+        ? `Correcting the mount now - drift ${formatDrift(driftArcmin)} exceeds ${threshold}'`
+        : `Watching for drift - will correct the mount past ${threshold}'`
+    );
   } else if (couplingMode === 'MODE_GOTO_FORWARD') {
     setMbArrow('mb-arrow-left', 'goto');
     // Same three-way pattern as Auto-correct above (found live 2026-08-08:
@@ -3861,13 +4001,17 @@ function applyMbDriftAndMode(couplingMode, correctionAction, driftArcmin, driftS
     const exceeded = driftArcmin !== null && driftArcmin > threshold;
     const busy = driftState === 'Busy';
     setMbArrow('mb-arrow-right', busy ? 'write' : 'goto');
-    captionEl.textContent = busy
-      ? `Correcting the mount now - drift ${driftArcmin.toFixed(1)}' exceeds ${threshold}'`
-      : exceeded
-      ? `Drift ${driftArcmin.toFixed(1)}' exceeds ${threshold}' - waiting on a fresh PiFinder solve (or drift is too large to auto-sync) before correcting`
-      : `Holding target - drift ${driftArcmin !== null ? driftArcmin.toFixed(1) : '0.0'}' within ${threshold}'`;
+    setMbCaption(
+      busy ? 'dot-yellow' : exceeded ? 'dot-unconfirmed' : 'dot-green',
+      busy ? 'Correcting now' : exceeded ? 'Waiting on fresh solve' : 'Holding target',
+      busy
+        ? `Correcting the mount now - drift ${formatDrift(driftArcmin)} exceeds ${threshold}'`
+        : exceeded
+        ? `Drift ${formatDrift(driftArcmin)} exceeds ${threshold}' - waiting on a fresh PiFinder solve (or drift is too large to auto-sync) before correcting`
+        : `Holding target - drift ${driftArcmin !== null ? formatDrift(driftArcmin) : '0.0\''} within ${threshold}'`
+    );
   }
-  const drift = driftArcmin !== null ? ` (drift ${driftArcmin.toFixed(1)}')` : '';
+  const drift = driftArcmin !== null ? ` (drift ${formatDrift(driftArcmin)})` : '';
   document.getElementById('mount-bridge-text').textContent =
     `${couplingMode.replace('MODE_', '').replace('_', ' ').toLowerCase()}${drift}`;
   return true;
@@ -3882,6 +4026,68 @@ function updateMbDiagram(data) {
   syncThresholdInputFromDriver(data.drift_threshold);
   applyMbDriftAndMode(data.coupling_mode, data.correction_action, data.drift_arcmin, data.drift_state);
   updateTargetSourceBadge(data.coupling_mode, data.target_source);
+  updateOnStepWebLink(data.mount_web_ip);
+}
+
+// The mount's own DEVICE_ADDRESS (indi_client.py's mount_bridge_status(),
+// only set for a TCP-connected mount, e.g. OnStep's WiFi module) doubles as
+// its onboard web UI's address - same device, default HTTP port 80 there.
+// Kept as a plain module-level var (not read back out of the DOM) so
+// openAllQuickLinks() below can use it without re-parsing anything.
+let onstepWebIp = null;
+function updateOnStepWebLink(ip) {
+  onstepWebIp = ip || null;
+  const row = document.getElementById('onstep-web-row');
+  const link = document.getElementById('onstep-web-link');
+  if (!onstepWebIp) {
+    row.style.display = 'none';
+    return;
+  }
+  row.style.display = '';
+  link.innerHTML = `<a class="ql-ip-btn" href="http://${onstepWebIp}/" target="_blank" rel="noopener" title="http://${onstepWebIp}/">${lastTwoOctets(onstepWebIp)}</a>`;
+}
+
+// One click, every reachable "important" link in its own tab - per direct
+// request, so the user isn't hunting through this collapsed section one
+// link at a time. Each window.open() call happens synchronously inside this
+// click handler (no fetch/await first) - popup blockers allow that; an
+// async gap before opening would get later ones blocked. Silently skips
+// whatever isn't known yet (e.g. onstepWebIp before the mount's ever been
+// seen TCP-connected) rather than erroring - same "n/a runs of missing data
+// are normal, not broken" spirit as the rest of this Links section.
+function openAllQuickLinks() {
+  let opened = 0;
+  let blocked = 0;
+  // window.open() returns null (Chrome/Firefox) when the popup blocker ate
+  // it - found live (2026-08-09): only the first tab (PiFinder Remote) ever
+  // opened, the rest were silently blocked. Most browsers allow exactly one
+  // new-tab open per click by default regardless of how many window.open()
+  // calls happen inside that same synchronous handler; there's no way
+  // around that from here short of the user allowing popups for this page,
+  // so the best this can do is detect it and say so instead of leaving the
+  // missing tabs unexplained.
+  const tryOpen = (url) => {
+    const win = window.open(url, '_blank', 'noopener');
+    if (win) opened++; else blocked++;
+  };
+  if (pifinderScreenUrl) {
+    const base = pifinderScreenUrl.replace(/\/image.*$/, '');
+    tryOpen(`${base}/remote`);
+  }
+  if (knownIps && knownIps.length > 0) {
+    tryOpen(`http://${knownIps[0]}:8624/`);
+    tryOpen(`http://${knownIps[0]}:80/`);
+  }
+  if (onstepWebIp) {
+    tryOpen(`http://${onstepWebIp}/`);
+  }
+  const note = document.getElementById('ql-open-all-note');
+  if (blocked > 0) {
+    note.textContent = `${blocked} tab${blocked === 1 ? '' : 's'} blocked by your browser - allow popups for this page and try again`;
+    note.style.display = '';
+  } else {
+    note.style.display = 'none';
+  }
 }
 
 // The Threshold field had no way to ever learn the driver's actual current
@@ -4188,14 +4394,22 @@ let mbDriftPollInFlight = false;
 // this is exactly the kind of thing that must not go unnoticed - the whole
 // point is not silently accepting a refusal like before.
 function updateMountRejectWarning(active, message) {
-  const row = document.getElementById('mb-reject-warning-row');
+  // 2026-08-09, direct feedback: this used to be its own always-shown-or-
+  // hidden red box between the caption and status rows - appearing/
+  // disappearing reflowed everything below it. Now a small toggle appended
+  // to the status line itself (reflow-free by default); the full warning
+  // text only takes up space once the user actually opens it, same
+  // collapsible pattern as #mb-mode-details above.
+  const toggle = document.getElementById('mb-reject-warning-toggle');
+  const detailsEl = document.getElementById('mb-reject-warning-details');
   const text = document.getElementById('mb-reject-warning-text');
   if (!active) {
-    row.style.display = 'none';
+    toggle.style.display = 'none';
+    detailsEl.style.display = 'none';
     return;
   }
   text.textContent = message || 'Mount refused the last Goto/Sync.';
-  row.style.display = 'flex';
+  toggle.style.display = '';
 }
 
 async function refreshMbDrift() {
@@ -5096,7 +5310,8 @@ function updateProfileRoleLine() {
   // banner above already says everything this role needs to say.
   document.getElementById('mb-status-row').style.display = hostMode ? 'none' : '';
   document.getElementById('mb-diagram').style.display = hostMode ? 'none' : '';
-  document.getElementById('mb-mode-caption').style.display = hostMode ? 'none' : '';
+  document.getElementById('mb-mode-caption-row').style.display = hostMode ? 'none' : '';
+  if (hostMode) document.getElementById('mb-mode-details').style.display = 'none';
   if (role === null) {
     el.style.display = 'none';
     return;

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -121,8 +121,30 @@
     image-rendering: pixelated;
     border-radius: 4px;
     background: #000;
-    flex-shrink: 0;
   }
+  #pifinder-screen-wrap { position: relative; flex-shrink: 0; }
+  /* Found live (2026-08-09, #187): the static splash fallback
+     (pifinder_welcome.png, red-channel-only to match the real OLED) is dark
+     enough that right after a real Pi reboot - before PiFinder's own web
+     server is even reachable to probe, can take up to a minute or more
+     competing with everything else the system starts at once - the tile
+     just looked dead, with nothing telling the user PiFinder was even
+     starting. This overlay makes that wait explicit regardless of how the
+     underlying splash image reads. Shown/hidden in
+     updatePiFinderStatusAndWizardLink(). */
+  #pifinder-screen-waiting {
+    position: absolute; inset: 0;
+    display: none;
+    align-items: center; justify-content: center;
+    text-align: center;
+    background: rgba(0, 0, 0, 0.55);
+    color: #ccc;
+    font-size: 0.72rem;
+    line-height: 1.4;
+    border-radius: 4px;
+    pointer-events: none;
+  }
+  #pifinder-screen-waiting.pifinder-screen-waiting-visible { display: flex; }
   #progress-wrap { margin-bottom: 0.8rem; }
   #progress-track {
     background: #262626;
@@ -1187,7 +1209,10 @@
         </div>
       </div>
       <div id="pifinder-glance-row">
-        <img id="pifinder-screen" src="/pifinder_welcome.png" alt="PiFinder screen" title="PiFinder OLED screen (live once running)">
+        <div id="pifinder-screen-wrap">
+          <img id="pifinder-screen" src="/pifinder_welcome.png" alt="PiFinder screen" title="PiFinder OLED screen (live once running)">
+          <div id="pifinder-screen-waiting">Waiting for<br>PiFinder&hellip;</div>
+        </div>
         <!-- Quick keys: same LEFT/UP/DOWN/RIGHT/SQUARE(+LNG_ Long-combo) codes
              PiFinder's own remote.html sends to /key_callback, proxied
              through this server's /api/pifinder_key (browser can't reach
@@ -1837,6 +1862,7 @@ function updatePiFinderStatusAndWizardLink() {
   // implying a check is in progress when there is nothing to check yet.
   // Found live 2026-08-03 testing PR #154's reinstall on real hardware.
   document.getElementById('mode-ampel-row').style.display = pifinderScreenUrl ? 'flex' : 'none';
+  document.getElementById('pifinder-screen-waiting').classList.toggle('pifinder-screen-waiting-visible', !pifinderScreenUrl);
   if (pifinderScreenUrl) {
     const base = pifinderScreenUrl.replace(/\/image.*$/, '');
     const port = new URL(pifinderScreenUrl).port || 80;

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -16,20 +16,26 @@
   @media (max-width: 767px) {
     body { padding: 0.8rem; }
   }
+  /* Grid layout (2026-08-09, direct feedback): PiFinder + Mode/Test/Power
+     stack in one column, Mount Bridge stands alone in the other (it's the
+     tile that most benefits from extra vertical room - the diagram/status/
+     coupling controls all stack inside it), Install/Update+Terminal always
+     spans the full width at the very bottom regardless of column count.
+     Named areas keep this independent of DOM order - .right-col (wrapping
+     #install-tile) stays exactly where it already was in the markup. */
   .page {
-    display: flex;
-    align-items: flex-start;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas:
+      "pifinder    mountbridge"
+      "mode        mountbridge"
+      "install     install";
     gap: 1.5rem;
   }
-  .left-col {
-    width: 40%;
-    min-width: 280px;
-    box-sizing: border-box;
-  }
-  .right-col {
-    width: 60%;
-    box-sizing: border-box;
-  }
+  #pifinder-glance-tile { grid-area: pifinder; }
+  #mount-bridge-tile { grid-area: mountbridge; }
+  #mode-tile { grid-area: mode; }
+  .right-col { grid-area: install; box-sizing: border-box; }
   /* Minimal responsive layout. Phones: always single column, both
      orientations - a phone's long side rarely exceeds ~900px even in
      landscape, well under the tablet range this project cares about, so
@@ -38,17 +44,24 @@
      the default below, needs no extra rule) - except large tablets
      (>=1366px, e.g. 12.9" iPad Pro), which behave like a PC regardless of
      orientation since the portrait-collapse rule is capped below that
-     width. PCs: the existing 40%/60% split already scales with the actual
-     window width with no extra rule needed - narrowing a desktop window
-     below 768px falls into the same phone rule above, so "depends on the
-     window" falls out of these two rules rather than needing a third. */
+     width. PCs: the existing two-column grid already scales with the
+     actual window width with no extra rule needed - narrowing a desktop
+     window below 768px falls into the same phone rule above, so "depends
+     on the window" falls out of these two rules rather than needing a
+     third. */
   @media (max-width: 767px) {
-    .page { flex-direction: column; gap: 1rem; }
-    .left-col, .right-col { width: 100%; min-width: 0; }
+    .page {
+      grid-template-columns: 1fr;
+      grid-template-areas: "pifinder" "mountbridge" "mode" "install";
+      gap: 1rem;
+    }
   }
   @media (min-width: 768px) and (max-width: 1365px) and (orientation: portrait) {
-    .page { flex-direction: column; gap: 1rem; }
-    .left-col, .right-col { width: 100%; min-width: 0; }
+    .page {
+      grid-template-columns: 1fr;
+      grid-template-areas: "pifinder" "mountbridge" "mode" "install";
+      gap: 1rem;
+    }
   }
   h1 { font-size: 1.3rem; margin: 0; }
   #page-title-row {
@@ -495,7 +508,6 @@
     border-radius: 8px;
     padding: 0.7rem 0.9rem;
     font-size: 0.82rem;
-    margin-top: 1rem;
   }
   #mode-status-line { font-weight: bold; margin-bottom: 0.6rem; }
   #mode-toggle-btn {
@@ -529,6 +541,19 @@
   .ql-small-btn:disabled { background: #1a1a1a; color: #666; border-color: #333; cursor: default; }
   .ql-small-btn:not(:disabled):hover { border-color: #777; color: #fff; }
   .ql-small-btn.mb-btn-active { border-color: #4caf50; background: #1c2a1c; color: #4caf50; }
+  /* Shared sizing for Sync/Stop (2026-08-09, direct feedback: these two are
+     frequent, important, mode-independent actions and need the same visual
+     weight as the coupling presets) - a self-contained base rather than
+     reusing .mb-coupling-btn directly, so .mb-abort-btn's red doesn't have
+     to fight a later cascade rule for who wins the background color. */
+  .mb-big-action-btn {
+    flex: 1; min-width: 8rem; min-height: 2.7rem; border-radius: 6px;
+    padding: 0.65rem 0.5rem; font-size: 0.85rem; font-weight: 600;
+    cursor: pointer; text-align: center; border: 1px solid #444;
+  }
+  #mb-big-actions-row { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.5rem; }
+  .mb-big-sync-btn { background: #1c2a1c; color: #7fc97f; border-color: #3a5a3a; }
+  .mb-big-sync-btn:hover { background: #24371f; border-color: #4caf50; color: #97dc97; }
   /* Deliberately loud/red, unlike every other small button here - this is
      a panic button (#179), it needs to read as different at a glance, not
      blend in with the rest of the row. */
@@ -710,7 +735,6 @@
     border-radius: 8px;
     padding: 0.7rem 0.9rem;
     font-size: 0.82rem;
-    margin-top: 1rem;
     position: relative;
   }
   #pfhost-ip { color: #4caf50; font-weight: bold; user-select: all; }
@@ -898,29 +922,16 @@
     background: #3a1414; color: #ff8a80; border: 1px solid #e53935;
     font-size: 0.8rem;
   }
-  /* Its own invisible .group-label spacer vertically offsets the button
-     past the label height Visual/GoTo have above their own buttons, so it
-     lines up with the actual button row instead of the heading row above
-     it. The button itself is flex:1 so it fills the stretched column
-     height exactly like .mb-coupling-group-buttons' buttons do - same
-     row-wide stretch as #mb-role-cards, min-height is just a floor.
-     margin-left:auto pins it to the far right on its own row once the
-     coupling groups wrap - falls back to sitting right after the last
-     group when there's no room left to push it further. */
-  #mb-decouple-group { flex: 0 0 auto; display: flex; flex-direction: column; margin-left: auto; }
+  /* Elongated pill (2026-08-09, direct feedback) - moved out of the
+     coupling-groups row into the Threshold row, next to the other
+     mode-independent one-shot actions above. */
   #mb-decouple-btn {
-    flex: 1;
-    min-height: 2.7rem;
-    width: 44px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 6px;
+    border-radius: 999px;
+    padding: 0.3rem 1rem;
     background: #232323;
     border: 1px solid #3a3a3a;
     color: #ccc;
-    font-size: 1rem;
-    line-height: 1;
+    font-size: 0.78rem;
     cursor: pointer;
   }
   #mb-decouple-btn:hover { background: #2a2a2a; color: #fff; }
@@ -1166,7 +1177,6 @@
 </div>
 
 <div class="page">
-  <div class="left-col">
     <div id="pifinder-glance-tile">
       <div class="tile-heading-row" style="cursor:default;">
         <h3 class="tile-heading" title="Direct links to PiFinder's own remote page, its INDI/mount setup wizard, and this Control Center - plus the project's documentation, and a quick hardware glance.">PiFinder<a class="help-link" href="/help.html#quick-links" target="_blank" rel="noopener" title="Help">i</a></h3>
@@ -1340,30 +1350,30 @@
             </div>
           </div>
           <div class="mb-coupling-group">
-            <div class="group-label mb-coupling-label"><span>GoTo</span><a class="help-link" href="/help.html#coupling-goto" target="_blank" rel="noopener" title="Help">i</a></div>
+            <div class="group-label mb-coupling-label"><span>GoTo</span><a class="help-link" href="/help.html#coupling-goto" target="_blank" rel="noopener" title="Help">i</a><span id="mb-target-source-badge" class="mb-target-source-badge" style="display:none;" title="Which side the currently held target most recently came from - read-only, updates automatically.">Following: <span id="mb-target-source-value">–</span></span></div>
             <div class="mb-coupling-group-buttons">
               <button id="wm-preset-goto-btn" class="mb-coupling-btn" onclick="onCouplingPresetClick('goto_forward')" disabled title="Holds whichever target was most recently, deliberately set - a PiFinder push-to (its own menu, or KStars' Goto on 'PiFinder LX200'), a mount-side GoTo (KStars on the mount, SkySafari, the mount's own app/hand controller), or a manual correction. No need to pick a side - it reacts to either automatically (#178).">GoTo</button>
-              <span id="mb-target-source-badge" class="mb-target-source-badge" style="display:none;" title="Which side the currently held target most recently came from - read-only, updates automatically.">Following: <span id="mb-target-source-value">–</span></span>
             </div>
-          </div>
-          <div id="mb-decouple-group">
-            <div class="group-label" style="visibility:hidden;">&nbsp;</div>
-            <button id="mb-decouple-btn" onclick="onDecoupleClick()" disabled title="Decouple - sets Coupling back to Off. PiFinder and mount stop syncing automatically until you pick a preset again. No dedicated preset button for this (Off is the driver's own default/neutral state). Disabled while already Off - nothing to decouple.">&times;</button>
           </div>
         </div>
       </div>
       <div id="mb-autoconnect-status" class="mb-hint" style="display:none;"></div>
+      <!-- Big, equal-weight action row (2026-08-09, direct feedback): Sync
+           and Stop are frequent, important, mode-independent actions - they
+           don't belong squeezed in as small text-labelled buttons next to
+           Threshold, they need the same visual weight as the coupling
+           presets above. -->
+      <div class="mb-row" id="mb-big-actions-row">
+        <button id="mb-manual-sync-btn" class="mb-big-action-btn mb-big-sync-btn" onclick="triggerManualSync()" title="One-shot: syncs the mount to PiFinder's current solved position right now, regardless of Coupling mode. Useful after moving the mount by hand - none of the Coupling presets react to that on their own.">Sync mount from PiFinder</button>
+        <button id="mb-abort-btn" class="mb-big-action-btn mb-abort-btn" onclick="triggerAbortMount()" title="Emergency stop: immediately aborts any mount motion AND sets Coupling to Off, so nothing re-triggers another correction afterward. Works even if PiFinder's own side is unavailable.">Stop movement</button>
+      </div>
       <div class="mb-row" id="mb-threshold-manual-row">
         <span id="mb-threshold-wrap" title="Used by Verify/Alert and the two Auto-correct presets: how far off before they warn/correct.">
           <span class="mb-row-label">Threshold:</span>
           <input type="number" id="wm-threshold-input" class="pf-num-input" value="5" min="0.1" max="600" step="0.5" style="width:4em;" onchange="applyThresholdChange()" oninput="scheduleThresholdChange()"> arcmin
         </span>
         <span id="mb-threshold-manual-sep"></span>
-        <span title="One-shot: syncs the mount to PiFinder's current solved position right now, regardless of Coupling mode. Useful after moving the mount by hand - none of the Coupling presets react to that on their own.">
-          <span class="mb-row-label">Manual:</span>
-          <button id="mb-manual-sync-btn" class="ql-small-btn" onclick="triggerManualSync()">Sync mount from PiFinder</button>
-        </span>
-        <button id="mb-abort-btn" class="ql-small-btn mb-abort-btn" onclick="triggerAbortMount()" title="Emergency stop: immediately aborts any mount motion AND sets Coupling to Off, so nothing re-triggers another correction afterward. Works even if PiFinder's own side is unavailable.">Stop movement</button>
+        <button id="mb-decouple-btn" onclick="onDecoupleClick()" disabled title="Decouple - sets Coupling back to Off. PiFinder and mount stop syncing automatically until you pick a preset again. No dedicated preset button for this (Off is the driver's own default/neutral state). Disabled while already Off - nothing to decouple.">Decouple</button>
       </div>
       <div class="hgroup-divider"></div>
       </div>
@@ -1566,8 +1576,6 @@ sudo systemctl start pifinder</pre>
         </div>
       </div>
       </div>
-
-  </div>
 
   <div class="right-col">
     <div id="install-tile">

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -889,6 +889,15 @@
   .mb-arrow.mb-arrow-goto { color: #4caf50; font-weight: bold; }
   #mb-mode-caption-row { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.6rem; }
   #mb-mode-caption { color: #888; font-size: 0.76rem; }
+  /* Same danger palette as .mb-abort-btn - the mount's own driver refused a
+     Goto/Sync (elevation/cable-wrap/axis limit), distinct from ordinary
+     drift (yellow/red badge above). */
+  #mb-reject-warning-row {
+    display: flex; align-items: center; gap: 0.4rem; margin-bottom: 0.6rem;
+    padding: 0.4rem 0.6rem; border-radius: 6px;
+    background: #3a1414; color: #ff8a80; border: 1px solid #e53935;
+    font-size: 0.8rem;
+  }
   /* Its own invisible .group-label spacer vertically offsets the button
      past the label height Visual/GoTo have above their own buttons, so it
      lines up with the actual button row instead of the heading row above
@@ -1307,6 +1316,9 @@
       </div>
       <div id="mb-mode-caption-row">
         <span id="mb-mode-caption">Not coupled yet</span>
+      </div>
+      <div id="mb-reject-warning-row" style="display:none;" title="The mount's own driver reported that it refused the last Goto/Sync - most likely an elevation or cable-wrap/axis limit. Not retrying the same command automatically - check the mount and its limit settings.">
+        <span>&#9888;</span><span id="mb-reject-warning-text"></span>
       </div>
       <div id="mb-status-row">
         <div id="mb-status-line"><span class="status-dot dot-white" id="mount-bridge-dot"></span><span id="mount-bridge-text">checking&hellip;</span><span id="mount-bridge-unconfirmed" style="display:none;" title="Our own status check couldn't reach Mount Bridge just now - this is very likely just that check's own timing, not a real disconnect (see Help). Showing the last confirmed state below; interactive buttons are paused until we can confirm again."> (unconfirmed)</span></div>
@@ -4136,6 +4148,22 @@ refreshMountBridgeStatus();
 // unlike the button-gated actions, which stay blocked until the slower poll
 // itself reconfirms things are safe to touch.
 let mbDriftPollInFlight = false;
+// Distinct from the drift badge - the mount's own driver refused a
+// Goto/Sync outright (elevation/cable-wrap/axis limit), not just imprecise
+// tracking. Kept on the fast poll (same cadence as the drift badge) since
+// this is exactly the kind of thing that must not go unnoticed - the whole
+// point is not silently accepting a refusal like before.
+function updateMountRejectWarning(active, message) {
+  const row = document.getElementById('mb-reject-warning-row');
+  const text = document.getElementById('mb-reject-warning-text');
+  if (!active) {
+    row.style.display = 'none';
+    return;
+  }
+  text.textContent = message || 'Mount refused the last Goto/Sync.';
+  row.style.display = 'flex';
+}
+
 async function refreshMbDrift() {
   if (mbDriftPollInFlight || mbActionInFlight) return;
   mbDriftPollInFlight = true;
@@ -4144,6 +4172,7 @@ async function refreshMbDrift() {
     const data = await resp.json();
     if (data.running) {
       applyMbDriftAndMode(data.coupling_mode, data.correction_action, data.drift_arcmin, data.drift_state);
+      updateMountRejectWarning(data.mount_reject_active, data.mount_reject_message);
     }
   } catch (e) {
     // best-effort - a miss here just means the number doesn't tick this cycle

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -873,6 +873,17 @@
   #mb-drift-badge.mb-drift-green { color: #4caf50; border-color: #4caf50; }
   #mb-drift-badge.mb-drift-yellow { color: #f5a623; border-color: #f5a623; }
   #mb-drift-badge.mb-drift-red { color: #e53935; border-color: #e53935; }
+  /* #178: read-only "who does the held target come from" badge next to the
+     unified GoTo button - deliberately plain/quiet (no color coding, this
+     isn't a warning state, just informational) per the "no manual
+     source switch" GUI direction. */
+  .mb-target-source-badge {
+    font-size: 0.76rem;
+    color: #888;
+    margin-left: 0.5rem;
+    white-space: nowrap;
+  }
+  .mb-target-source-badge #mb-target-source-value { color: #ccc; font-weight: 600; }
   .mb-arrow.mb-arrow-read { color: #5b9bd5; }
   .mb-arrow.mb-arrow-write { color: #f5a623; font-weight: bold; }
   .mb-arrow.mb-arrow-goto { color: #4caf50; font-weight: bold; }
@@ -1317,15 +1328,10 @@
             </div>
           </div>
           <div class="mb-coupling-group">
-            <div class="group-label mb-coupling-label"><span>Goto Mount</span><a class="help-link" href="/help.html#coupling-goto-mount" target="_blank" rel="noopener" title="Help">i</a></div>
+            <div class="group-label mb-coupling-label"><span>GoTo</span><a class="help-link" href="/help.html#coupling-goto" target="_blank" rel="noopener" title="Help">i</a></div>
             <div class="mb-coupling-group-buttons">
-              <button id="wm-preset-auto-goto-btn" class="mb-coupling-btn" onclick="onCouplingPresetClick('auto_correct_goto')" disabled title="Corrects by slewing the mount to PiFinder's solved position once drift exceeds the threshold - actually moves the mount, needs a Goto-capable mount.">Follow mount's goto</button>
-            </div>
-          </div>
-          <div class="mb-coupling-group">
-            <div class="group-label mb-coupling-label"><span>Goto PiFinder</span><a class="help-link" href="/help.html#coupling-goto-pifinder" target="_blank" rel="noopener" title="Help">i</a></div>
-            <div class="mb-coupling-group-buttons">
-              <button id="wm-preset-goto-btn" class="mb-coupling-btn" onclick="onCouplingPresetClick('goto_forward')" disabled title="Forwards every push-to/goto target sent to PiFinder (from its own menu, or KStars' Goto on the 'PiFinder LX200' device) straight through to the real mount too.">Follow PiFinder's push to</button>
+              <button id="wm-preset-goto-btn" class="mb-coupling-btn" onclick="onCouplingPresetClick('goto_forward')" disabled title="Holds whichever target was most recently, deliberately set - a PiFinder push-to (its own menu, or KStars' Goto on 'PiFinder LX200'), a mount-side GoTo (KStars on the mount, SkySafari, the mount's own app/hand controller), or a manual correction. No need to pick a side - it reacts to either automatically (#178).">GoTo</button>
+              <span id="mb-target-source-badge" class="mb-target-source-badge" style="display:none;" title="Which side the currently held target most recently came from - read-only, updates automatically.">Following: <span id="mb-target-source-value">–</span></span>
             </div>
           </div>
           <div id="mb-decouple-group">
@@ -3505,7 +3511,7 @@ async function refreshHardwareStatus() {
 // already done.
 function updateWmCouplingGate() {
   const enabled = !!wmSelectedProfile && !mbStatusUnconfirmed;
-  ['wm-preset-verify-btn', 'wm-preset-auto-sync-btn', 'wm-preset-auto-goto-btn', 'wm-preset-goto-btn'].forEach((id) => {
+  ['wm-preset-verify-btn', 'wm-preset-auto-sync-btn', 'wm-preset-goto-btn'].forEach((id) => {
     document.getElementById(id).disabled = !enabled;
   });
 }
@@ -3639,12 +3645,30 @@ function updateCouplingButtons(mode, correctionAction) {
   let active = null;
   if (mode === 'MODE_VERIFY_ALERT') active = 'wm-preset-verify-btn';
   else if (mode === 'MODE_GOTO_FORWARD') active = 'wm-preset-goto-btn';
-  else if (mode === 'MODE_AUTO_CORRECT') {
-    active = correctionAction === 'goto' ? 'wm-preset-auto-goto-btn' : 'wm-preset-auto-sync-btn';
-  }
-  ['wm-preset-verify-btn', 'wm-preset-auto-sync-btn', 'wm-preset-auto-goto-btn', 'wm-preset-goto-btn'].forEach((id) => {
+  // MODE_AUTO_CORRECT + goto ("Follow mount's goto") no longer has a GUI
+  // button (#178, see MB_PRESET_INFO's comment) - if the driver still
+  // somehow reports it (e.g. set via the raw INDI panel), fall back to
+  // highlighting the Sync preset's row so the tile doesn't just show
+  // nothing highlighted for a real, active mode.
+  else if (mode === 'MODE_AUTO_CORRECT') active = 'wm-preset-auto-sync-btn';
+  ['wm-preset-verify-btn', 'wm-preset-auto-sync-btn', 'wm-preset-goto-btn'].forEach((id) => {
     document.getElementById(id).classList.toggle('mb-btn-active', id === active);
   });
+}
+
+// #178: read-only "who does the currently held target come from" badge -
+// only meaningful while GoTo (MODE_GOTO_FORWARD) is the active mode, hidden
+// otherwise (Verify/Alert and Auto-correct-Sync have no "held target"
+// concept at all).
+function updateTargetSourceBadge(mode, targetSource) {
+  const badge = document.getElementById('mb-target-source-badge');
+  if (mode !== 'MODE_GOTO_FORWARD' || !targetSource) {
+    badge.style.display = 'none';
+    return;
+  }
+  badge.style.display = '';
+  document.getElementById('mb-target-source-value').textContent =
+    targetSource === 'mount' ? 'Mount' : 'PiFinder';
 }
 
 const MB_FOV_LIMIT_ARCMIN = 30;  // 0.5 degrees (full-moon diameter) - generic assumption, not measured; see CSS comment on #mb-drift-badge
@@ -3811,6 +3835,7 @@ function updateMbDiagram(data) {
   updateBridgeSettingsInfo(data);
   syncThresholdInputFromDriver(data.drift_threshold);
   applyMbDriftAndMode(data.coupling_mode, data.correction_action, data.drift_arcmin, data.drift_state);
+  updateTargetSourceBadge(data.coupling_mode, data.target_source);
 }
 
 // The Threshold field had no way to ever learn the driver's actual current
@@ -4142,10 +4167,15 @@ setInterval(refreshMbDrift, 2000);
 // made no sense once you consider it's irrelevant for the other two
 // presets), but still just one underlying mode server-side, distinguished
 // by the action.
+// auto_correct_goto ("Follow mount's goto") removed 2026-08-08 (#178) - now
+// redundant: with Reposition Detection active, goto_forward alone already
+// reacts symmetrically to both a PiFinder push-to AND an external mount-side
+// command, so the two-preset split no longer reflects a real behavioral
+// difference, only unnecessary GUI complexity. See
+// docs/concepts/mount_bridge_reposition_detection.md.
 const MB_PRESET_INFO = {
   verify_alert: { btnId: 'wm-preset-verify-btn', mode: 'verify_alert' },
   auto_correct_sync: { btnId: 'wm-preset-auto-sync-btn', mode: 'auto_correct', action: 'sync' },
-  auto_correct_goto: { btnId: 'wm-preset-auto-goto-btn', mode: 'auto_correct', action: 'goto' },
   goto_forward: { btnId: 'wm-preset-goto-btn', mode: 'goto_forward' },
 };
 

--- a/indi_pifinder_bridge/pifinder_bridge_client.cpp
+++ b/indi_pifinder_bridge/pifinder_bridge_client.cpp
@@ -101,6 +101,29 @@ void PiFinderBridgeClient::newProperty(INDI::Property property)
         m_shadowOnCoordSetSP = property.getSwitch();
 }
 
+void PiFinderBridgeClient::updateProperty(INDI::Property property)
+{
+    const bool fromMount = m_mountName == property.getDeviceName();
+
+    if (fromMount && property.isNameMatch("EQUATORIAL_EOD_COORD") && property.getState() == IPS_ALERT)
+        m_mountRejectedLastCoords = true;
+}
+
+void PiFinderBridgeClient::newMessage(INDI::BaseDevice baseDevice, int messageID)
+{
+    if (m_mountName != baseDevice.getDeviceName())
+        return;
+
+    // messageQueue() returns "<ISO-8601 timestamp>: <text>" - strip the
+    // timestamp prefix for GUI display, INDI clients already show one of
+    // their own alongside it.
+    std::string msg = baseDevice.messageQueue(messageID);
+    const auto sep = msg.find(": ");
+    if (sep != std::string::npos)
+        msg = msg.substr(sep + 2);
+    m_mountRejectMessage = msg;
+}
+
 void PiFinderBridgeClient::removeProperty(INDI::Property property)
 {
     if (property.getNumber() == m_piFinderEqNP)
@@ -207,6 +230,9 @@ bool PiFinderBridgeClient::sendMountCoords(double ra, double dec, const char *co
     if (coordSetSwitch == nullptr)
         return false;
 
+    m_mountRejectedLastCoords = false;
+    m_mountRejectMessage.clear();
+
     m_mountOnCoordSetSP->reset();
     coordSetSwitch->setState(ISS_ON);
     sendNewSwitch(m_mountOnCoordSetSP);
@@ -216,6 +242,16 @@ bool PiFinderBridgeClient::sendMountCoords(double ra, double dec, const char *co
     m_mountEqNP->setState(IPS_BUSY);
     sendNewNumber(m_mountEqNP);
 
+    return true;
+}
+
+bool PiFinderBridgeClient::mountRejectedLastCoords(std::string &outMessage)
+{
+    if (!m_mountRejectedLastCoords)
+        return false;
+
+    outMessage = m_mountRejectMessage;
+    m_mountRejectedLastCoords = false;
     return true;
 }
 

--- a/indi_pifinder_bridge/pifinder_bridge_client.cpp
+++ b/indi_pifinder_bridge/pifinder_bridge_client.cpp
@@ -106,7 +106,10 @@ void PiFinderBridgeClient::updateProperty(INDI::Property property)
     const bool fromMount = m_mountName == property.getDeviceName();
 
     if (fromMount && property.isNameMatch("EQUATORIAL_EOD_COORD") && property.getState() == IPS_ALERT)
+    {
+        std::lock_guard<std::mutex> lock(m_mountRejectMutex);
         m_mountRejectedLastCoords = true;
+    }
 }
 
 void PiFinderBridgeClient::newMessage(INDI::BaseDevice baseDevice, int messageID)
@@ -121,6 +124,8 @@ void PiFinderBridgeClient::newMessage(INDI::BaseDevice baseDevice, int messageID
     const auto sep = msg.find(": ");
     if (sep != std::string::npos)
         msg = msg.substr(sep + 2);
+
+    std::lock_guard<std::mutex> lock(m_mountRejectMutex);
     m_mountRejectMessage = msg;
 }
 
@@ -230,8 +235,11 @@ bool PiFinderBridgeClient::sendMountCoords(double ra, double dec, const char *co
     if (coordSetSwitch == nullptr)
         return false;
 
-    m_mountRejectedLastCoords = false;
-    m_mountRejectMessage.clear();
+    {
+        std::lock_guard<std::mutex> lock(m_mountRejectMutex);
+        m_mountRejectedLastCoords = false;
+        m_mountRejectMessage.clear();
+    }
 
     m_mountOnCoordSetSP->reset();
     coordSetSwitch->setState(ISS_ON);
@@ -247,6 +255,8 @@ bool PiFinderBridgeClient::sendMountCoords(double ra, double dec, const char *co
 
 bool PiFinderBridgeClient::mountRejectedLastCoords(std::string &outMessage)
 {
+    std::lock_guard<std::mutex> lock(m_mountRejectMutex);
+
     if (!m_mountRejectedLastCoords)
         return false;
 

--- a/indi_pifinder_bridge/pifinder_bridge_client.h
+++ b/indi_pifinder_bridge/pifinder_bridge_client.h
@@ -14,6 +14,7 @@
 #include "baseclient.h"
 #include "basedevice.h"
 
+#include <mutex>
 #include <string>
 
 class PiFinderBridgeClient : public INDI::BaseClient
@@ -57,6 +58,11 @@ class PiFinderBridgeClient : public INDI::BaseClient
         // that poll on a timer don't get stuck re-handling the same event
         // forever - also cleared by the next sendMountCoords() call.
         // outMessage receives the driver's own log text if one was seen.
+        // Thread-safe: the underlying INDI::BaseClient runs its own incoming-
+        // traffic thread (per its own doc comment on connectServer()), so
+        // updateProperty()/newMessage() - which set the state this reads -
+        // fire on a different thread than the driver's TimerHit(), which
+        // calls this. See m_mountRejectMutex.
         bool mountRejectedLastCoords(std::string &outMessage);
 
         // Reads the mount's own TELESCOPE_MOUNT_TYPE switch (every INDI::Telescope
@@ -102,6 +108,11 @@ class PiFinderBridgeClient : public INDI::BaseClient
         INDI::PropertyViewSwitch *m_mountAbortSP = nullptr;
         INDI::PropertyViewSwitch *m_mountSlewRateSP = nullptr;
 
+        // Written from updateProperty()/newMessage() (INDI::BaseClient's own
+        // I/O thread), read/written from sendMountCoords()/
+        // mountRejectedLastCoords() (the driver's TimerHit() thread) - needs
+        // real synchronization, not just "worked in testing so far".
+        mutable std::mutex m_mountRejectMutex;
         bool m_mountRejectedLastCoords = false;
         std::string m_mountRejectMessage;
 

--- a/indi_pifinder_bridge/pifinder_bridge_client.h
+++ b/indi_pifinder_bridge/pifinder_bridge_client.h
@@ -49,6 +49,16 @@ class PiFinderBridgeClient : public INDI::BaseClient
         // coordSetName is one of the mount's ON_COORD_SET switch names, e.g. "SYNC", "TRACK", "SLEW"
         bool sendMountCoords(double ra, double dec, const char *coordSetName);
 
+        // True (once) if, since the last sendMountCoords() call, the mount's
+        // own EQUATORIAL_EOD_COORD reported IPS_ALERT - every INDI telescope
+        // driver's native way of saying it refused or could not complete a
+        // Goto/Sync (e.g. an elevation or cable-wrap/axis-limit rejection).
+        // Consumed on read (clears itself once returned true) so callers
+        // that poll on a timer don't get stuck re-handling the same event
+        // forever - also cleared by the next sendMountCoords() call.
+        // outMessage receives the driver's own log text if one was seen.
+        bool mountRejectedLastCoords(std::string &outMessage);
+
         // Reads the mount's own TELESCOPE_MOUNT_TYPE switch (every INDI::Telescope
         // has it: MOUNT_ALTAZ / MOUNT_EQ_FORK / MOUNT_EQ_GEM) and maps it to
         // PiFinder's own "Alt/Az" / "EQ" setting values. Returns false if the
@@ -74,7 +84,9 @@ class PiFinderBridgeClient : public INDI::BaseClient
     protected:
         void newDevice(INDI::BaseDevice dp) override;
         void newProperty(INDI::Property property) override;
+        void updateProperty(INDI::Property property) override;
         void removeProperty(INDI::Property property) override;
+        void newMessage(INDI::BaseDevice baseDevice, int messageID) override;
 
     private:
         std::string m_piFinderName;
@@ -89,6 +101,9 @@ class PiFinderBridgeClient : public INDI::BaseClient
         INDI::PropertyViewSwitch *m_mountMountTypeSP = nullptr;
         INDI::PropertyViewSwitch *m_mountAbortSP = nullptr;
         INDI::PropertyViewSwitch *m_mountSlewRateSP = nullptr;
+
+        bool m_mountRejectedLastCoords = false;
+        std::string m_mountRejectMessage;
 
         std::string m_shadowName;
         bool m_shadowOnline = false;

--- a/indi_pifinder_bridge/pifinder_mount_bridge.cpp
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.cpp
@@ -511,24 +511,46 @@ bool PiFinderMountBridge::handleRepositionDetection(bool havePositions, double p
     if (!havePositions)
         return false;
 
-    // --- Fall 2: mount busy/moved without either of our own state machines having commanded it. ---
+    // --- Fall 2: mount moved without either of our own state machines having commanded it. ---
     const bool weCommandedIt = m_forwardState == ForwardState::SLEWING || m_correctState == CorrectState::SLEWING;
-    const bool mountBusy = m_client->isMountSlewing();
 
-    if (mountBusy && !weCommandedIt)
+    // Onset detection: compare the mount's own position against the last
+    // tick's, rather than watching isMountSlewing() (see m_lastPolledMountRA's
+    // own comment in the header - a real external move can complete without
+    // ever reporting IPS_BUSY at all). Skipped while we already know about
+    // an in-progress external move (avoids re-triggering the log/settle
+    // countdown every tick while it's still settling) and while we
+    // commanded the current motion ourselves (that's a real, large,
+    // expected delta - not Fall 2).
+    if (!std::isnan(m_lastPolledMountRA) && !weCommandedIt && !m_externalSlewInProgress)
     {
-        if (!m_externalSlewInProgress)
-            LOG_INFO("Mount is slewing without a command from Mount Bridge itself - external control detected "
-                      "(hand-paddle, SkySafari, the OnStep app, or a mount-side GoTo). Will adopt the new "
-                      "position once settled and confirmed by a fresh PiFinder solve.");
-        m_externalSlewInProgress = true;
-        return true;
+        const double mountDeltaArcmin =
+            angularSeparationArcmin(mountRA, mountDec, m_lastPolledMountRA, m_lastPolledMountDec);
+        const double elapsedSec = std::max(0.0, static_cast<double>(time(nullptr) - m_lastPolledMountTime));
+        const double maxPlausiblePassiveDrift = elapsedSec * MAX_SIDEREAL_DRIFT_ARCMIN_PER_SEC;
+
+        if (mountDeltaArcmin > maxPlausiblePassiveDrift)
+        {
+            LOGF_INFO("Mount moved %.1f arcmin since the last check (~%.0fs ago, more than the %.1f' passive sky "
+                      "motion could plausibly produce) without a command from Mount Bridge itself - external "
+                      "control detected (hand-paddle, SkySafari, the OnStep app, or a mount-side GoTo). Will "
+                      "adopt the new position once settled and confirmed by a fresh PiFinder solve.",
+                      mountDeltaArcmin, elapsedSec, maxPlausiblePassiveDrift);
+            m_externalSlewInProgress = true;
+            m_externalSettleTicksRemaining = SETTLE_TICKS;
+        }
     }
+    m_lastPolledMountRA = mountRA;
+    m_lastPolledMountDec = mountDec;
+    m_lastPolledMountTime = time(nullptr);
 
     if (m_externalSlewInProgress)
     {
-        if (mountBusy)
-            return true; // still moving
+        if (m_externalSettleTicksRemaining > 0)
+        {
+            --m_externalSettleTicksRemaining;
+            return true; // give the mount a few ticks to physically finish settling - isMountSlewing() can't be trusted to tell us (see above)
+        }
         if (!isPiFinderSolveFresh(SolveFreshnessMaxAgeN[0].value))
             return true; // finished moving, but waiting for a fresh solve to confirm before trusting it (#79)
 

--- a/indi_pifinder_bridge/pifinder_mount_bridge.cpp
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.cpp
@@ -554,6 +554,18 @@ bool PiFinderMountBridge::handleRepositionDetection(bool havePositions, double p
         return false;
 
     // --- Fall 3 vs Fall 4: no command signal seen, but PiFinder-vs-mount disagree past Threshold. ---
+    // Never trust this drift number off a stale solve - same freshness gate
+    // every other drift-consuming code path in this file already has
+    // (SETTLING, HOLDING's own correction, CorrectState::SETTLING). Found
+    // live (2026-08-08, #186 testing): right after Fall 1 forwards a
+    // legitimate PushTo and the mount arrives, PiFinder's own reported
+    // position hasn't necessarily been reconfirmed by a fresh solve yet -
+    // without this gate, that transient (but real) mismatch got
+    // misclassified as an implausible Fall-4 jump instead of just waiting
+    // for the next solve like every other arrival-verification path does.
+    if (!isPiFinderSolveFresh(SolveFreshnessMaxAgeN[0].value))
+        return false;
+
     if (drift <= DriftThresholdN[0].value)
     {
         m_lastConfirmedGoodTime = time(nullptr); // currently agreeing - this moment is confirmed-good

--- a/indi_pifinder_bridge/pifinder_mount_bridge.cpp
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.cpp
@@ -205,6 +205,16 @@ bool PiFinderMountBridge::initProperties()
     IUFillNumberVector(&DriftStatusNP, DriftStatusN, 1, getDeviceName(), "DRIFT_STATUS", "Status",
                        "Main Control", IP_RO, 60, IPS_IDLE);
 
+    // Distinct from DriftStatusNP - that one means "the mount is tracking a
+    // bit imprecisely, will self-correct". This means the mount refused a
+    // Goto/Sync outright (e.g. an elevation or cable-wrap/axis limit), which
+    // is what led to the balcony-wall incident: the software silently
+    // accepted the refusal instead of telling the user. IPS_ALERT while a
+    // refusal is active, IPS_OK once a subsequent attempt succeeds.
+    IUFillText(&MountRejectT[0], "MESSAGE", "Message", "");
+    IUFillTextVector(&MountRejectTP, MountRejectT, 1, getDeviceName(), "MOUNT_REJECT",
+                       "Mount refused Goto/Sync", "Main Control", IP_RO, 60, IPS_IDLE);
+
     addDebugControl();
     setDefaultPollingPeriod(2000);
 
@@ -240,6 +250,7 @@ bool PiFinderMountBridge::updateProperties()
         defineProperty(&MaxSyncDriftNP);
         defineProperty(&SolveFreshnessMaxAgeNP);
         defineProperty(&DriftStatusNP);
+        defineProperty(&MountRejectTP);
         defineProperty(&ShadowSyncSP);
         defineProperty(&RepositionConfirmSP);
         defineProperty(&TargetSourceSP);
@@ -265,6 +276,7 @@ bool PiFinderMountBridge::updateProperties()
         deleteProperty(MaxSyncDriftNP.name);
         deleteProperty(SolveFreshnessMaxAgeNP.name);
         deleteProperty(DriftStatusNP.name);
+        deleteProperty(MountRejectTP.name);
         deleteProperty(ShadowSyncSP.name);
         deleteProperty(RepositionConfirmSP.name);
         deleteProperty(TargetSourceSP.name);
@@ -712,6 +724,21 @@ void PiFinderMountBridge::TimerHit()
     SetTimer(getCurrentPollingPeriod());
 }
 
+void PiFinderMountBridge::setMountRejectWarning(bool active, const std::string &message)
+{
+    const IPState newState = active ? IPS_ALERT : IPS_OK;
+    const char *newText = active ? message.c_str() : "";
+
+    // Avoid redundant INDI traffic/log noise every poll tick when nothing
+    // changed - same reasoning as setTargetSource() below.
+    if (MountRejectTP.s == newState && std::string(MountRejectT[0].text ? MountRejectT[0].text : "") == newText)
+        return;
+
+    IUSaveText(&MountRejectT[0], newText);
+    MountRejectTP.s = newState;
+    IDSetText(&MountRejectTP, nullptr);
+}
+
 void PiFinderMountBridge::setTargetSource(int index)
 {
     if (TargetSourceS[index].s == ISS_ON)
@@ -793,6 +820,7 @@ void PiFinderMountBridge::handleGotoForward()
                 LOGF_INFO("New PiFinder target (RA %.4fh, DEC %.4f deg) - forwarded Goto to mount.",
                           targetRA, targetDec);
                 setTargetSource(TARGET_SOURCE_PIFINDER);
+                setMountRejectWarning(false, ""); // fresh attempt - any old warning no longer applies
                 m_lastForwardedRA = targetRA;
                 m_lastForwardedDec = targetDec;
                 m_settleRetriesRemaining = MAX_SETTLE_RETRIES;
@@ -828,6 +856,23 @@ void PiFinderMountBridge::handleGotoForward()
 
         case ForwardState::SETTLING:
         {
+            std::string rejectMsg;
+            if (m_client->mountRejectedLastCoords(rejectMsg))
+            {
+                LOGF_WARN("Mount refused the Goto (%s) - likely an elevation or cable-wrap/axis limit, not just"
+                          " settling. Not retrying the same command - now holding.",
+                          rejectMsg.empty() ? "no message from driver" : rejectMsg.c_str());
+                setMountRejectWarning(true, rejectMsg.empty() ? "Mount refused the Goto (no message from driver)" : rejectMsg);
+                m_forwardState = ForwardState::HOLDING;
+                break;
+            }
+            // Deliberately NOT clearing the warning just because *this tick*
+            // saw no new rejection - mountRejectedLastCoords() is
+            // consume-on-read, so it reads false on every tick after the one
+            // that actually caught it. Clearing here would erase the warning
+            // one tick after showing it, before a human ever sees it. Only
+            // cleared below on a genuinely confirmed-good arrival.
+
             if (m_settleTicksRemaining > 0)
             {
                 --m_settleTicksRemaining;
@@ -907,8 +952,11 @@ void PiFinderMountBridge::handleGotoForward()
                     LOGF_WARN("Gave up refining after %d attempt(s): residual %.1f arcmin still exceeds threshold %.1f - now holding, will retry on the next drift check.",
                               MAX_SETTLE_RETRIES, drift, threshold);
                 else
+                {
                     LOGF_INFO("Arrival verified by PiFinder solve: residual %.1f arcmin, within threshold %.1f - now holding.",
                               drift, threshold);
+                    setMountRejectWarning(false, "");
+                }
                 m_forwardState = ForwardState::HOLDING;
             }
             break;
@@ -935,6 +983,7 @@ void PiFinderMountBridge::handleGotoForward()
                         LOGF_INFO("New PiFinder target (RA %.4fh, DEC %.4f deg) while holding - forwarded Goto to mount.",
                                   targetRA, targetDec);
                         setTargetSource(TARGET_SOURCE_PIFINDER);
+                        setMountRejectWarning(false, ""); // fresh attempt - any old warning no longer applies
                         m_lastForwardedRA = targetRA;
                         m_lastForwardedDec = targetDec;
                         m_settleRetriesRemaining = MAX_SETTLE_RETRIES;
@@ -965,6 +1014,20 @@ void PiFinderMountBridge::handleGotoForward()
                 break;
             }
 
+            {
+                std::string rejectMsg;
+                if (m_client->mountRejectedLastCoords(rejectMsg))
+                {
+                    LOGF_WARN("Mount refused the correction (%s) - likely an elevation or cable-wrap/axis limit."
+                              " Not retrying the same command this tick.",
+                              rejectMsg.empty() ? "no message from driver" : rejectMsg.c_str());
+                    setMountRejectWarning(true, rejectMsg.empty() ? "Mount refused the correction (no message from driver)" : rejectMsg);
+                    break;
+                }
+                // Same reasoning as SETTLING above - not cleared here, only
+                // on a genuinely confirmed-good drift check below.
+            }
+
             // Still the same held target - watch for it drifting past
             // Threshold (e.g. ordinary mount tracking imperfection) and
             // correct exactly like SETTLING does, just re-triggerable
@@ -985,7 +1048,10 @@ void PiFinderMountBridge::handleGotoForward()
             IDSetNumber(&DriftStatusNP, nullptr);
 
             if (drift <= threshold)
+            {
+                setMountRejectWarning(false, "");
                 break;
+            }
 
             if (drift > MaxSyncDriftN[0].value)
             {
@@ -1050,6 +1116,7 @@ void PiFinderMountBridge::handleAutoCorrectGoto(bool exceeded, double piRA, doub
                 m_correctTargetDec = piDec;
                 m_correctSettleRetriesRemaining = MAX_SETTLE_RETRIES;
                 m_correctState = CorrectState::SLEWING;
+                setMountRejectWarning(false, ""); // fresh attempt - any old warning no longer applies
             }
             else
             {
@@ -1080,6 +1147,24 @@ void PiFinderMountBridge::handleAutoCorrectGoto(bool exceeded, double piRA, doub
         case CorrectState::SETTLING:
         {
             DriftStatusNP.s = IPS_BUSY;
+
+            {
+                std::string rejectMsg;
+                if (m_client->mountRejectedLastCoords(rejectMsg))
+                {
+                    LOGF_WARN("Mount refused the auto-correct Goto (%s) - likely an elevation or"
+                              " cable-wrap/axis limit, not just settling. Not retrying the same command -"
+                              " resuming normal monitoring.",
+                              rejectMsg.empty() ? "no message from driver" : rejectMsg.c_str());
+                    setMountRejectWarning(true, rejectMsg.empty() ? "Mount refused the auto-correct Goto (no message from driver)" : rejectMsg);
+                    m_correctState = CorrectState::IDLE;
+                    break;
+                }
+                // Same reasoning as ForwardState::SETTLING above - not
+                // cleared here, only on a genuinely confirmed-good residual
+                // check below.
+            }
+
             if (m_correctSettleTicksRemaining > 0)
             {
                 --m_correctSettleTicksRemaining;
@@ -1148,8 +1233,11 @@ void PiFinderMountBridge::handleAutoCorrectGoto(bool exceeded, double piRA, doub
                     LOGF_WARN("Auto-correct gave up refining after %d attempt(s): residual %.1f arcmin still exceeds threshold %.1f.",
                               MAX_SETTLE_RETRIES, drift, threshold);
                 else
+                {
                     LOGF_INFO("Auto-correct arrival verified by PiFinder solve: residual %.1f arcmin, within threshold %.1f.",
                               drift, threshold);
+                    setMountRejectWarning(false, "");
+                }
                 m_correctState = CorrectState::IDLE;
             }
             break;

--- a/indi_pifinder_bridge/pifinder_mount_bridge.cpp
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.cpp
@@ -1292,9 +1292,28 @@ bool PiFinderMountBridge::ISNewSwitch(const char *dev, const char *name, ISState
             // Any mode change resets the Goto-Forward state machine, so
             // re-entering it always re-baselines against whatever target
             // PiFinder currently has instead of reacting to a stale one.
+            //
+            // Snapshot that existing target directly as the baseline (rather
+            // than NaN) - found live (2026-08-09): NaN made handleGotoForward()
+            // treat the *next* observed target, even a genuinely new one just
+            // picked in KStars right as/after this mode switch, as "first
+            // observation, just baseline it, don't forward" (see that
+            // function's own comment) - the Goto silently did nothing on the
+            // first press and only fired on a second, distinct-enough one.
+            // Snapshotting here still protects against re-firing a stale
+            // pre-existing target (the actual original intent), while letting
+            // a target that's different from what was already there act
+            // immediately. Falls back to NaN if PiFinder has no target at all
+            // yet - handleGotoForward()'s isnan-guarded baseline path (needed
+            // separately for a driver restart while this mode is already
+            // active, which never runs through ISNewSwitch at all) still
+            // covers that case correctly.
             m_forwardState = ForwardState::IDLE;
-            m_lastForwardedRA = std::nan("");
-            m_lastForwardedDec = std::nan("");
+            if (!m_client->getPiFinderTargetRADE(m_lastForwardedRA, m_lastForwardedDec))
+            {
+                m_lastForwardedRA = std::nan("");
+                m_lastForwardedDec = std::nan("");
+            }
 
             // Same idea for Auto-Correct's Goto-refine state machine - don't
             // let an in-progress settle/retry cycle from a previous mode
@@ -1586,6 +1605,13 @@ bool PiFinderMountBridge::ISNewNumber(const char *dev, const char *name, double 
             IUUpdateNumber(&DriftThresholdNP, values, names, n);
             DriftThresholdNP.s = IPS_OK;
             IDSetNumber(&DriftThresholdNP, nullptr);
+            // Found live (2026-08-09): unlike MaxSyncDriftNP/BridgeModeSP/
+            // ShadowSyncSP just above/below, this handler never persisted
+            // the change - a user-set Threshold silently reverted to the
+            // compiled-in default (5) on the next driver restart, with
+            // nothing in the GUI explaining why. Same auto-save-on-change
+            // pattern as those, just missing here.
+            saveConfig(true, DriftThresholdNP.name);
             return true;
         }
 
@@ -1594,6 +1620,9 @@ bool PiFinderMountBridge::ISNewNumber(const char *dev, const char *name, double 
             IUUpdateNumber(&MaxSyncDriftNP, values, names, n);
             MaxSyncDriftNP.s = IPS_OK;
             IDSetNumber(&MaxSyncDriftNP, nullptr);
+            // Same gap as DriftThresholdNP above (2026-08-09) - found while
+            // fixing that one, same missing auto-save.
+            saveConfig(true, MaxSyncDriftNP.name);
             return true;
         }
 
@@ -1602,6 +1631,9 @@ bool PiFinderMountBridge::ISNewNumber(const char *dev, const char *name, double 
             IUUpdateNumber(&SolveFreshnessMaxAgeNP, values, names, n);
             SolveFreshnessMaxAgeNP.s = IPS_OK;
             IDSetNumber(&SolveFreshnessMaxAgeNP, nullptr);
+            // Same gap as DriftThresholdNP above (2026-08-09) - found while
+            // fixing that one, same missing auto-save.
+            saveConfig(true, SolveFreshnessMaxAgeNP.name);
             return true;
         }
     }

--- a/indi_pifinder_bridge/pifinder_mount_bridge.cpp
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.cpp
@@ -396,6 +396,40 @@ void PiFinderMountBridge::handleShadowSync()
     m_client->syncShadowCoords(piRA, piDec);
 }
 
+void PiFinderMountBridge::runModeReadinessCheck()
+{
+    if (BridgeModeS[MODE_OFF].s == ISS_ON)
+        return; // nothing to verify - Coupling being Off is itself the "nothing needed" state
+
+    if (!m_client->isReady())
+    {
+        // Not fixable here (needs the devices to actually connect) - just
+        // make sure it's visible instead of silently doing nothing until
+        // someone notices drift never updates. TimerHit()'s own isReady()
+        // gate already handles this correctly once connected; this is
+        // purely a heads-up at the moment the mode was chosen.
+        LOG_WARN("Coupling mode enabled, but PiFinder and/or mount aren't both connected yet - "
+                 "will start once ready.");
+    }
+
+    // A sanity limit smaller than the correction threshold would silently
+    // block every correction whose drift falls between the two forever -
+    // "exceeds threshold" but also "exceeds sanity cap", so it never syncs
+    // and the GUI just shows a permanent, unexplained Alert. Safe to
+    // auto-fix (raising a limit is strictly less restrictive, never a
+    // safety regression) rather than just warn.
+    if (MaxSyncDriftN[0].value < DriftThresholdN[0].value)
+    {
+        LOGF_WARN("Auto-Sync sanity limit (%.1f') was smaller than Threshold (%.1f') - corrections in "
+                  "that gap could never fire. Raised the sanity limit to match.",
+                  MaxSyncDriftN[0].value, DriftThresholdN[0].value);
+        MaxSyncDriftN[0].value = DriftThresholdN[0].value;
+        MaxSyncDriftNP.s = IPS_OK;
+        IDSetNumber(&MaxSyncDriftNP, nullptr);
+        saveConfig(true, MaxSyncDriftNP.name);
+    }
+}
+
 void PiFinderMountBridge::TimerHit()
 {
     if (!isConnected())
@@ -968,6 +1002,7 @@ bool PiFinderMountBridge::ISNewSwitch(const char *dev, const char *name, ISState
             // of what the user picks live, same "selection doesn't stick"
             // shape as #158's ACTIVE_DEVICES bug.
             saveConfig(true, BridgeModeSP.name);
+            runModeReadinessCheck();
             return true;
         }
 

--- a/indi_pifinder_bridge/pifinder_mount_bridge.cpp
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.cpp
@@ -179,6 +179,16 @@ bool PiFinderMountBridge::initProperties()
     IUFillSwitchVector(&AbortMountSP, AbortMountS, 1, getDeviceName(), "ABORT_MOUNT",
                        "Emergency stop", "Main Control", IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
 
+    IUFillSwitch(&RepositionConfirmS[REPOSITION_CONFIRM_YES], "REPOSITION_CONFIRM_YES", "Adopt new position", ISS_OFF);
+    IUFillSwitch(&RepositionConfirmS[REPOSITION_CONFIRM_NO], "REPOSITION_CONFIRM_NO", "Revert to held target", ISS_OFF);
+    IUFillSwitchVector(&RepositionConfirmSP, RepositionConfirmS, 2, getDeviceName(), "REPOSITION_CONFIRM",
+                       "Unexplained reposition", "Main Control", IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
+
+    IUFillSwitch(&TargetSourceS[TARGET_SOURCE_PIFINDER], "TARGET_SOURCE_PIFINDER", "PiFinder", ISS_ON);
+    IUFillSwitch(&TargetSourceS[TARGET_SOURCE_MOUNT], "TARGET_SOURCE_MOUNT", "Mount", ISS_OFF);
+    IUFillSwitchVector(&TargetSourceSP, TargetSourceS, 2, getDeviceName(), "TARGET_SOURCE",
+                       "Following", "Main Control", IP_RO, ISR_1OFMANY, 0, IPS_IDLE);
+
     IUFillNumber(&DriftThresholdN[0], "THRESHOLD_ARCMIN", "Threshold (arcmin)", "%.1f", 0.1, 600, 0.5, 5);
     IUFillNumberVector(&DriftThresholdNP, DriftThresholdN, 1, getDeviceName(), "DRIFT_THRESHOLD",
                        "Drift Threshold", "Main Control", IP_RW, 60, IPS_IDLE);
@@ -231,6 +241,8 @@ bool PiFinderMountBridge::updateProperties()
         defineProperty(&SolveFreshnessMaxAgeNP);
         defineProperty(&DriftStatusNP);
         defineProperty(&ShadowSyncSP);
+        defineProperty(&RepositionConfirmSP);
+        defineProperty(&TargetSourceSP);
 
         // Restore the saved Coupling mode/threshold/etc. now that their
         // properties actually exist - see m_connectedConfigLoaded's
@@ -254,6 +266,8 @@ bool PiFinderMountBridge::updateProperties()
         deleteProperty(SolveFreshnessMaxAgeNP.name);
         deleteProperty(DriftStatusNP.name);
         deleteProperty(ShadowSyncSP.name);
+        deleteProperty(RepositionConfirmSP.name);
+        deleteProperty(TargetSourceSP.name);
     }
 
     return true;
@@ -430,6 +444,141 @@ void PiFinderMountBridge::runModeReadinessCheck()
     }
 }
 
+bool PiFinderMountBridge::handleRepositionDetection(bool havePositions, double piRA, double piDec, double mountRA,
+                                                     double mountDec, double drift)
+{
+    // --- A Fall-4 confirmation from a previous tick is still open: only check its timeout here. ---
+    if (m_repositionConfirmPending)
+    {
+        if (time(nullptr) < m_repositionConfirmDeadline)
+            return true; // still waiting on a response - don't let the old per-mode logic act meanwhile
+
+        LOG_WARN("Reposition confirmation timed out - treating as unintentional, reverting to the held target.");
+        m_repositionConfirmPending = false;
+        IUResetSwitch(&RepositionConfirmSP);
+        RepositionConfirmSP.s = IPS_ALERT;
+        IDSetSwitch(&RepositionConfirmSP, nullptr);
+        if (havePositions)
+        {
+            // Same Sync+re-Goto pattern HOLDING already uses for ordinary
+            // drift - explicitly authorized past MaxSyncDriftNP this one
+            // time, since a human-reviewable confirmation window just
+            // expired unanswered rather than this being blind automation.
+            //
+            // Found live (2026-08-08): NOT routing this through the normal
+            // SLEWING state caused an infinite loop - the next tick saw the
+            // mount moving without weCommandedIt being true (misclassified
+            // as ANOTHER external reposition), and marking "confirmed good"
+            // immediately (before the Goto had actually converged) meant
+            // any still-remaining residual looked implausible again right
+            // away. Fixed: fire the same commands, but hand control back to
+            // the existing SLEWING/SETTLING machinery to verify real
+            // convergence (same discipline as every other correction path)
+            // instead of declaring success ourselves. m_lastConfirmedGoodTime
+            // is deliberately NOT touched here - it only updates once drift
+            // is actually observed back within Threshold, same as normal.
+            applySlewRateForDrift(drift);
+            if (m_client->sendMountCoords(piRA, piDec, "SYNC") &&
+                m_client->sendMountCoords(m_lastForwardedRA, m_lastForwardedDec, "TRACK"))
+            {
+                if (BridgeModeS[MODE_GOTO_FORWARD].s == ISS_ON)
+                {
+                    m_settleRetriesRemaining = MAX_SETTLE_RETRIES;
+                    m_forwardState = ForwardState::SLEWING;
+                }
+                else
+                {
+                    m_correctSettleRetriesRemaining = MAX_SETTLE_RETRIES;
+                    m_correctState = CorrectState::SLEWING;
+                }
+            }
+        }
+        return true;
+    }
+
+    if (!havePositions)
+        return false;
+
+    // --- Fall 2: mount busy/moved without either of our own state machines having commanded it. ---
+    const bool weCommandedIt = m_forwardState == ForwardState::SLEWING || m_correctState == CorrectState::SLEWING;
+    const bool mountBusy = m_client->isMountSlewing();
+
+    if (mountBusy && !weCommandedIt)
+    {
+        if (!m_externalSlewInProgress)
+            LOG_INFO("Mount is slewing without a command from Mount Bridge itself - external control detected "
+                      "(hand-paddle, SkySafari, the OnStep app, or a mount-side GoTo). Will adopt the new "
+                      "position once settled and confirmed by a fresh PiFinder solve.");
+        m_externalSlewInProgress = true;
+        return true;
+    }
+
+    if (m_externalSlewInProgress)
+    {
+        if (mountBusy)
+            return true; // still moving
+        if (!isPiFinderSolveFresh(SolveFreshnessMaxAgeN[0].value))
+            return true; // finished moving, but waiting for a fresh solve to confirm before trusting it (#79)
+
+        m_externalSlewInProgress = false;
+        m_lastForwardedRA = piRA;
+        m_lastForwardedDec = piDec;
+        m_correctTargetRA = piRA;
+        m_correctTargetDec = piDec;
+        m_lastConfirmedGoodTime = time(nullptr);
+        m_forwardState = ForwardState::HOLDING;
+        m_correctState = CorrectState::IDLE;
+        setTargetSource(TARGET_SOURCE_MOUNT);
+        LOGF_INFO("External reposition confirmed by a fresh PiFinder solve (RA %.4fh, DEC %.4f deg) - adopted "
+                  "as the new held target.",
+                  piRA, piDec);
+        return true;
+    }
+
+    // Our own correction is already mid-flight (SLEWING/SETTLING) - let
+    // handleGotoForward()/handleAutoCorrectGoto() manage it uninterrupted,
+    // don't reclassify a transitional position as anything.
+    if (weCommandedIt)
+        return false;
+
+    // --- Fall 3 vs Fall 4: no command signal seen, but PiFinder-vs-mount disagree past Threshold. ---
+    if (drift <= DriftThresholdN[0].value)
+    {
+        m_lastConfirmedGoodTime = time(nullptr); // currently agreeing - this moment is confirmed-good
+        m_repositionBaselineTrusted = true;
+        return false;
+    }
+
+    if (!m_repositionBaselineTrusted)
+    {
+        // Haven't observed a genuine confirmed-good moment since the last
+        // reset (restart/mode-switch) yet - any pre-existing drift here
+        // could simply be a backlog from being offline, not a sudden
+        // implausible jump. Defer entirely to the existing HOLDING/Auto-
+        // correct logic (still backstopped by MaxSyncDriftNP) until a real
+        // baseline has actually been established.
+        return false;
+    }
+
+    const double elapsedSec = static_cast<double>(time(nullptr) - m_lastConfirmedGoodTime);
+    const double maxPlausibleDrift = elapsedSec * MAX_SIDEREAL_DRIFT_ARCMIN_PER_SEC;
+
+    if (drift <= maxPlausibleDrift)
+        return false; // Fall 3: physically plausible passive drift - let the existing HOLDING/Auto-correct logic handle it as before
+
+    // Fall 4: exceeds what passive sky motion could produce in the elapsed
+    // time - ask rather than guess (see docs/concepts/mount_bridge_reposition_detection.md UC4).
+    m_repositionConfirmPending = true;
+    m_repositionConfirmDeadline = time(nullptr) + REPOSITION_CONFIRM_TIMEOUT_SEC;
+    RepositionConfirmSP.s = IPS_BUSY;
+    IDSetSwitch(&RepositionConfirmSP, nullptr);
+    LOGF_WARN("Drift %.1f arcmin exceeds what passive sky motion could produce in %.0fs (max plausible %.1f') - "
+              "likely a deliberate reposition (e.g. clutch released) or a disturbance. Confirm via "
+              "REPOSITION_CONFIRM within %ds, or it will be treated as unintentional and reverted automatically.",
+              drift, elapsedSec, maxPlausibleDrift, REPOSITION_CONFIRM_TIMEOUT_SEC);
+    return true;
+}
+
 void PiFinderMountBridge::TimerHit()
 {
     if (!isConnected())
@@ -469,7 +618,31 @@ void PiFinderMountBridge::TimerHit()
         DriftStatusNP.s = exceeded ? IPS_ALERT : IPS_OK;
     }
 
-    if (BridgeModeS[MODE_GOTO_FORWARD].s == ISS_ON)
+    // Reposition Detection (#178) only applies to the two "held target"
+    // Goto-based modes (Goto-Forward, Auto-correct's Goto action) - it
+    // needs a held-target concept to adopt into, which Verify/Alert (never
+    // touches the mount) and Auto-correct's plain Sync action (no target,
+    // just continuous re-sync) don't have. See
+    // docs/concepts/mount_bridge_reposition_detection.md.
+    // Was emergency-disabled live (2026-08-08) after a false-positive
+    // Fall-4 loop (see git history) - re-enabled after two fixes: reverts
+    // now route through the normal SLEWING state instead of declaring
+    // success immediately (so convergence is actually verified), and the
+    // rate-based classification only activates after a genuine
+    // confirmed-good baseline, not immediately after every restart.
+    const bool repositionDetectionApplies =
+        BridgeModeS[MODE_GOTO_FORWARD].s == ISS_ON ||
+        (BridgeModeS[MODE_AUTO_CORRECT].s == ISS_ON && CorrectionActionS[ACTION_GOTO].s == ISS_ON);
+    const bool repositionHandledThisTick =
+        repositionDetectionApplies && handleRepositionDetection(havePositions, piRA, piDec, mountRA, mountDec, drift);
+
+    if (repositionHandledThisTick)
+    {
+        // Fully handled above (external slew in progress/just adopted, or
+        // a Fall-4 confirmation pending/just resolved) - skip the normal
+        // per-mode logic so it can't act on the same drift a moment ago.
+    }
+    else if (BridgeModeS[MODE_GOTO_FORWARD].s == ISS_ON)
     {
         handleGotoForward();
     }
@@ -537,6 +710,16 @@ void PiFinderMountBridge::TimerHit()
     if (havePositions)
         IDSetNumber(&DriftStatusNP, nullptr);
     SetTimer(getCurrentPollingPeriod());
+}
+
+void PiFinderMountBridge::setTargetSource(int index)
+{
+    if (TargetSourceS[index].s == ISS_ON)
+        return; // already showing this - avoid redundant INDI traffic every tick
+    IUResetSwitch(&TargetSourceSP);
+    TargetSourceS[index].s = ISS_ON;
+    TargetSourceSP.s = IPS_OK;
+    IDSetSwitch(&TargetSourceSP, nullptr);
 }
 
 void PiFinderMountBridge::applySlewRateForDrift(double driftArcmin)
@@ -609,6 +792,7 @@ void PiFinderMountBridge::handleGotoForward()
             {
                 LOGF_INFO("New PiFinder target (RA %.4fh, DEC %.4f deg) - forwarded Goto to mount.",
                           targetRA, targetDec);
+                setTargetSource(TARGET_SOURCE_PIFINDER);
                 m_lastForwardedRA = targetRA;
                 m_lastForwardedDec = targetDec;
                 m_settleRetriesRemaining = MAX_SETTLE_RETRIES;
@@ -750,6 +934,7 @@ void PiFinderMountBridge::handleGotoForward()
                     {
                         LOGF_INFO("New PiFinder target (RA %.4fh, DEC %.4f deg) while holding - forwarded Goto to mount.",
                                   targetRA, targetDec);
+                        setTargetSource(TARGET_SOURCE_PIFINDER);
                         m_lastForwardedRA = targetRA;
                         m_lastForwardedDec = targetDec;
                         m_settleRetriesRemaining = MAX_SETTLE_RETRIES;
@@ -995,6 +1180,21 @@ bool PiFinderMountBridge::ISNewSwitch(const char *dev, const char *name, ISState
             // and back.
             m_correctState = CorrectState::IDLE;
 
+            // Same for Reposition Detection's own tracking (#178) - don't
+            // let a stale "watching an external slew" or "confirmation
+            // pending" state, or an outdated drift-rate baseline, survive a
+            // mode switch.
+            m_externalSlewInProgress = false;
+            m_lastConfirmedGoodTime = 0;
+            m_repositionBaselineTrusted = false;
+            if (m_repositionConfirmPending)
+            {
+                m_repositionConfirmPending = false;
+                IUResetSwitch(&RepositionConfirmSP);
+                RepositionConfirmSP.s = IPS_IDLE;
+                IDSetSwitch(&RepositionConfirmSP, nullptr);
+            }
+
             // Persist so the chosen mode actually survives a reconnect -
             // see m_connectedConfigLoaded's comment. Without this, the
             // saved config just keeps replaying whatever was last actively
@@ -1086,6 +1286,79 @@ bool PiFinderMountBridge::ISNewSwitch(const char *dev, const char *name, ISState
 
             IUResetSwitch(&AbortMountSP);
             IDSetSwitch(&AbortMountSP, nullptr);
+            return true;
+        }
+
+        if (strcmp(name, RepositionConfirmSP.name) == 0)
+        {
+            IUUpdateSwitch(&RepositionConfirmSP, states, names, n);
+
+            if (!m_repositionConfirmPending)
+            {
+                LOG_WARN("No reposition confirmation is currently pending.");
+                RepositionConfirmSP.s = IPS_ALERT;
+            }
+            else if (RepositionConfirmS[REPOSITION_CONFIRM_YES].s == ISS_ON)
+            {
+                double piRA, piDec;
+                if (m_client->getPiFinderRADE(piRA, piDec))
+                {
+                    m_lastForwardedRA = piRA;
+                    m_lastForwardedDec = piDec;
+                    m_correctTargetRA = piRA;
+                    m_correctTargetDec = piDec;
+                    m_forwardState = ForwardState::HOLDING;
+                    m_correctState = CorrectState::IDLE;
+                    m_lastConfirmedGoodTime = time(nullptr);
+                    setTargetSource(TARGET_SOURCE_MOUNT);
+                    LOGF_INFO("Reposition confirmed - adopted (RA %.4fh, DEC %.4f deg) as the new held target.",
+                              piRA, piDec);
+                    RepositionConfirmSP.s = IPS_OK;
+                }
+                else
+                {
+                    LOG_ERROR("Could not read PiFinder's position to adopt - not ready.");
+                    RepositionConfirmSP.s = IPS_ALERT;
+                }
+                m_repositionConfirmPending = false;
+            }
+            else if (RepositionConfirmS[REPOSITION_CONFIRM_NO].s == ISS_ON)
+            {
+                double piRA, piDec;
+                if (m_client->getPiFinderRADE(piRA, piDec))
+                {
+                    // Same fix as the timeout path above (see its comment) -
+                    // route through the normal SLEWING state so the existing
+                    // SETTLING logic verifies real convergence, instead of
+                    // declaring success immediately.
+                    applySlewRateForDrift(angularSeparationArcmin(piRA, piDec, m_lastForwardedRA, m_lastForwardedDec));
+                    if (m_client->sendMountCoords(piRA, piDec, "SYNC") &&
+                        m_client->sendMountCoords(m_lastForwardedRA, m_lastForwardedDec, "TRACK"))
+                    {
+                        if (BridgeModeS[MODE_GOTO_FORWARD].s == ISS_ON)
+                        {
+                            m_settleRetriesRemaining = MAX_SETTLE_RETRIES;
+                            m_forwardState = ForwardState::SLEWING;
+                        }
+                        else
+                        {
+                            m_correctSettleRetriesRemaining = MAX_SETTLE_RETRIES;
+                            m_correctState = CorrectState::SLEWING;
+                        }
+                    }
+                    LOG_INFO("Reposition declined - reverting to the held target.");
+                    RepositionConfirmSP.s = IPS_OK;
+                }
+                else
+                {
+                    LOG_ERROR("Could not read PiFinder's position to revert from - not ready.");
+                    RepositionConfirmSP.s = IPS_ALERT;
+                }
+                m_repositionConfirmPending = false;
+            }
+
+            IUResetSwitch(&RepositionConfirmSP);
+            IDSetSwitch(&RepositionConfirmSP, nullptr);
             return true;
         }
     }

--- a/indi_pifinder_bridge/pifinder_mount_bridge.cpp
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.cpp
@@ -312,6 +312,60 @@ void PiFinderMountBridge::syncMountTypeToPiFinder()
     }
 }
 
+bool PiFinderMountBridge::isShadowDeviceSafe() const
+{
+    const std::string shadowName = ShadowDeviceT[SHADOW_DEVICE].text;
+    if (shadowName.empty())
+        return false;
+
+    // Must never fire if the shadow name happens to coincide with a real,
+    // load-bearing device (typo, profile mixup, future reconfiguration) -
+    // otherwise Shadow Sync would start Sync-ing the REAL mount or
+    // PiFinder straight from PiFinder's raw live position, completely
+    // bypassing Coupling's threshold/freshness/MaxSyncDrift gates. Found
+    // via user pushback (2026-08-08) while designing the auto-arm below -
+    // auto-arming removes the one manual "did I really mean to point this
+    // there" pause a human had before, so this check has to stand in for
+    // it unconditionally.
+    if (shadowName == std::string(ActiveDeviceT[ACTIVE_MOUNT].text))
+        return false;
+    if (shadowName == std::string(ActiveDeviceT[ACTIVE_PIFINDER].text))
+        return false;
+
+    return true;
+}
+
+void PiFinderMountBridge::autoArmShadowSyncIfDevicePresent()
+{
+    // Auto-enables ShadowSyncSP the moment its target device is actually
+    // present and safe to use - User decision (2026-08-08): keep the
+    // manual switch (discoverable, real off-switch) rather than removing
+    // it, but make sure nobody has to remember to (re-)flip it after every
+    // driver restart. Fires once per device (re)appearance, not every
+    // tick - m_shadowAutoArmed resets below once the device drops out
+    // again, so reconnecting re-triggers auto-arm rather than leaving a
+    // stale "already armed" flag across a device swap.
+    if (!m_client->isShadowReady() || !isShadowDeviceSafe())
+    {
+        m_shadowAutoArmed = false;
+        return;
+    }
+
+    if (m_shadowAutoArmed || ShadowSyncS[SHADOW_SYNC_ENABLE].s == ISS_ON)
+    {
+        m_shadowAutoArmed = true;
+        return;
+    }
+
+    IUResetSwitch(&ShadowSyncSP);
+    ShadowSyncS[SHADOW_SYNC_ENABLE].s = ISS_ON;
+    ShadowSyncSP.s = IPS_OK;
+    IDSetSwitch(&ShadowSyncSP, nullptr);
+    saveConfig(true, ShadowSyncSP.name);
+    m_shadowAutoArmed = true;
+    LOGF_INFO("Shadow device '%s' detected - Shadow Sync auto-enabled.", ShadowDeviceT[SHADOW_DEVICE].text);
+}
+
 void PiFinderMountBridge::handleShadowSync()
 {
     // Deliberately does not depend on m_client->isReady() (which requires
@@ -321,6 +375,9 @@ void PiFinderMountBridge::handleShadowSync()
     // never touches DriftStatusNP/exceeded/drift - those describe PiFinder
     // vs the *real* mount, unrelated to this.
     if (ShadowSyncS[SHADOW_SYNC_ENABLE].s != ISS_ON)
+        return;
+
+    if (!isShadowDeviceSafe())
         return;
 
     if (!m_client->isShadowReady())
@@ -345,6 +402,7 @@ void PiFinderMountBridge::TimerHit()
         return;
 
     syncMountTypeToPiFinder();
+    autoArmShadowSyncIfDevicePresent();
     handleShadowSync();
 
     if (!m_client->isReady())

--- a/indi_pifinder_bridge/pifinder_mount_bridge.h
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.h
@@ -104,6 +104,19 @@ class PiFinderMountBridge : public INDI::DefaultDevice
         // able to influence the real mount or Coupling correction logic -
         // it only ever reads PiFinder's position and Syncs a second
         // device, nothing else.
+        //
+        // Kept the manual switch (2026-08-08, User decision after
+        // weighing removing it): rather than removing the toggle to avoid
+        // "forgot to re-enable it", auto-arm it instead - see
+        // autoArmShadowSyncIfDevicePresent(), called whenever the shadow
+        // device is (re)detected, so it's on by default whenever the
+        // Simulator exists without the user needing to remember, while
+        // still leaving a real, discoverable way to turn it off if
+        // explicitly wanted (not just an obscure blank-the-name trick).
+        // Also gated by isShadowDeviceSafe() regardless of the switch -
+        // MUST never fire if the shadow name happens to equal the real
+        // ACTIVE_MOUNT/ACTIVE_PIFINDER (typo, profile mixup, future
+        // reconfiguration).
         ITextVectorProperty ShadowDeviceTP;
         IText ShadowDeviceT[1] {};
         enum { SHADOW_DEVICE };
@@ -111,6 +124,10 @@ class PiFinderMountBridge : public INDI::DefaultDevice
         ISwitchVectorProperty ShadowSyncSP;
         ISwitch ShadowSyncS[2];
         enum { SHADOW_SYNC_ENABLE, SHADOW_SYNC_DISABLE };
+
+        bool isShadowDeviceSafe() const;
+        bool m_shadowAutoArmed = false; // guards auto-arm to once per device (re)appearance, not every tick
+        void autoArmShadowSyncIfDevicePresent();
 
         void handleShadowSync();
 

--- a/indi_pifinder_bridge/pifinder_mount_bridge.h
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.h
@@ -335,6 +335,34 @@ class PiFinderMountBridge : public INDI::DefaultDevice
         // never needs to know *which* one - only that it wasn't itself).
         bool m_externalSlewInProgress = false;
 
+        // Fall-2 onset detection (2026-08-08 revision) - compares the
+        // mount's own EQUATORIAL_EOD_COORD tick-to-tick instead of watching
+        // for an IPS_BUSY state. Found live: a real, small/fast external
+        // Sync+Goto (~20', the exact "hand-paddle nudge" scenario #178 is
+        // meant to support) never produced an observable Busy state at all -
+        // verified via a raw INDI wire capture on port 7624, state stayed
+        // "Idle" throughout. isMountSlewing() is reliable for OUR OWN larger
+        // Goto-Forward/Auto-correct moves elsewhere in this file (unchanged,
+        // still fine there) but cannot be trusted as the *detection* signal
+        // for Fall 2, at any poll rate - the edge it would need to be caught
+        // on may simply never exist on the wire. A tick-to-tick position
+        // delta needs no such edge - any real movement shows up, however
+        // fast. Distinguished from passive drift (no tracking - see
+        // MAX_SIDEREAL_DRIFT_ARCMIN_PER_SEC's own comment: deliberate
+        // routine practice on this friction-clutch mount) using the exact
+        // same physical plausibility bound Fall 3/4 already uses, applied
+        // here to the mount's own movement rather than the PiFinder-vs-
+        // mount difference.
+        double m_lastPolledMountRA = std::nan("");
+        double m_lastPolledMountDec = std::nan("");
+        long m_lastPolledMountTime = 0;
+
+        // Once a genuine external move is detected, give the mount a few
+        // ticks to physically finish settling before trusting its position -
+        // same reasoning/constant as SETTLE_TICKS for our own moves, since
+        // isMountSlewing() can't reliably tell us "still moving" here either.
+        int m_externalSettleTicksRemaining = 0;
+
         // Timestamp of the last position Mount Bridge is confident is
         // correct (either a just-adopted reposition, or the last
         // successful HOLDING/SETTLING correction) - the reference point the

--- a/indi_pifinder_bridge/pifinder_mount_bridge.h
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.h
@@ -289,4 +289,102 @@ class PiFinderMountBridge : public INDI::DefaultDevice
         int m_correctSettleRetriesRemaining = 0;
 
         void handleAutoCorrectGoto(bool exceeded, double piRA, double piDec, double drift, double threshold);
+
+        // Reposition Detection (#178, 2026-08-08) - see
+        // docs/concepts/mount_bridge_reposition_detection.md for the full
+        // design (decision matrix, sequence diagrams, ADR). Runs as a
+        // shared pre-check in TimerHit(), before handleGotoForward()/
+        // handleAutoCorrectGoto() - classifies every PiFinder-vs-mount
+        // disagreement instead of blindly treating all of them as
+        // "ordinary drift to correct":
+        //   - Mount busy/moved, but NEITHER of our own state machines just
+        //     commanded it (SLEWING) -> an external client did (hand-paddle
+        //     over its own direct TCP/WiFi link to the mount controller,
+        //     SkySafari, the OnStep app, KStars-GoTo-on-the-mount - all
+        //     indistinguishable from each other and not distinguished on
+        //     purpose, see the concept doc's Architecture section). Wait
+        //     for it to finish + a fresh PiFinder solve, then adopt the new
+        //     position as the held target - no Sync/Goto needed, the
+        //     mount's own model is already correct since real motor motion
+        //     was involved.
+        //   - No command signal at all, but PiFinder-vs-mount disagree by
+        //     more than the sky's own physical speed limit could produce
+        //     since the last confirmed-good position -> the mount's
+        //     internal model itself is stale (classic case: clutch open,
+        //     OTA moved by hand without the motor/encoders registering it -
+        //     live-verified 2026-08-08, see basic-memory 00093). Genuinely
+        //     ambiguous whether this was deliberate (User: normal practice
+        //     on friction-clutch mounts, incl. occasionally this EQ-6) or
+        //     accidental - ask via ShadowSync-style low-friction
+        //     confirmation rather than guessing either way.
+        // Returns true if this tick was fully handled here (external slew
+        // in progress or just adopted, or a Fall-4 confirmation is pending/
+        // just resolved) - callers must skip their own normal handling for
+        // this tick in that case, so the old per-mode Sync+re-Goto logic
+        // never fires on the same drift a pending confirmation is already
+        // watching.
+        bool handleRepositionDetection(bool havePositions, double piRA, double piDec, double mountRA,
+                                        double mountDec, double drift);
+
+        // True while we're watching a mount slew we did NOT ourselves just
+        // command (i.e. neither ForwardState::SLEWING nor
+        // CorrectState::SLEWING) - sudden onset is what proves "someone
+        // else is driving this mount right now" (see 3.1/3.2 in the concept
+        // doc: the INDI driver reflects the mount controller's real state
+        // regardless of which external client caused it, so Mount Bridge
+        // never needs to know *which* one - only that it wasn't itself).
+        bool m_externalSlewInProgress = false;
+
+        // Timestamp of the last position Mount Bridge is confident is
+        // correct (either a just-adopted reposition, or the last
+        // successful HOLDING/SETTLING correction) - the reference point the
+        // physical drift-rate classification measures elapsed time from.
+        // Deliberately time_t via std::time(), matching isPiFinderSolveFresh()'s
+        // own existing timestamp convention elsewhere in this file.
+        long m_lastConfirmedGoodTime = 0;
+        static constexpr double MAX_SIDEREAL_DRIFT_ARCMIN_PER_SEC = 0.35; // measured live 2026-08-08 (~0.25-0.3'/s), generous margin
+
+        // Found live (2026-08-08): right after a restart/mode-switch,
+        // m_lastConfirmedGoodTime gets baselined on the very first tick
+        // regardless of how much drift already exists (e.g. accumulated
+        // during the restart itself, or left over from before) - the very
+        // NEXT tick then judges that pre-existing drift against only ~1
+        // poll interval of elapsed time, almost always exceeding the
+        // physical plausibility bound and misfiring Fall 4 before the
+        // existing, proven HOLDING/Auto-correct mechanism ever got a
+        // chance to just fix it normally. Fix: the rate-based Fall-3/4
+        // judgment only activates once a genuine confirmed-good moment
+        // (drift already within Threshold) has actually been observed
+        // since the last reset - until then, defer entirely to the
+        // existing correction logic (still backstopped by MaxSyncDriftNP).
+        bool m_repositionBaselineTrusted = false;
+
+        // Fall 4 (clutch/disturbance) pending-confirmation state - a
+        // ShadowSync-style low-friction Yes/No, not a full manual-Sync
+        // workflow. Times out to an automatic "No" (revert) rather than
+        // sitting on a stale position indefinitely if nobody answers.
+        bool m_repositionConfirmPending = false;
+        long m_repositionConfirmDeadline = 0;
+        static constexpr int REPOSITION_CONFIRM_TIMEOUT_SEC = 45;
+        ISwitchVectorProperty RepositionConfirmSP;
+        ISwitch RepositionConfirmS[2];
+        enum { REPOSITION_CONFIRM_YES, REPOSITION_CONFIRM_NO };
+
+        // Read-only "who does the currently held target come from" badge
+        // (#178 GUI unification, 2026-08-08): with Reposition Detection
+        // active, MODE_GOTO_FORWARD alone already reacts symmetrically to
+        // both a PiFinder push-to (Fall 1) and an external mount-side
+        // command (Fall 2) - the separate "Follow mount's goto" preset
+        // (MODE_AUTO_CORRECT+ACTION_GOTO) is now redundant for this use
+        // case. The GUI replaces both with a single "GoTo" button (always
+        // sets MODE_GOTO_FORWARD) and shows this badge instead of making
+        // the user pre-select a source. Set whenever a target is adopted -
+        // Fall 1 -> PIFINDER, Fall 2/Fall-4-confirmed-yes -> MOUNT (the
+        // mount's own position was what got trusted); ordinary Fall-3
+        // corrections and Fall-4 reverts don't change the source, they're
+        // just re-affirming the existing held target.
+        ISwitchVectorProperty TargetSourceSP;
+        ISwitch TargetSourceS[2];
+        enum { TARGET_SOURCE_PIFINDER, TARGET_SOURCE_MOUNT };
+        void setTargetSource(int index);
 };

--- a/indi_pifinder_bridge/pifinder_mount_bridge.h
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.h
@@ -129,6 +129,17 @@ class PiFinderMountBridge : public INDI::DefaultDevice
         bool m_shadowAutoArmed = false; // guards auto-arm to once per device (re)appearance, not every tick
         void autoArmShadowSyncIfDevicePresent();
 
+        // Mode-Readiness-Check (2026-08-08, User request): runs whenever a
+        // Coupling mode other than Off is (re-)selected. Verifies known
+        // easy-to-forget preconditions instead of silently assuming them -
+        // reports what it can't fix itself, auto-corrects what it safely
+        // can (currently: MaxSyncDriftNP being smaller than
+        // DriftThresholdNP, which would silently block every correction
+        // in that gap forever). Deliberately does NOT touch
+        // TELESCOPE_TRACK_STATE or anything else the user might have
+        // intentionally configured - see 00090's Regel 2 in basic-memory.
+        void runModeReadinessCheck();
+
         void handleShadowSync();
 
         // Coupling degree - see 00009 for the rationale of each stage.

--- a/indi_pifinder_bridge/pifinder_mount_bridge.h
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.h
@@ -387,4 +387,11 @@ class PiFinderMountBridge : public INDI::DefaultDevice
         ISwitch TargetSourceS[2];
         enum { TARGET_SOURCE_PIFINDER, TARGET_SOURCE_MOUNT };
         void setTargetSource(int index);
+
+        // Read-only, GUI-visible warning distinct from DriftStatusNP - see
+        // the initProperties() comment. Empty message + IPS_OK/IDLE while
+        // clear, driver's own refusal text + IPS_ALERT while active.
+        ITextVectorProperty MountRejectTP;
+        IText MountRejectT[1];
+        void setMountRejectWarning(bool active, const std::string &message);
 };

--- a/indi_pifinder_simulator/pifinder_simulator.cpp
+++ b/indi_pifinder_simulator/pifinder_simulator.cpp
@@ -1,5 +1,7 @@
 #include "pifinder_simulator.h"
 
+#include <cstring>
+
 static std::unique_ptr<PiFinderSimulator> pifinder_simulator(new PiFinderSimulator());
 
 PiFinderSimulator::PiFinderSimulator()
@@ -24,6 +26,22 @@ bool PiFinderSimulator::initProperties()
     SetParkDataType(PARK_NONE);
 
     addAuxControls();
+
+    PushToTargetNP[0].fill("RA", "RA (h)", "%.6f", 0, 24, 0, 0);
+    PushToTargetNP[1].fill("DEC", "DEC (deg)", "%.6f", -90, 90, 0, 0);
+    PushToTargetNP.fill(getDeviceName(), "SIMULATE_PUSH_TO", "Simulate push-to", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
+
+    return true;
+}
+
+bool PiFinderSimulator::updateProperties()
+{
+    INDI::Telescope::updateProperties();
+
+    if (isConnected())
+        defineProperty(PushToTargetNP);
+    else
+        deleteProperty(PushToTargetNP);
 
     return true;
 }
@@ -72,4 +90,29 @@ bool PiFinderSimulator::Sync(double ra, double dec)
     LOGF_INFO("Sync: RA %.4fh, DEC %.4f deg.", ra, dec);
     NewRaDec(m_currentRA, m_currentDEC);
     return true;
+}
+
+bool PiFinderSimulator::ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
+{
+    if (dev != nullptr && !strcmp(dev, getDeviceName()) && !strcmp(name, PushToTargetNP.getName()))
+    {
+        PushToTargetNP.update(values, names, n);
+        PushToTargetNP.setState(IPS_OK);
+        PushToTargetNP.apply();
+
+        // Deliberately only touches TargetNP (TARGET_EOD_COORD), not
+        // m_currentRA/DEC - see the header comment on PushToTargetNP. A real
+        // push-to doesn't change PiFinder's own reported position either.
+        TargetNP[0].setValue(PushToTargetNP[0].getValue());
+        TargetNP[1].setValue(PushToTargetNP[1].getValue());
+        TargetNP.setState(IPS_OK);
+        TargetNP.apply();
+
+        LOGF_INFO("Simulated PiFinder push-to: RA %.4fh, DEC %.4f deg (TARGET_EOD_COORD updated, "
+                  "current position left unchanged).",
+                  PushToTargetNP[0].getValue(), PushToTargetNP[1].getValue());
+        return true;
+    }
+
+    return INDI::Telescope::ISNewNumber(dev, name, values, names, n);
 }

--- a/indi_pifinder_simulator/pifinder_simulator.h
+++ b/indi_pifinder_simulator/pifinder_simulator.h
@@ -45,11 +45,13 @@ class PiFinderSimulator : public INDI::Telescope
 
     protected:
         bool initProperties() override;
+        bool updateProperties() override;
         bool Connect() override;
         bool Disconnect() override;
         bool ReadScopeStatus() override;
         bool Goto(double ra, double dec) override;
         bool Sync(double ra, double dec) override;
+        bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
 
     private:
         // Wherever it was last Sync'd/GoTo'd to - defaults to RA 0h/Dec 0deg
@@ -58,4 +60,15 @@ class PiFinderSimulator : public INDI::Telescope
         // fix in #107) until the user sets something real.
         double m_currentRA = 0.0;
         double m_currentDEC = 0.0;
+
+        // Distinct from Sync()/Goto() above, which move the simulated "sky
+        // truth" position itself (m_currentRA/DEC, what a test session feeds
+        // PiFinder via fake_solve). This instead only updates the inherited
+        // TargetNP (TARGET_EOD_COORD) - the exact same base-class mechanism
+        // every real INDI::Telescope driver (including the real "PiFinder
+        // LX200") populates on a genuine push-to, and exactly what Mount
+        // Bridge's getPiFinderTargetRADE() watches for Fall 1 detection.
+        // Lets a test session simulate a PiFinder push-to without needing
+        // real PiFinder hardware/software running - see #186.
+        INDI::PropertyNumber PushToTargetNP {2};
 };


### PR DESCRIPTION
## Summary

Batches several rounds of Mount Bridge work plus this session's GUI/driver fixes:

**Reposition Detection & safety (#178, #186)**
- Unified GoTo mode: single button, auto-detects whether PiFinder or the mount drove the last reposition instead of requiring a pre-selected direction.
- Fall 2 (external mount reposition) detection reworked from IPS_BUSY-based (proven live not to fire reliably for small/fast OnStep moves) to a tick-to-tick mount-position delta comparison.
- Native detection of the mount silently refusing/clamping a Goto or Sync (elevation/cable-wrap/axis limits), surfaced as a GUI warning instead of failing silently.
- Fall 3/4 drift checks gated on solve freshness; mutex added around the shared client/driver state; infinite-loop bugs in the original Reposition Detection fixed.

**Mode readiness & Shadow Sync**
- Mode-Readiness-Check: verifies/auto-fixes known preconditions when a coupling mode is enabled instead of failing opaquely.
- Shadow Sync auto-arms when its target device is present, with a safety guard.

**This session (2026-08-08/09)**
- Fix #194: Goto-Forward silently ignored the first Goto after any mode switch (or a driver restart while already active) - `ISNewSwitch()` now snapshots the existing target as the forwarding baseline instead of blanking it to NaN.
- Fix #195: `DriftThresholdNP`/`MaxSyncDriftNP`/`SolveFreshnessMaxAgeNP` never called `saveConfig()`, so none of them survived a driver restart.
- Fix #188 (dup: #167): `_startup_hardware_test()`'s Cam/GPS check now retries indefinitely instead of giving up after one bounded window, so a slow full reboot no longer leaves a stale "unreachable" result.
- Fix #187: OLED-mirror tile no longer looks dead for 3-60s+ after a real Pi reboot - explicit "Waiting for PiFinder…" overlay.
- GUI: Mount Bridge's connection diagram/drift readout/status moved into the PiFinder tile (grouped with Cam/Solve/IMU/GPS, both pure status displays); mode-caption and mount-reject warning no longer reflow the whole page on text-length changes; drift readout shows degrees+arcmin past 60'.
- GUI: Quick keys D-pad now visibly flashes red on an actual failed press instead of looking identical to a successful one (was a silent no-op).
- GUI: Quick Links redesigned - IP rows as small buttons with full-address tooltips, new OnStep Web UI link (IP read live from the mount driver's own `DEVICE_ADDRESS`), "Open all links" button with popup-blocker detection, GitHub/PiFinder/StellarMate split into separate rows with Discord invites added.
- `docs/concepts/mount_bridge_multistar_alignment.md`: concept doc for automatic multi-star/multi-point alignment (#191, not yet implemented).
- CHANGELOG.md and help.html updated to match.

## Test plan

- [x] TC-PFSM-178-01 Steps 1-4 (Fall 1-3 + Fall 2 external reposition) - passed live against real hardware (hand controller, real GoTo, real camera solve).
- [x] Goto-Forward first-click fix - live-verified against real KStars + OnStep mount after the fix.
- [x] Threshold/MaxSyncDrift/SolveFreshness persistence - build deployed live, config now saved on set.
- [x] Startup hardware test self-heal, OLED-mirror wait overlay - live-verified across a real full Pi reboot.
- [x] D-pad, Quick Links (IP buttons, Open all links, OnStep Web UI discovery) - live-verified in browser against real hardware.
- [ ] TC-PFSM-178-01 Step 5 (Fall 4 confirmation flow) - not yet run, tracked separately (#184/#185).
