### PR TITLE
Sync mount from PiFinder: drop to standard 500 font-weight

### DIFF
--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -624,7 +624,7 @@
      other buttons at rest and only visibly change while actually
      processing, via the :disabled rule below during triggerManualSync()'s
      in-flight window). */
-  .mb-big-sync-btn { background: #222; color: #ddd; border-color: #444; }
+  .mb-big-sync-btn { background: #222; color: #ddd; border-color: #444; font-weight: 500; }
   .mb-big-sync-btn:not(:disabled):hover { border-color: #777; }
   .mb-big-sync-btn:disabled { background: #1a1a1a; color: #666; border-color: #333; cursor: default; }
   /* Deliberately loud/red, unlike every other small button here - this is


### PR DESCRIPTION
Follow-up to #208 - direct feedback that the button still read as bolder than its Auto-correct/GoTo neighbors after the color fix. `.mb-big-action-btn`'s shared base carries `font-weight:600` (intentional for `.mb-abort-btn`'s panic-button emphasis), which the color-only fix didn't override for Sync. Now explicitly matches `.mb-coupling-btn`'s 500.