### PR TITLE
docs: sync README version banner to PiFinder 2.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ The primary goal is to allow users to leverage the powerful plate-solving and ob
 
 > ### ✅ **Current Version — v2.0.0**
 >
-> * Built and verified for **PiFinder software 2.6.0** on **StellarMate OS 2.2.1** (Arch Linux) — PiFinder is now pinned to this exact release tag (see `version.txt`), not the upstream `release` branch's moving HEAD, for reproducible installs.
+> * Built and verified for **PiFinder software 2.6.1** on **StellarMate OS 2.2.1** (Arch Linux) — PiFinder is now pinned to this exact release tag (see `version.txt`), not the upstream `release` branch's moving HEAD, for reproducible installs.
 > * **Raspberry Pi 4**: Fully supported — camera ✅, plate solve ✅, IMU ✅, GPS ✅. Tested under real night sky (2026-07-12).
 > * **Raspberry Pi 5**: Supported — GPS ✅, Web UI ✅, OLED ✅. (A months-long "OLED stays dark" issue was traced to a defective HAT unit, not a Pi5/software limitation — resolved 2026-07-17 by swapping the physical HAT board.) **Keyboard ⚠️**: on the test unit, a Geekworm X1203 UPS shield shares GPIO 16 with the keypad matrix's column 0 (keys 7/4/1/LEFT), permanently disabling that whole column — a real hardware resource conflict between the two add-on boards, not a Pi5 or software limitation, and specific to setups with that UPS shield attached. Camera requires a 15-pin FFC CSI adapter cable (Pi4 uses 22-pin) — not yet installed on the test unit.
-> * **INDI integration**: standalone LX200 driver + optional real-mount coupling ("Mount Bridge"), verified end-to-end against a real Skywatcher EQ5/OnStepX mount, all five Coupling presets (including the new "Mount is source" simulation mode) — see [Readme_PiFinder_LX200.md](Readme_PiFinder_LX200.md) and [CHANGELOG.md](CHANGELOG.md).
+> * **INDI integration**: standalone LX200 driver + optional real-mount coupling ("Mount Bridge"), verified end-to-end against a real Skywatcher EQ5/OnStepX mount, all four Coupling presets — see [Readme_PiFinder_LX200.md](Readme_PiFinder_LX200.md) and [CHANGELOG.md](CHANGELOG.md).
 > * **New in this release**: the PiFinder tile gained "Quick keys" — a compact on-page keypad (arrows, Long, Enter, two selectable layouts) to drive PiFinder's OLED menu without switching to its separate Remote page. Mount Bridge, PiFinder Mode/Test/Power, and Install or Update are now collapsible, with your choice remembered across reloads. A Night mode toggle renders all page text in glowing red. PiFinder installs/updates now target a pinned release tag instead of the upstream `release` branch's moving HEAD, fixing an installer that could refuse to run the moment upstream cut a new release. A new "PiFinder" status badge shows PiFinder's own Mount Type + PiFinder Type settings at a glance (green while running, red if they don't match the connected mount), and the Mount Bridge diagram's mount icon now shows the mount's own type. See [CHANGELOG.md](CHANGELOG.md) for the full list.
 
 ---
@@ -158,10 +158,8 @@ coupled mount and let real IMU dead-reckoning track from there, for testing with
 "Toggle Display" button
 for an optional secondary small SPI display (see `test_tools/`), and always-available Reboot/Shutdown
 buttons for the whole Pi. A **Mount Bridge** tile folds the Coupling Dial setup (Web Manager profile,
-drivers, mount link, connect, and five one-click Coupling presets — Verify/Alert only,
-Auto-correct (Sync), Auto-correct (Goto & Track), Goto-Forward, and "Mount is source" - reverses the
-usual direction so the mount drives PiFinder's position instead, for full simulation without any
-PiFinder hardware) into a single guided checklist,
+drivers, mount link, connect, and four one-click Coupling presets — Verify/Alert only,
+Auto-correct (Sync), Auto-correct (Goto & Track), and Goto-Forward) into a single guided checklist,
 including an "Autoconnect" mode that drives the whole thing automatically once you pick a Coupling
 preset, or an explicit "Setup" button to run that same setup deliberately first. Run it with:
 ```bash

--- a/README_de.md
+++ b/README_de.md
@@ -16,10 +16,10 @@ Das Hauptziel ist es, Nutzern die leistungsfähigen Plate-Solving- und Objektsuc
 
 > ### ✅ **Aktuelle Version — v2.0.0**
 >
-> * Gebaut und verifiziert für **PiFinder-Software 2.6.0** auf **StellarMate OS 2.2.1** (Arch Linux) — PiFinder ist jetzt fest auf diesen Release-Tag gepinnt (siehe `version.txt`), nicht mehr auf den beweglichen HEAD des upstream `release`-Branches, für reproduzierbare Installationen.
+> * Gebaut und verifiziert für **PiFinder-Software 2.6.1** auf **StellarMate OS 2.2.1** (Arch Linux) — PiFinder ist jetzt fest auf diesen Release-Tag gepinnt (siehe `version.txt`), nicht mehr auf den beweglichen HEAD des upstream `release`-Branches, für reproduzierbare Installationen.
 > * **Raspberry Pi 4**: Vollständig unterstützt — Kamera ✅, Plate-Solve ✅, IMU ✅, GPS ✅. Unter echtem Nachthimmel getestet (2026-07-12).
 > * **Raspberry Pi 5**: Unterstützt — GPS ✅, Web-UI ✅, OLED ✅. (Ein monatelanges "OLED bleibt dunkel"-Problem entpuppte sich als defektes HAT-Board, kein Pi5-/Software-Problem — gelöst am 2026-07-17 durch Austausch des physischen HAT-Boards.) **Tastatur ⚠️**: Am Testgerät belegt ein Geekworm-X1203-UPS-Shield GPIO 16 gemeinsam mit Spalte 0 der Tastaturmatrix (Tasten 7/4/1/LEFT) — dadurch ist diese komplette Spalte dauerhaft unbrauchbar. Ein echter Hardware-Ressourcenkonflikt zwischen zwei Aufsteck-Boards, kein Pi5- oder Software-Problem, und nur relevant bei Setups mit diesem UPS-Shield. Kamera benötigt ein 15-poliges FFC-CSI-Adapterkabel (Pi4 nutzt 22-polig) — beim Testgerät noch nicht verbaut.
-> * **INDI-Integration**: eigenständiger LX200-Treiber + optionale Kopplung an eine echte Montierung ("Mount Bridge"), Ende-zu-Ende verifiziert gegen eine echte Skywatcher-EQ5/OnStepX-Montierung, alle fünf Coupling-Presets (inklusive des neuen Simulationsmodus "Mount is source") — siehe [Readme_PiFinder_LX200_de.md](Readme_PiFinder_LX200_de.md) und [CHANGELOG.md](CHANGELOG.md).
+> * **INDI-Integration**: eigenständiger LX200-Treiber + optionale Kopplung an eine echte Montierung ("Mount Bridge"), Ende-zu-Ende verifiziert gegen eine echte Skywatcher-EQ5/OnStepX-Montierung, alle vier Coupling-Presets — siehe [Readme_PiFinder_LX200_de.md](Readme_PiFinder_LX200_de.md) und [CHANGELOG.md](CHANGELOG.md).
 > * **Neu in diesem Release**: die PiFinder-Kachel hat "Quick keys" bekommen — ein kompaktes Tastenfeld direkt auf der Seite (Pfeile, Long, Enter, zwei wählbare Layouts), um PiFinders OLED-Menü zu bedienen, ohne auf die separate Remote-Seite zu wechseln. Mount Bridge, PiFinder Mode/Test/Power und Install or Update sind jetzt einklappbar, die Wahl bleibt über Reloads hinweg gespeichert. Ein Night-Mode-Umschalter stellt den gesamten Seitentext in leuchtendem Rot dar. PiFinder-Installationen/Updates zielen jetzt auf einen gepinnten Release-Tag statt auf den beweglichen HEAD des upstream `release`-Branches — behebt einen Installer, der sich weigern konnte zu laufen, sobald upstream einen neuen Release geschnitten hat. Ein neues "PiFinder"-Badge zeigt PiFinders eigene Mount-Type- + PiFinder-Type-Einstellungen auf einen Blick (grün solange PiFinder läuft, rot bei Nichtübereinstimmung mit der verbundenen Montierung), und das Montierungssymbol im Mount-Bridge-Diagramm zeigt jetzt zusätzlich den eigenen Mount Type der Montierung. Siehe [CHANGELOG.md](CHANGELOG.md) für die vollständige Liste.
 
 ---
@@ -159,10 +159,8 @@ Reckoning verfolgt sie danach weiter, zum Testen ohne Himmelszugang), ein "Toggl
 für ein optionales kleines SPI-Zweitdisplay
 (siehe `test_tools/`) sowie immer verfügbare Reboot-/Shutdown-Buttons für den ganzen Pi. Eine
 **Mount-Bridge**-Kachel fasst die Einrichtung des Coupling Dial (Web-Manager-Profil, Treiber,
-Mount-Verknüpfung, Verbinden sowie fünf Ein-Klick-Coupling-Presets — Verify/Alert only,
-Auto-correct (Sync), Auto-correct (Goto & Track), Goto-Forward und "Mount is source" — kehrt die
-übliche Richtung um, sodass die Montierung PiFinders Position vorgibt statt umgekehrt, für volle
-Simulation ganz ohne PiFinder-Hardware) in einer einzigen geführten
+Mount-Verknüpfung, Verbinden sowie vier Ein-Klick-Coupling-Presets — Verify/Alert only,
+Auto-correct (Sync), Auto-correct (Goto & Track) und Goto-Forward) in einer einzigen geführten
 Checkliste zusammen, inklusive eines "Autoconnect"-Modus, der den ganzen Ablauf automatisch
 durchführt, sobald ein Coupling-Preset ausgewählt wird, oder eines expliziten "Setup"-Buttons, um
 das gezielt vorab zu erledigen. Starten mit:


### PR DESCRIPTION
Fixes the stale version banner (README.md/README_de.md) - PiFinder software 2.6.0 → 2.6.1 (matching version.txt), and dropped the "Mount is source" Coupling preset mention (removed from the codebase entirely on 2026-08-05, 77ee83d) - both READMEs still described it as one of five presets; corrected to four. Left the "v2.0.0" project-version headline untouched since no v2.x git tag exists yet.