### PR TITLE
Fix picamera2/drm_preview.py patch drift, pin picamera2==0.3.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,6 +248,17 @@ All notable changes to this project are documented in this file. Format loosely 
 
 ### Fixed
 
+- **picamera2/drm_preview.py patch drift**: `diffs/drm_preview_smos.diff` (makes the optional `pykms`
+  import gracefully absent on Arch/SMOS) failed to apply against picamera2 0.3.37 - found live on a
+  fresh Pi5 install, `pip install picamera2` pulled 0.3.37 (a newer release than this Pi4's existing
+  0.3.36), whose `drm_preview.py` had gained a new `FMT_MAP` entry (`"NV12"`) the diff's hunks didn't
+  account for, breaking the whole camera import on that device. Same fragility class as the earlier
+  pandas/#190 patch-drift issues - `picamera2` was entirely unpinned in requirements.txt, so a fresh
+  install's exact version (and therefore whether any given patch still applies) depended purely on
+  *when* setup happened to run. Regenerated the diff against the real 0.3.37 source and pinned
+  `picamera2==0.3.37` explicitly in `pifinder_stellarmate_setup.sh` (same reasoning as the existing
+  python-libcamera pin) so the diff and the installed version can no longer drift apart on a fresh
+  install.
 - Fix #194: Goto-Forward silently ignored the first Goto after any BridgeMode switch (or a driver
   restart while it was already the active mode) - `ISNewSwitch()`'s reset of the forwarding baseline
   to a NaN sentinel made `handleGotoForward()` treat the very next observed target, even a brand new

--- a/diffs/drm_preview_smos.diff
+++ b/diffs/drm_preview_smos.diff
@@ -1,5 +1,5 @@
---- /tmp/drm_preview_orig.py	2026-05-22 18:28:54.725687732 +0200
-+++ /home/stellarmate/PiFinder/python/.venv/lib/python3.14/site-packages/picamera2/previews/drm_preview.py	2026-05-21 11:29:04.457029530 +0200
+--- drm_preview_0337_orig.py	2026-08-09 23:46:56.874942410 +0200
++++ drm_preview_0337_patched.py	2026-08-09 23:47:15.300381835 +0200
 @@ -8,9 +8,16 @@
      # If available, use pure python kms package
      import kms as pykms
@@ -28,7 +28,7 @@
          self.lock = threading.Lock()
          self.use_count = 0
  
-@@ -49,20 +58,22 @@
+@@ -49,21 +58,23 @@
  
  class DrmPreview(NullPreview):
      FMT_MAP = {
@@ -42,11 +42,13 @@
 -        "XBGR8888": PixelFormat.XBGR8888,
 -        "YUV420": PixelFormat.YUV420,
 -        "YVU420": PixelFormat.YVU420,
+-        "NV12": PixelFormat.NV12,
 -        "MJPEG": PixelFormat.BGR888,
 +        "XRGB8888": PixelFormat.XRGB8888 if _pykms_available else None,
 +        "XBGR8888": PixelFormat.XBGR8888 if _pykms_available else None,
 +        "YUV420": PixelFormat.YUV420 if _pykms_available else None,
 +        "YVU420": PixelFormat.YVU420 if _pykms_available else None,
++        "NV12": PixelFormat.NV12 if _pykms_available else None,
 +        "MJPEG": PixelFormat.BGR888 if _pykms_available else None,
      }
  

--- a/pifinder_stellarmate_setup.sh
+++ b/pifinder_stellarmate_setup.sh
@@ -633,6 +633,19 @@ else
     find "${pifinder_home}/PiFinder" -type f -name "*.pyc" -delete
     find "${pifinder_home}/PiFinder" -type d -name "__pycache__" -delete
 
+    # Pin picamera2 to a known-good version - PiFinder's own requirements.txt
+    # leaves it unpinned, so a fresh install can silently pull a newer
+    # release whose drm_preview.py has drifted from
+    # diffs/drm_preview_smos.diff's expected context, breaking the patch
+    # applied below (found live 2026-08-09: a fresh Pi5 install pulled
+    # 0.3.37, which added an FMT_MAP entry the diff's hunks didn't account
+    # for - same fragility class as the pandas/#190 patch-drift issues).
+    # Same reasoning as python-libcamera's pin above - keep this version and
+    # the diff in sync; if drm_preview.py's patch ever needs regenerating
+    # for a newer picamera2, bump this pin to match in the same change.
+    echo "🔧 Pinning picamera2 to 0.3.37 (matches diffs/drm_preview_smos.diff) ..."
+    pip install picamera2==0.3.37
+
     # Install python-libinput 0.1.0 manually (0.3.0a0 unavailable; setup.py uses removed 'imp')
     echo "🔧 Installing python-libinput 0.1.0 (patched for Python 3.12+) ..."
     LIBINPUT_TMP=$(mktemp -d)


### PR DESCRIPTION
## Summary

Found live tonight on a fresh Pi5 install (`dev` branch, from scratch): setup completed with a CRITICAL WARNING - `drm_preview.py patch FAILED for picamera2 0.3.37 — update diffs/drm_preview_smos.diff! Camera import will fail.`

Root cause: `picamera2` is entirely unpinned in PiFinder's own `requirements.txt`, so a fresh `pip install` grabs whatever's newest on PyPI at that moment. This Pi5 install pulled 0.3.37 (newer than any version the diff was tested against); upstream added a new `FMT_MAP` entry (`"NV12"`) between the existing entries, shifting the lines `diffs/drm_preview_smos.diff`'s third hunk expected, so `patch` failed on that hunk and left `drm_preview.py` unpatched - `pykms` (not available on Arch/SMOS) would then hard-fail on import when the camera tries to display a preview.

Confirmed **not** Pi5-specific - it's purely a picamera2-version-drift issue that depends on when `pip install` happens to run, independent of Pi model. This Pi4 wasn't affected only because its venv was set up earlier, while 0.3.36 was still current.

## Fix

- Regenerated `diffs/drm_preview_smos.diff` against the real picamera2 0.3.37 upstream source (downloaded the actual wheel, applied the same semantic patch - optional `pykms` import, guarded `FMT_MAP`/`DrmManager`/`DrmPreview.__init__` - now also covering the new `NV12` entry).
- Pinned `picamera2==0.3.37` explicitly in `pifinder_stellarmate_setup.sh`, right after `install_requirements()` - same reasoning as the existing `python-libcamera` pin just above it in the same script. Keeps the diff and the installed version from drifting apart on any future fresh install, closing off this whole fragility class (same pattern as the earlier pandas/#190 patch-drift issues).

## Test plan

- [x] Downloaded the real picamera2 0.3.37 wheel, extracted `drm_preview.py`, confirmed the new diff applies cleanly via the exact same invocation the setup script uses (`patch -N target < diff`) - byte-exact match against the intended patched output, no `.rej` file.
- [x] Confirmed the new diff does *not* apply cleanly to the older 0.3.36 (expected - the `FMT_MAP` hunk differs) - not a regression since the new pin means fresh installs never see 0.3.36 again.
- [x] `bash -n pifinder_stellarmate_setup.sh` - syntax check passes.
- [ ] Not yet re-run end-to-end on the actual Pi5 that hit this - the Pi5 session is picking this up next.