### PR TITLE
Mount Bridge: route ActiveDevices reconnect through the standard connection flow (#204)

### DIFF
--- a/indi_pifinder_bridge/pifinder_mount_bridge.cpp
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.cpp
@@ -1684,11 +1684,34 @@ bool PiFinderMountBridge::ISNewText(const char *dev, const char *name, char *tex
             // time that happened - a self-inflicted periodic drop that
             // looked identical to "something else keeps killing the
             // connection" from the outside.
+            // #204: Connect()/Disconnect() called as plain functions here
+            // used to bypass INDI::DefaultDevice's own post-connect
+            // bookkeeping entirely - the framework's own CONNECTION switch
+            // handler (defaultdevice.cpp's onNewValues lambda) always
+            // follows a successful Connect()/Disconnect() with
+            // setConnected()+updateProperties(), which is what actually
+            // flips isConnected() and re-defines/deletes the
+            // connected-only properties (including the ones #161's second
+            // loadConfig(true) call and TimerHit()'s own continued
+            // scheduling implicitly depend on). Skipping both left
+            // TimerHit() permanently stopped after this reconnect - found
+            // live (2026-08-10) testing #159: drift froze for good, even
+            // after reverting ActiveDeviceTP back to the original working
+            // device, only a full process restart recovered it. Now
+            // mirrors the framework's own two-branch sequence exactly.
             if (changed && isConnected())
             {
                 LOG_INFO("Active devices changed - reconnecting to apply.");
-                Disconnect();
-                Connect();
+                if (Disconnect())
+                {
+                    setConnected(false, IPS_IDLE);
+                    updateProperties();
+                }
+                if (Connect())
+                {
+                    setConnected(true);
+                    updateProperties();
+                }
             }
             return true;
         }


### PR DESCRIPTION
## Summary
- `ActiveDeviceTP`'s `ISNewText()` reconnect handler called `Disconnect()`/`Connect()` as plain function calls, bypassing `INDI::DefaultDevice`'s own post-connect bookkeeping (`setConnected()` + `updateProperties()`) entirely.
- Confirmed against the real libindi source (`defaultdevice.cpp`'s `onNewValues` lambda for `CONNECTION`): the framework always follows a successful `Connect()`/`Disconnect()` with those two calls - skipping them left `TimerHit()` permanently stopped after this reconnect path.
- Fix mirrors the framework's own two-branch sequence exactly.

Fixes #204.

## Test plan
- [x] Built cleanly (`bash bin/build_indi_bridge.sh`)
- [x] Live-verified: set `ACTIVE_MOUNT` to a nonexistent device, then back to the working one; injected a real PiFinder position change via `/api/fake_solve` and confirmed `DRIFT_ARCMIN` updated within the very next poll tick (2s) - proves `TimerHit()` is not stuck after the reconnect