### PR TITLE
Fix #194 properly: event-triggered Goto-Forward target detection

### DIFF
--- a/indi_pifinder_bridge/pifinder_bridge_client.cpp
+++ b/indi_pifinder_bridge/pifinder_bridge_client.cpp
@@ -104,11 +104,21 @@ void PiFinderBridgeClient::newProperty(INDI::Property property)
 void PiFinderBridgeClient::updateProperty(INDI::Property property)
 {
     const bool fromMount = m_mountName == property.getDeviceName();
+    const bool fromPiFinder = m_piFinderName == property.getDeviceName();
 
     if (fromMount && property.isNameMatch("EQUATORIAL_EOD_COORD") && property.getState() == IPS_ALERT)
     {
         std::lock_guard<std::mutex> lock(m_mountRejectMutex);
         m_mountRejectedLastCoords = true;
+    }
+    else if (fromPiFinder && property.isNameMatch("TARGET_EOD_COORD"))
+    {
+        // Every genuine Goto request on the PiFinder device re-publishes
+        // this property (see consumePiFinderTargetPending()'s own comment
+        // in the header) - mark it pending regardless of whether the value
+        // actually changed from last time.
+        std::lock_guard<std::mutex> lock(m_piFinderTargetMutex);
+        m_piFinderTargetPending = true;
     }
 }
 
@@ -179,6 +189,14 @@ bool PiFinderBridgeClient::getPiFinderTargetRADE(double &ra, double &dec) const
     ra = m_piFinderTargetNP->at(0)->getValue();
     dec = m_piFinderTargetNP->at(1)->getValue();
     return true;
+}
+
+bool PiFinderBridgeClient::consumePiFinderTargetPending()
+{
+    std::lock_guard<std::mutex> lock(m_piFinderTargetMutex);
+    const bool wasPending = m_piFinderTargetPending;
+    m_piFinderTargetPending = false;
+    return wasPending;
 }
 
 bool PiFinderBridgeClient::isMountSlewing() const

--- a/indi_pifinder_bridge/pifinder_bridge_client.h
+++ b/indi_pifinder_bridge/pifinder_bridge_client.h
@@ -44,6 +44,27 @@ class PiFinderBridgeClient : public INDI::BaseClient
         // solved position and never changes just because a target was set.
         bool getPiFinderTargetRADE(double &ra, double &dec) const;
 
+        // Edge-triggered companion to getPiFinderTargetRADE() above (added
+        // for the Goto-Forward mode-switch safety fix, see
+        // handleGotoForward()/ISNewSwitch() in pifinder_mount_bridge.cpp).
+        // getPiFinderTargetRADE() only ever answers "what is PiFinder's
+        // target *right now*" - it cannot tell "a fresh Goto request just
+        // arrived" apart from "the same value has been sitting there since
+        // before", which is exactly the ambiguity that made a value-only
+        // comparison unsafe (turning Goto-Forward mode on could immediately
+        // re-fire whatever target happened to already be there). This flag
+        // is set in updateProperty() on every genuine TARGET_EOD_COORD
+        // update from the PiFinder device - including a request for the
+        // *same* RA/Dec as before, since libindi's own INDI::Telescope::
+        // ISNewNumber() re-publishes that property on every incoming Goto
+        // request regardless of whether the value changed (verified against
+        // this project's own PiFinder LX200 driver, see lx200_pifinder.cpp's
+        // Goto() comment) - so a fresh click always sets this, even for an
+        // unchanged target, while a target that's merely still sitting there
+        // from before never does. consumePiFinderTargetPending() reads and
+        // clears it atomically so each real event is only ever acted on once.
+        bool consumePiFinderTargetPending();
+
         // True while the mount is actively slewing (EQUATORIAL_EOD_COORD busy).
         bool isMountSlewing() const;
 
@@ -115,6 +136,14 @@ class PiFinderBridgeClient : public INDI::BaseClient
         mutable std::mutex m_mountRejectMutex;
         bool m_mountRejectedLastCoords = false;
         std::string m_mountRejectMessage;
+
+        // Guards m_piFinderTargetPending - same cross-thread reasoning as
+        // m_mountRejectMutex above (written from updateProperty()'s I/O
+        // thread, read/cleared from the driver's TimerHit() thread). Own
+        // mutex rather than reusing m_mountRejectMutex - unrelated state,
+        // no reason to couple their locking.
+        mutable std::mutex m_piFinderTargetMutex;
+        bool m_piFinderTargetPending = false;
 
         std::string m_shadowName;
         bool m_shadowOnline = false;

--- a/indi_pifinder_bridge/pifinder_mount_bridge.cpp
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.cpp
@@ -812,36 +812,35 @@ void PiFinderMountBridge::handleGotoForward()
             if (!hasTarget)
                 return;
 
-            if (std::isnan(m_lastForwardedRA))
+            if (!m_client->consumePiFinderTargetPending())
             {
-                // First observation since entering this mode - establish a
-                // baseline without forwarding a Goto, so switching into
-                // Goto-Forward (or a driver restart, e.g. for a hot-swapped
-                // build) doesn't immediately re-send whatever push-to target
-                // happened to already be set on PiFinder.
+                // No genuinely new Goto *event* since we started watching
+                // (a BridgeMode switch, or a driver restart while this mode
+                // was already active) - see consumePiFinderTargetPending()'s
+                // own header comment for why this is event-based, not a
+                // value comparison. Whatever target is already sitting here
+                // is presumed stale/already acted on, not something to
+                // blindly re-fire (found live 2026-08-09: turning Goto-
+                // Forward on immediately re-slewed to the last-held target -
+                // an earlier value-comparison approach here couldn't
+                // reliably tell "stale" apart from "new").
                 //
-                // Transition straight to HOLDING rather than staying IDLE:
+                // Still move to HOLDING rather than staying IDLE forever:
                 // found live (2026-08-08) that a driver restart while
                 // Goto-Forward was already active and holding a target left
-                // the state machine permanently stuck in IDLE - the target
-                // hadn't "changed" since it was already set before the
-                // restart, so isNewTarget below never fired and drift went
-                // uncorrected indefinitely (Altair drifted to 3.3' with no
-                // correction). HOLDING doesn't fire anything on this tick
-                // either (no Goto here), but from the *next* tick on it
-                // actively re-checks drift/threshold and self-corrects -
-                // exactly the same "just establish a baseline, don't fire
-                // yet" intent above, but without going permanently dormant.
+                // the state machine permanently stuck in IDLE - nothing
+                // "new" ever arrived, so drift went uncorrected indefinitely
+                // (Altair drifted to 3.3' with no correction). HOLDING does
+                // not fire anything on this tick either (no Goto here), but
+                // from the *next* tick on it both actively re-checks drift/
+                // threshold (self-correcting via the existing settle logic)
+                // and applies this exact same pending-flag check itself, so
+                // a subsequent genuinely new target still fires immediately.
                 m_lastForwardedRA = targetRA;
                 m_lastForwardedDec = targetDec;
                 m_forwardState = ForwardState::HOLDING;
                 return;
             }
-
-            const bool isNewTarget = std::abs(targetRA - m_lastForwardedRA) > 1e-9 ||
-                                      std::abs(targetDec - m_lastForwardedDec) > 1e-9;
-            if (!isNewTarget)
-                return;
 
             {
                 double mountRA, mountDec;
@@ -999,12 +998,11 @@ void PiFinderMountBridge::handleGotoForward()
         case ForwardState::HOLDING:
         {
             // A new push-to target always takes priority over continuing to
-            // hold the old one - same "is this genuinely new" check as IDLE.
+            // hold the old one - same pending-event check as IDLE (see
+            // consumePiFinderTargetPending()'s header comment).
             if (hasTarget)
             {
-                const bool isNewTarget = std::abs(targetRA - m_lastForwardedRA) > 1e-9 ||
-                                          std::abs(targetDec - m_lastForwardedDec) > 1e-9;
-                if (isNewTarget)
+                if (m_client->consumePiFinderTargetPending())
                 {
                     {
                         double mountRA, mountDec;
@@ -1293,27 +1291,25 @@ bool PiFinderMountBridge::ISNewSwitch(const char *dev, const char *name, ISState
             // re-entering it always re-baselines against whatever target
             // PiFinder currently has instead of reacting to a stale one.
             //
-            // Snapshot that existing target directly as the baseline (rather
-            // than NaN) - found live (2026-08-09): NaN made handleGotoForward()
-            // treat the *next* observed target, even a genuinely new one just
-            // picked in KStars right as/after this mode switch, as "first
-            // observation, just baseline it, don't forward" (see that
-            // function's own comment) - the Goto silently did nothing on the
-            // first press and only fired on a second, distinct-enough one.
-            // Snapshotting here still protects against re-firing a stale
-            // pre-existing target (the actual original intent), while letting
-            // a target that's different from what was already there act
-            // immediately. Falls back to NaN if PiFinder has no target at all
-            // yet - handleGotoForward()'s isnan-guarded baseline path (needed
-            // separately for a driver restart while this mode is already
-            // active, which never runs through ISNewSwitch at all) still
-            // covers that case correctly.
+            // Discard any pending target-update event from before this
+            // switch - handleGotoForward()'s IDLE case (see its own comment)
+            // now reacts to a genuinely new Goto *event*
+            // (consumePiFinderTargetPending(), edge-triggered) rather than
+            // comparing RA/Dec values, so this is a plain "start listening
+            // from here" reset, not a value snapshot. This replaces an
+            // earlier value-snapshot version of this fix (2026-08-09) that
+            // turned out unsafe live: turning Goto-Forward on immediately
+            // re-slewed to the mount's last-held target, because a value
+            // comparison alone can't reliably tell "stale target already
+            // sitting there" apart from "genuinely new" (see
+            // pifinder_bridge_client.h's consumePiFinderTargetPending() for
+            // why an event-based signal fixes that). A target that was
+            // already there before this switch produces no new event and is
+            // correctly ignored; picking the very same object again in
+            // KStars right after switching modes still fires immediately,
+            // since that click produces a fresh event regardless of value.
             m_forwardState = ForwardState::IDLE;
-            if (!m_client->getPiFinderTargetRADE(m_lastForwardedRA, m_lastForwardedDec))
-            {
-                m_lastForwardedRA = std::nan("");
-                m_lastForwardedDec = std::nan("");
-            }
+            m_client->consumePiFinderTargetPending();
 
             // Same idea for Auto-Correct's Goto-refine state machine - don't
             // let an in-progress settle/retry cycle from a previous mode


### PR DESCRIPTION
## Summary

The previous #194 fix (merged via PR #196) snapshotted the existing PiFinder target as the forwarding baseline on a BridgeMode switch, comparing RA/Dec values to detect "genuinely new" targets. Found live: turning Goto-Forward on immediately re-slewed the mount to whatever target was already sitting there - a value comparison alone cannot reliably tell "stale target" apart from "fresh request for the same coordinates."

Replaced with an event-based signal instead. `PiFinderBridgeClient` now tracks `m_piFinderTargetPending`, set in `updateProperty()` whenever `TARGET_EOD_COORD` updates arrive from the PiFinder device - libindi's own `INDI::Telescope::ISNewNumber()` republishes that property on every incoming Goto request regardless of whether the value changed (see `lx200_pifinder.cpp`'s `Goto()` comment), so a fresh click always sets this even for an unchanged target, while a target merely still sitting there from before never does. `consumePiFinderTargetPending()` reads and clears it atomically.

`handleGotoForward()`'s IDLE and HOLDING cases now check-and-consume this flag instead of comparing RA/Dec against `m_lastForwardedRA/Dec`. `ISNewSwitch()` just consumes/clears the flag on a BridgeMode switch (discarding whatever's pending from before), rather than snapshotting a value.

## Test plan

- [x] Stale pre-existing target no longer fires when Goto-Forward is turned on (mount correctly held at PiFinder's actual live position instead) - verified against Telescope Simulator + Injected Solve, no real mount involved.
- [x] A genuinely new target still fires immediately on the first request, no second click needed - verified via both KStars and direct INDI property writes.
- [x] Root-caused an initial false failure (mount not slewing to a genuinely new target) to a stuck long-running driver process, not driver logic - confirmed via debug-instrumented build showing correct pending/consume/fire behavior on a fresh process; a clean driver restart resolved it. Root cause of the original stall not yet fully pinned down (tracked as a follow-up, not blocking this fix).