### PR TITLE
Fix #192 (OLED-mirror wait state) and #193 (Solve badge/Mount Bridge freshness explanation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable changes to this project are documented in this file. Format loosely 
 
 ### Added
 
+- Fix #192: the OLED-mirror wait overlay now queries `pifinder.service`'s own systemd state
+  (`_real_service_state()`, `gui_installer/server.py`, surfaced via `/api/pifinder_mode`'s new
+  `real_service_state` field) instead of only inferring things from `/image` probe success/failure -
+  shows "PiFinder service is starting…" while systemd itself is still activating, and "PiFinder
+  service failed to start" if it crashes outright, instead of the same generic "Waiting for
+  PiFinder…" throughout regardless of what's actually happening. Deliberately leaves the "inactive"
+  state's message alone (still the generic wait text) - that state is indistinguishable here from a
+  legitimately-up Fake Mode, which runs as a separate, non-systemd process this check doesn't see.
+- **Solve badge / Mount Bridge freshness (#193)**: added an explanatory tooltip to the ampel's
+  "Solve" badge (it reflects whether the camera is *currently* solving, with no age limit - a
+  different question from Mount Bridge's own "fresh enough to correct from" check) and a matching
+  parenthetical in Mount Bridge's own "waiting on fresh solve" caption details, instead of changing
+  either one's actual criteria - the two can legitimately disagree (this can stay green off an older
+  solve while Mount Bridge is still waiting for a newer one), so the fix is explaining the
+  distinction, not eliminating it.
 - **Injected Solve (Dead Reckoning)**: a real, visible simulation mode - injects a one-time RA/Dec
   into PiFinder (seeded from the currently coupled mount, or the API directly) and lets PiFinder's
   own IMU dead-reckoning carry it forward from there, the same mechanism a real solve uses. Renamed

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -240,6 +240,23 @@ def _real_service_failed() -> bool:
     ).returncode == 0
 
 
+def _real_service_state() -> str:
+    """pifinder.service's raw systemd ActiveState string (active,
+    activating, inactive, failed, deactivating, ...) - added 2026-08-09
+    (#192) so the frontend's OLED-mirror wait overlay can say something
+    concrete about *why* it's still waiting instead of a generic message
+    the whole time. Deliberately not --quiet: without it, `systemctl
+    is-active` prints the state to stdout regardless of exit code (a
+    non-0 exit just means "not active", the printed state still tells you
+    which of inactive/failed/activating/deactivating it actually is)."""
+    result = subprocess.run(
+        ["systemctl", "is-active", "pifinder.service"],
+        capture_output=True,
+        text=True,
+    )
+    return (result.stdout or "").strip() or "unknown"
+
+
 def _lcd_overlay_active() -> bool:
     """Whether the Waveshare LCD dev overlay is active right now - checked
     against the actual framebuffer device, not /boot/config.txt (overlays
@@ -2128,7 +2145,17 @@ class Handler(BaseHTTPRequestHandler):
             else:
                 mode = "none"
             self._send_json(
-                {"mode": mode, "transitioning": transitioning, "error": error, "target": target}
+                {
+                    "mode": mode,
+                    "transitioning": transitioning,
+                    "error": error,
+                    "target": target,
+                    # Raw systemd state (#192) - lets the OLED-mirror wait
+                    # overlay distinguish "service not started"/"failed" from
+                    # "started, just not answering /image yet" instead of a
+                    # single generic message throughout.
+                    "real_service_state": _real_service_state(),
+                }
             )
             return
 

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -1276,7 +1276,7 @@
       <div id="pifinder-glance-row">
         <div id="pifinder-screen-wrap">
           <img id="pifinder-screen" src="/pifinder_welcome.png" alt="PiFinder screen" title="PiFinder OLED screen (live once running)">
-          <div id="pifinder-screen-waiting">Waiting for<br>PiFinder&hellip;</div>
+          <div id="pifinder-screen-waiting"><span id="pifinder-screen-waiting-text">Waiting for<br>PiFinder&hellip;</span></div>
           <a class="help-link pifinder-screen-help" href="https://pifinder.readthedocs.io/en/release/user_guide.html" target="_blank" rel="noopener" title="PiFinder User Guide">i</a>
         </div>
         <!-- Quick keys: same LEFT/UP/DOWN/RIGHT/SQUARE(+LNG_ Long-combo) codes
@@ -1337,7 +1337,7 @@
             </svg>
             <span>Cam</span>
           </div>
-          <div class="mode-ampel-badge" title="Solve">
+          <div class="mode-ampel-badge" title="Solve - green means the camera is currently succeeding at plate-solving, with no age limit. This is a different question from Mount Bridge's own 'fresh enough to correct from' check (its Solve Freshness setting, default 5s) - the two can disagree: this can stay green off an older solve while Mount Bridge is still waiting for a newer one.">
             <svg class="mode-ampel-icon mode-ampel-icon-unconfirmed" id="mode-ampel-solve-icon" style="color:#f5a623;" viewBox="0 0 24 24" aria-hidden="true">
               <circle cx="12" cy="12" r="8" fill="none" stroke="currentColor" stroke-width="1.3"/>
               <path d="M12 2.5v4M12 17.5v4M2.5 12h4M17.5 12h4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
@@ -1795,6 +1795,13 @@ let modeLogPolling = false;
 let lastHwCamera = null;
 let lastHwImu = null;
 let lastDebugSolve = null;
+// pifinder.service's raw systemd state (from refreshMode()'s own poll,
+// every 5s) - read by updatePiFinderStatusAndWizardLink()'s wait overlay
+// (2026-08-09, #192) so it can say something concrete ("service is
+// starting…", "service failed to start") instead of a single generic
+// message for the entire time pifinderScreenUrl is still null, regardless
+// of *why*.
+let lastRealServiceState = null;
 
 // Builds "camera", "IMU", or "camera/IMU" from whichever of the two is
 // actually missing - both "not functional" messages below used to hardcode
@@ -1947,6 +1954,22 @@ function updatePiFinderStatusAndWizardLink() {
   // Found live 2026-08-03 testing PR #154's reinstall on real hardware.
   document.getElementById('mode-ampel-row').style.display = pifinderScreenUrl ? 'flex' : 'none';
   document.getElementById('pifinder-screen-waiting').classList.toggle('pifinder-screen-waiting-visible', !pifinderScreenUrl);
+  if (!pifinderScreenUrl) {
+    // Only override the default "Waiting for PiFinder…" text for the two
+    // unambiguous systemd states (#192) - "inactive" is deliberately left
+    // alone, since that's also what a legitimately-up Fake Mode looks like
+    // here (lastRealServiceState only ever reflects the real pifinder.service
+    // unit, not Fake Mode's separate non-systemd process) - showing "not
+    // running" there would be actively wrong, not just unhelpful.
+    const waitingTextEl = document.getElementById('pifinder-screen-waiting-text');
+    if (lastRealServiceState === 'activating') {
+      waitingTextEl.innerHTML = 'PiFinder service<br>is starting&hellip;';
+    } else if (lastRealServiceState === 'failed') {
+      waitingTextEl.innerHTML = 'PiFinder service<br>failed to start';
+    } else {
+      waitingTextEl.innerHTML = 'Waiting for<br>PiFinder&hellip;';
+    }
+  }
   if (pifinderScreenUrl) {
     const base = pifinderScreenUrl.replace(/\/image.*$/, '');
     const port = new URL(pifinderScreenUrl).port || 80;
@@ -3461,6 +3484,10 @@ async function refreshMode() {
   try {
     const resp = await fetch('/api/pifinder_mode', { cache: 'no-store' });
     const data = await resp.json();
+    if (data.real_service_state !== lastRealServiceState) {
+      lastRealServiceState = data.real_service_state || null;
+      updatePiFinderStatusAndWizardLink();
+    }
     if (data.transitioning) {
       dotEl.className = 'status-dot dot-yellow dot-unconfirmed';
       textEl.textContent = data.target === 'real' ? 'Starting Real Mode…' : 'Starting Fake Mode…';
@@ -3984,7 +4011,7 @@ function applyMbDriftAndMode(couplingMode, correctionAction, driftArcmin, driftS
       gated ? 'dot-unconfirmed' : exceeded ? 'dot-yellow' : 'dot-green',
       gated ? 'Waiting on fresh solve' : exceeded ? 'Correcting now' : 'Watching for drift',
       gated
-        ? `Drift ${formatDrift(driftArcmin)} exceeds ${threshold}', but PiFinder's last solve isn't fresh enough to correct from yet`
+        ? `Drift ${formatDrift(driftArcmin)} exceeds ${threshold}', but PiFinder's last solve isn't fresh enough to correct from yet (the Solve badge above can still show green here - it has no age limit of its own, see its tooltip)`
         : exceeded
         ? `Correcting the mount now - drift ${formatDrift(driftArcmin)} exceeds ${threshold}'`
         : `Watching for drift - will correct the mount past ${threshold}'`
@@ -4007,7 +4034,7 @@ function applyMbDriftAndMode(couplingMode, correctionAction, driftArcmin, driftS
       busy
         ? `Correcting the mount now - drift ${formatDrift(driftArcmin)} exceeds ${threshold}'`
         : exceeded
-        ? `Drift ${formatDrift(driftArcmin)} exceeds ${threshold}' - waiting on a fresh PiFinder solve (or drift is too large to auto-sync) before correcting`
+        ? `Drift ${formatDrift(driftArcmin)} exceeds ${threshold}' - waiting on a fresh PiFinder solve (or drift is too large to auto-sync) before correcting (the Solve badge above can still show green here - it has no age limit of its own, see its tooltip)`
         : `Holding target - drift ${driftArcmin !== null ? formatDrift(driftArcmin) : '0.0\''} within ${threshold}'`
     );
   }


### PR DESCRIPTION
## Summary

- Fix #192: the OLED-mirror wait overlay now queries `pifinder.service`'s own systemd state (`_real_service_state()` in `gui_installer/server.py`, exposed via `/api/pifinder_mode`'s new `real_service_state` field) instead of only inferring things from `/image` probe success/failure. Shows "PiFinder service is starting…" while systemd is activating, and "PiFinder service failed to start" on a crash, instead of a single generic "Waiting for PiFinder…" message throughout.
- Fix #193: added an explanatory tooltip to the ampel's "Solve" badge and a matching parenthetical in Mount Bridge's "waiting on fresh solve" caption - explains the legitimate difference between "camera is currently solving" (no age limit) and "fresh enough for Mount Bridge to correct from" (age-gated), instead of changing either one's criteria.

## Test plan

- [x] `_real_service_state()` verified directly against the live `pifinder.service` unit (`active` case confirmed).
- [x] Python (`server.py`) and HTML/JS (`status_page.html`) syntax/tag-balance validated.
- [ ] Live verification of the "activating"/"failed" overlay text during a real service restart - not yet observed live, only reasoned from `systemctl is-active`'s documented output and the existing polling wiring.
