### PR TITLE
Mount Bridge: retry-with-backoff for cold-start property-binding race (#159)

### DIFF
--- a/indi_pifinder_bridge/pifinder_bridge_client.cpp
+++ b/indi_pifinder_bridge/pifinder_bridge_client.cpp
@@ -16,6 +16,11 @@ void PiFinderBridgeClient::setDevices(const std::string &piFinderName, const std
     m_mountAbortSP = nullptr;
     m_mountSlewRateSP = nullptr;
 
+    m_bindingRetryTicksElapsed = 0;
+    m_bindingRetryCooldownTicks = 0;
+    m_bindingRetryAttempts = 0;
+    m_bindingGaveUp = false;
+
     watchDevice(m_piFinderName.c_str());
     watchDevice(m_mountName.c_str());
 }
@@ -23,6 +28,46 @@ void PiFinderBridgeClient::setDevices(const std::string &piFinderName, const std
 bool PiFinderBridgeClient::isReady() const
 {
     return m_piFinderEqNP != nullptr && m_mountEqNP != nullptr && m_mountOnCoordSetSP != nullptr;
+}
+
+bool PiFinderBridgeClient::retryMissingPropertiesIfNeeded()
+{
+    if (isReady() || m_bindingGaveUp)
+        return false;
+
+    ++m_bindingRetryTicksElapsed;
+
+    if (m_bindingRetryTicksElapsed < BINDING_RETRY_GRACE_TICKS)
+        return false;
+
+    if (m_bindingRetryCooldownTicks > 0)
+    {
+        --m_bindingRetryCooldownTicks;
+        return false;
+    }
+
+    if (m_bindingRetryAttempts >= BINDING_RETRY_MAX_ATTEMPTS)
+    {
+        m_bindingGaveUp = true;
+        return false;
+    }
+
+    // Re-request only whichever properties never arrived - watchProperty(),
+    // unlike watchDevice(), actually resends <getProperties> on every call,
+    // which is exactly what's needed here (a device/property that showed up
+    // late gets asked again, one that's genuinely never coming doesn't get
+    // silently retried forever without eventually hitting the attempt cap
+    // above).
+    if (!m_piFinderEqNP)
+        watchProperty(m_piFinderName.c_str(), "EQUATORIAL_EOD_COORD");
+    if (!m_mountEqNP)
+        watchProperty(m_mountName.c_str(), "EQUATORIAL_EOD_COORD");
+    if (!m_mountOnCoordSetSP)
+        watchProperty(m_mountName.c_str(), "ON_COORD_SET");
+
+    ++m_bindingRetryAttempts;
+    m_bindingRetryCooldownTicks = BINDING_RETRY_INTERVAL_TICKS;
+    return true;
 }
 
 void PiFinderBridgeClient::setShadowDevice(const std::string &shadowName)

--- a/indi_pifinder_bridge/pifinder_bridge_client.h
+++ b/indi_pifinder_bridge/pifinder_bridge_client.h
@@ -24,6 +24,32 @@ class PiFinderBridgeClient : public INDI::BaseClient
 
         void setDevices(const std::string &piFinderName, const std::string &mountName);
 
+        // Cold-start property-binding race (#159): watchDevice() in
+        // setDevices() only ever sends the initial <getProperties> request
+        // once - if indiserver or the watched driver itself hasn't finished
+        // registering yet at that exact moment (common right after a full
+        // Pi reboot, when every driver is starting up together), the
+        // properties isReady() depends on may simply never arrive, with
+        // nothing to notice or retry. Live-verified: a plain
+        // Disconnect()/Connect() cycle does NOT recover this (it repeats
+        // the same one-shot request), only a full process restart did.
+        // Call once per TimerHit() tick while !isReady() - internally
+        // no-ops until a short grace period has passed (give the original
+        // subscription a first real chance), then re-requests whichever of
+        // the three properties are still missing via watchProperty()
+        // (which - unlike watchDevice() - actually resends
+        // <getProperties> on every call), on a bounded backoff. Returns
+        // true on ticks where a retry was actually (re-)issued, so the
+        // driver can log it. See bindingGaveUp() for the final-failure case.
+        bool retryMissingPropertiesIfNeeded();
+
+        // True once BINDING_RETRY_MAX_ATTEMPTS has been exhausted without
+        // isReady() ever becoming true - a genuinely absent/misconfigured
+        // device (wrong name in Active devices, driver not actually
+        // running), not just a slow cold-start race. Reset by setDevices()
+        // (a fresh Connect() deserves a fresh attempt).
+        bool bindingGaveUp() const { return m_bindingGaveUp; }
+
         // Third, fully independent device (#181) - purely mirrors
         // PiFinder's position via Sync for visualization/testing, never
         // participates in isReady()/getMountRADE()/sendMountCoords(). Safe
@@ -128,6 +154,17 @@ class PiFinderBridgeClient : public INDI::BaseClient
         INDI::PropertyViewSwitch *m_mountMountTypeSP = nullptr;
         INDI::PropertyViewSwitch *m_mountAbortSP = nullptr;
         INDI::PropertyViewSwitch *m_mountSlewRateSP = nullptr;
+
+        // #159 cold-start property-binding retry - tick-counted (against
+        // TimerHit()'s own ~2s period), same idiom as the driver's own
+        // SETTLE_TICKS/MAX_FRESHNESS_WAIT_TICKS, not wall-clock timing.
+        static constexpr int BINDING_RETRY_GRACE_TICKS = 2;    // ~4s: let the original subscription resolve on its own first
+        static constexpr int BINDING_RETRY_INTERVAL_TICKS = 2; // ~4s between retry attempts
+        static constexpr int BINDING_RETRY_MAX_ATTEMPTS = 3;   // "a handful", ~16s total budget incl. grace
+        int m_bindingRetryTicksElapsed = 0;
+        int m_bindingRetryCooldownTicks = 0;
+        int m_bindingRetryAttempts = 0;
+        bool m_bindingGaveUp = false;
 
         // Written from updateProperty()/newMessage() (INDI::BaseClient's own
         // I/O thread), read/written from sendMountCoords()/

--- a/indi_pifinder_bridge/pifinder_mount_bridge.cpp
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.cpp
@@ -715,9 +715,24 @@ void PiFinderMountBridge::TimerHit()
 
     if (!m_client->isReady())
     {
+        // #159: cold-start race - a watched device/property that hadn't
+        // registered with indiserver yet when Connect() first ran could
+        // otherwise sit "not ready" forever, indistinguishable from a real
+        // functional bug (isReady() gates most of the driver's own
+        // behavior, and nothing here previously explained why).
+        if (m_client->retryMissingPropertiesIfNeeded())
+            LOG_INFO("PiFinder/mount device properties not all available yet - retrying subscription.");
+        else if (m_client->bindingGaveUp() && !m_bindingGiveUpLogged)
+        {
+            LOG_ERROR("PiFinder/mount device properties never became available - check Active "
+                      "devices names match running drivers, or that both are actually connected. "
+                      "Reconnect once confirmed.");
+            m_bindingGiveUpLogged = true;
+        }
         SetTimer(getCurrentPollingPeriod());
         return;
     }
+    m_bindingGiveUpLogged = false;
 
     // Drift is computed and published whenever the bridge is ready
     // (PiFinder solving, mount connected), regardless of Coupling mode -

--- a/indi_pifinder_bridge/pifinder_mount_bridge.h
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.h
@@ -129,6 +129,13 @@ class PiFinderMountBridge : public INDI::DefaultDevice
         bool m_shadowAutoArmed = false; // guards auto-arm to once per device (re)appearance, not every tick
         void autoArmShadowSyncIfDevicePresent();
 
+        // #159: guards the "binding never resolved" ERROR log to once per
+        // give-up, not every tick thereafter - reset whenever isReady()
+        // comes true again (a later disconnect/reconnect deserves a fresh
+        // warning if it happens again). See PiFinderBridgeClient::
+        // retryMissingPropertiesIfNeeded()/bindingGaveUp().
+        bool m_bindingGiveUpLogged = false;
+
         // Mode-Readiness-Check (2026-08-08, User request): runs whenever a
         // Coupling mode other than Off is (re-)selected. Verifies known
         // easy-to-forget preconditions instead of silently assuming them -


### PR DESCRIPTION
## Summary

Fixes #159: `PiFinderBridgeClient::setDevices()` only ever sends the initial `<getProperties>` request once via `watchDevice()` - if indiserver or the watched driver itself hadn't finished registering yet at that exact moment (common right after a full Pi reboot, when every driver starts up together), the properties `isReady()` depends on could simply never arrive, with nothing to notice or retry. `isReady()` gates most of the driver's behavior, so this looked like a real functional bug ("Mount is source" completely broken) rather than a timing race - distinguishable from #158's scenario only by checking `isReady()` directly.

New `PiFinderBridgeClient::retryMissingPropertiesIfNeeded()`, called once per `TimerHit()` tick while `!isReady()`: after a short grace period, re-requests whichever of the three properties (`EQUATORIAL_EOD_COORD` x2, `ON_COORD_SET`) are still missing via `watchProperty()` (which, unlike `watchDevice()`, actually resends `<getProperties>` on every call), on a bounded backoff - a handful of attempts over ~16s total, then gives up and logs an error once, so a genuinely absent/misconfigured device (wrong name in Active devices, driver not actually running) is visible rather than retried forever.

## Test plan

Live-verified directly against the real driver/INDI stack via `indi_setprop`/`indi_getprop` + raw INDI protocol capture (`socat`), plus a real cold restart (FIFO `stop`/`start` - the same mechanism a full reboot would trigger for this driver):

- [x] **Genuine give-up path**: persisted a deliberately nonexistent device name in `ACTIVE_DEVICES.ACTIVE_MOUNT`, did a full FIFO `stop`/`start` (fresh process, same as a cold boot), captured the raw INDI message stream - got exactly 3 `[INFO] ... retrying subscription` messages followed by exactly 1 `[ERROR] ... never became available`, correctly spaced (~4s apart) and never repeated after give-up.
- [x] **No regression on the happy path**: normal restart with the real device configured - `isReady()` becomes true within the grace period, drift starts computing correctly, zero retry/give-up messages logged.
- [x] Verified internal state progression (`bindingGaveUp()` transitioning false→true at the expected tick) via temporary debug instrumentation, removed before this commit.

## Also found (filing separately, out of scope here)

While testing, found that changing `ACTIVE_DEVICES` while already connected - #158's own live-reconnect path, which calls `Disconnect()`/`Connect()` directly rather than through the standard `CONNECTION` switch - leaves `TimerHit()` permanently stopped afterward (confirmed via drift never updating again even after reverting to the real device; only a full process restart recovered it). Will file as a new issue.