### PR TITLE
Multi-Point Alignment (#191): real candidate selection, Control Center GUI, simulator test tooling

### DIFF
--- a/diffs/api_extensions_py.diff
+++ b/diffs/api_extensions_py.diff
@@ -1,16 +1,36 @@
-diff --git a/python/PiFinder/api_extensions.py b/python/PiFinder/api_extensions.py
-index 5d973c7b..04179883 100644
---- a/python/PiFinder/api_extensions.py
-+++ b/python/PiFinder/api_extensions.py
-@@ -21,6 +21,7 @@ import logging
- 
+--- python/PiFinder/api_extensions.py.orig
++++ python/PiFinder/api_extensions.py
+@@ -18,13 +18,29 @@
+ import io
+ import json
+ import logging
++import math
+
  from flask import request, session, Response
  from PIL import Image
 +from PiFinder.types.positioning import FakeSolve
- 
+
  logger = logging.getLogger("PiFinderAPI")
- 
-@@ -160,6 +161,8 @@ def register_api_routes(app, server_instance, require_auth=False):
+
+
++def _angular_separation_deg(ra1, dec1, ra2, dec2) -> float:
++    """Great-circle separation in degrees between two J2000 RA/Dec points
++    (both in degrees). Standard haversine form - no existing helper for
++    this in calc_utils.py/catalogs.py to reuse."""
++    ra1_r, dec1_r, ra2_r, dec2_r = (math.radians(x) for x in (ra1, dec1, ra2, dec2))
++    d_ra = ra2_r - ra1_r
++    d_dec = dec2_r - dec1_r
++    a = (
++        math.sin(d_dec / 2) ** 2
++        + math.cos(dec1_r) * math.cos(dec2_r) * math.sin(d_ra / 2) ** 2
++    )
++    return math.degrees(2 * math.asin(min(1.0, math.sqrt(a))))
++
++
+ def _json_response(data, status=200):
+     """Unified JSON response format"""
+     return Response(
+@@ -160,6 +176,8 @@
                  "power_state": ss.power_state(),
                  "solve_state": ss.solve_state(),
                  "camera_type": ss.camera_type(),
@@ -19,10 +39,10 @@ index 5d973c7b..04179883 100644
                  "location": loc.to_dict() if loc else None,
                  "solution": _solution_to_dict(sol),
                  "datetime": {
-@@ -213,6 +216,35 @@ def register_api_routes(app, server_instance, require_auth=False):
+@@ -213,6 +231,162 @@
              logger.error("api/location error: %s", e)
              return _json_response({"error": str(e)}, 500)
- 
+
 +    @app.route("/api/current_target")
 +    def api_current_target():
 +        """Returns the on-device push-to target, if any - whatever object the
@@ -52,13 +72,140 @@ index 5d973c7b..04179883 100644
 +            logger.error("api/current_target error: %s", e)
 +            return _json_response({"error": str(e)}, 500)
 +
++    @app.route("/api/nearby_bright_stars")
++    def api_nearby_bright_stars():
++        """
++        Return up to `count` named bright stars from PiFinder's own "Str"
++        catalog within `radius` degrees of a center point, each currently at
++        or above `min_altitude` degrees of altitude - candidate targets for
++        an external automated multi-point mount-alignment sequence (Mount
++        Bridge's own MULTI_POINT_ALIGN, see PiFinder_Stellarmate's
++        docs/concepts/mount_bridge_multistar_alignment.md §4.2).
++
++        Not PiFinder's own "alignment" (camera-to-eyepiece target_pixel
++        calibration - see docs/ax/positioning/CONTEXT.md). Deliberately
++        named to avoid that established vocabulary rather than collide
++        with it - this has nothing to do with target_pixel/AlignOnRaDec.
++
++        Query parameters:
++            ra, dec: degrees, J2000 - center of the search. Defaults to
++                PiFinder's own current solved position if omitted.
++            radius: degrees, default 60.
++            count: max results, default 4.
++            min_altitude: degrees above horizon, default 20.
++
++        Returns {"candidates": [{"ra": deg, "dec": deg, "name": str or null,
++        "mag": float or null, "altitude": deg}, ...]}, sorted brightest
++        (lowest magnitude) first, already altitude-filtered - callers do
++        not need to re-check visibility themselves.
++        """
++        try:
++            ss = server_instance.shared_state
++            qs = request.args
++            radius = float(qs.get("radius", 60.0))
++            count = int(qs.get("count", 4))
++            min_altitude = float(qs.get("min_altitude", 20.0))
++
++            if "ra" in qs and "dec" in qs:
++                center_ra = float(qs["ra"])
++                center_dec = float(qs["dec"])
++            else:
++                sol = ss.solution()
++                if sol is None or not sol.has_pointing():
++                    return _json_response(
++                        {"error": "no ra/dec given and no current solve available"},
++                        400,
++                    )
++                aligned = sol.pointing.aligned.estimate
++                center_ra = float(aligned.RA)
++                center_dec = float(aligned.Dec)
++
++            location = ss.location()
++            dt = ss.datetime()
++            if location is None or dt is None or not location.lock:
++                return _json_response(
++                    {"error": "location/time not available (GPS not locked?)"}, 503
++                )
++
++            from PiFinder.calc_utils import sf_utils
++            from PiFinder.db.objects_db import ObjectsDatabase
++
++            sf_utils.set_location(location.lat, location.lon, location.altitude)
++
++            db = ObjectsDatabase()
++            _conn, cursor = db.get_pifinder_database()
++            # names.rowid ordering matters here: bright_stars_loader.py
++            # inserts "Str <sequence>" first, then the common name (e.g.
++            # "Alioth"), then the Latin/Bayer designation last - so each
++            # object has several rows in `names`, not one. Fetch them all
++            # per object and pick the best one in Python below rather than
++            # returning a duplicate candidate per name variant.
++            cursor.execute(
++                """
++                SELECT objects.id, objects.ra, objects.dec, objects.mag,
++                       names.common_name
++                FROM catalog_objects
++                JOIN objects ON objects.id = catalog_objects.object_id
++                LEFT JOIN names ON names.object_id = objects.id
++                WHERE catalog_objects.catalog_code = 'Str'
++                ORDER BY objects.id, names.rowid
++                """
++            )
++            rows = cursor.fetchall()
++
++            objects_by_id: dict[int, dict] = {}
++            for object_id, ra, dec, mag_json, name in rows:
++                entry = objects_by_id.get(object_id)
++                if entry is None:
++                    mag = None
++                    if mag_json:
++                        try:
++                            mag = json.loads(mag_json).get("filter_mag")
++                        except (TypeError, ValueError, json.JSONDecodeError):
++                            mag = None
++                    entry = {"ra": ra, "dec": dec, "mag": mag, "name": None}
++                    objects_by_id[object_id] = entry
++                # Prefer the first name that isn't the synthetic "Str N"
++                # catalog-sequence name (a real common/Latin name is far
++                # more useful for a user-facing candidate list); keep "Str
++                # N" only as a last-resort fallback if nothing else exists.
++                is_catalog_seq_name = name is not None and name.startswith("Str ")
++                if entry["name"] is None or (
++                    entry["name"].startswith("Str ") and not is_catalog_seq_name
++                ):
++                    entry["name"] = name
++
++            candidates = []
++            for entry in objects_by_id.values():
++                ra, dec = entry["ra"], entry["dec"]
++                if _angular_separation_deg(center_ra, center_dec, ra, dec) > radius:
++                    continue
++                alt, _az = sf_utils.radec_to_altaz(ra, dec, dt)
++                if alt < min_altitude:
++                    continue
++                candidates.append(
++                    {
++                        "ra": ra,
++                        "dec": dec,
++                        "name": entry["name"],
++                        "mag": entry["mag"],
++                        "altitude": alt,
++                    }
++                )
++
++            candidates.sort(key=lambda c: (c["mag"] is None, c["mag"]))
++            return _json_response({"candidates": candidates[:count]})
++        except Exception as e:
++            logger.error("api/nearby_bright_stars error: %s", e)
++            return _json_response({"error": str(e)}, 500)
++
      @app.route("/api/solution")
      def api_solution():
          try:
-@@ -750,6 +782,90 @@ def register_api_routes(app, server_instance, require_auth=False):
+@@ -750,6 +924,90 @@
      # 4. Lightweight control endpoints (optional, for remote triggering by OpenClaw)
      # ───────────────────────────────────────────────
- 
+
 +    @app.route("/api/debug_solve", methods=["POST"])
 +    def api_debug_solve():
 +        """Toggle the same "debug"/test-image substitution as Tools -> Test

--- a/docs/concepts/mount_bridge_multistar_alignment.md
+++ b/docs/concepts/mount_bridge_multistar_alignment.md
@@ -233,6 +233,20 @@ Without a real solve, a point simply waits out `MAX_FRESHNESS_WAIT_TICKS` and ge
 existing behavior); test against real sky/hardware for meaningful end-to-end verification of this
 PoC's actual alignment behavior.
 
+**Abort verified at the INDI wire, and "PiFinder doesn't follow" root-caused (2026-08-10, #217).**
+Raw INDI trace (no GUI, no Control Center - see `test_tools/multipoint_alignment_trace.py`)
+against `Telescope Simulator` confirmed `MULTI_POINT_ALIGN.ALIGN_STOP` correctly calls
+`abortMount()` and halts the sequence (0/4 points, mount position frozen after Stop) - the
+"can't abort" report traces to the missing dedicated GUI affordance noted just above, not a
+backend fault. Separately, a full run showed all 4 candidate points being skipped
+(`isPiFinderSolveFresh()` never true) because, on an indoor bench rig, PiFinder's own pre-solve
+sleep state machine (`main.py`'s `WARMUP`→sleep→`RETRY` cycle - no real stars in the camera's
+FOV, so no initial solve is ever reached) leaves `solve_source` stuck at `"IMU"` with a stale
+`last_solve_success`, not the required `"CAM"`. This is an environment limit of the test rig, not
+an alignment-logic bug, but it does expose a real reporting gap worth fixing separately: the
+sequence still reports `IPS_OK` ("sequence complete") even when 0/N points were actually synced -
+see #217 for the full trace, interpretation, and reproduction steps.
+
 Once the full feature (catalog selection, median-of-N, KStars feed) is built, it inherits Mount
 Bridge's existing test surface (INDI Control Panel, `indi_getprop`/`indi_setprop`, the Control
 Center GUI, live verification under real sky) rather than introducing a new one. Testing methodology

--- a/docs/concepts/mount_bridge_multistar_alignment.md
+++ b/docs/concepts/mount_bridge_multistar_alignment.md
@@ -195,17 +195,42 @@ it too rather than maintaining two separate "teach a verified position" code pat
 
 ## 6. Installation / Test
 
-Not yet implemented — no installation/test surface exists yet. Once built, this inherits Mount
+**Update (2026-08-10): a reduced PoC exists**, `feature/191-multipoint-alignment-poc` (not
+merged) — `MULTI_POINT_ALIGN` INDI switch (Start/Stop) on Mount Bridge, a fixed 4-point set (§4.3's
+core sequence, no §4.2 catalog selection, no §4.3 median-of-N, no §4.5 KStars feed). See the header
+comment on `MultiPointAlignSP`/`m_alignPoints` in `pifinder_mount_bridge.h` for the exact scope.
+Live-verified end to end against `Telescope Simulator`.
+
+**Safety — PoC has no altitude/horizon awareness, do not run against a real mount.** Live-confirmed
+(User, 2026-08-10): the fixed points get Goto'd blindly regardless of current visibility — harmless
+against a simulator, a genuine mechanical collision risk against a real mount (cable wrap,
+counterweight/OTA into the pier or tripod), independent of and not caught by the mount's own coarse
+elevation limit (e.g. OnStep's "Slew elevation Limit", which only guards ~-10° altitude, not
+"technically above that but physically unreachable from here"). §4.2's catalog-driven,
+altitude-filtered selection is what would close this — deliberately left as a documented blocker
+rather than a partial fix for this PoC (User decision).
+
+**Waiting for a fresh solve at each point needs no special handling for real use** (User, 2026-08-10):
+the mount arrives, PiFinder's own continuous camera solve loop naturally produces a fresh solve once
+stationary, exactly as it always does — the sequence's per-point wait is correct as designed, not a
+gap to work around. This only fails to self-resolve when testing against `Telescope Simulator` +
+Injected Solve specifically (no real camera in that loop at all, so nothing ever re-solves on its
+own) — a testing-environment limitation, not something the feature itself needs to accommodate.
+Without a real solve, a point simply waits out `MAX_FRESHNESS_WAIT_TICKS` and gets skipped (§4.4's
+existing behavior); test against real sky/hardware for meaningful end-to-end verification of this
+PoC's actual alignment behavior.
+
+Once the full feature (catalog selection, median-of-N, KStars feed) is built, it inherits Mount
 Bridge's existing test surface (INDI Control Panel, `indi_getprop`/`indi_setprop`, the Control
-Center GUI, live verification under real sky) rather than introducing a new one. Given tonight's
-live-testing experience (`basic-memory/pifinder-stellarmate/00089` §7), testing methodology notes
-worth carrying forward:
+Center GUI, live verification under real sky) rather than introducing a new one. Testing methodology
+notes worth carrying forward from earlier live-testing experience
+(`basic-memory/pifinder-stellarmate/00089` §7):
 - Prefer real, continuous camera solving over synthetic `/api/fake_solve` injection when verifying
   the median-of-N-solves step — synthetic injections showed non-deterministic drift under repeated
-  rapid calls tonight, which would confound testing an aggregation step specifically designed to
-  smooth out solve noise.
+  rapid calls, which would confound testing an aggregation step specifically designed to smooth out
+  solve noise.
 - `/api/fake_solve`'s RA is in degrees, not hours — convert before any INDI property use (a real
-  ~23° mis-slew happened tonight from exactly this mistake).
+  ~23° mis-slew happened from exactly this mistake in an earlier session).
 
 ## 7. Effort / Priority
 

--- a/docs/concepts/mount_bridge_multistar_alignment.md
+++ b/docs/concepts/mount_bridge_multistar_alignment.md
@@ -214,38 +214,44 @@ configured minimum altitude are never selected in the first place, not caught af
 cable-wrap/meridian-flip risk for a given mount's current orientation - same class of gap as the
 still-open KStars-horizon-fencing item, unrelated to this fix.
 
-**No Control Center GUI yet (User decision, 2026-08-10) - INDI Control Panel only.** Deliberately
-not built this session ("erstmal nicht - Branch bleibt technisch/INDI-only") - no Start/Stop button,
-no progress display, no visible warning surface in the Control Center itself. Right now the only
-places to observe this feature at all are the INDI Control Panel's own properties/log (fetch
-failures go to `MULTI_POINT_ALIGN`'s `IPS_ALERT` + a `LOG_ERROR`; a skipped point logs a
-`LOG_WARN`) - a normal Control Center user has no way to see or use this feature yet. Revisit once
-§4.3/§4.5 (or at least a scoping decision to skip them) land, per the User's own stated preference
-to build GUI "in einem Rutsch" rather than piecemeal.
+**Control Center GUI: now being built (2026-08-10) - see #217.** The earlier "erstmal nicht"
+deferral is superseded: raw-INDI testing (below) showed the underlying `ALIGN_START`/`ALIGN_STOP`
+mechanism is correct, but with no dedicated Start/Stop/progress affordance anywhere outside the
+generic INDI Control Panel, a working Stop read as "can't abort" in practice. The GUI is being
+added now rather than deferred further.
 
-**Waiting for a fresh solve at each point needs no special handling for real use** (User, 2026-08-10):
-the mount arrives, PiFinder's own continuous camera solve loop naturally produces a fresh solve once
-stationary, exactly as it always does — the sequence's per-point wait is correct as designed, not a
-gap to work around. This only fails to self-resolve when testing against `Telescope Simulator` +
-Injected Solve specifically (no real camera in that loop at all, so nothing ever re-solves on its
-own) — a testing-environment limitation, not something the feature itself needs to accommodate.
-Without a real solve, a point simply waits out `MAX_FRESHNESS_WAIT_TICKS` and gets skipped (§4.4's
-existing behavior); test against real sky/hardware for meaningful end-to-end verification of this
-PoC's actual alignment behavior.
-
-**Abort verified at the INDI wire, and "PiFinder doesn't follow" root-caused (2026-08-10, #217).**
-Raw INDI trace (no GUI, no Control Center - see `test_tools/multipoint_alignment_trace.py`)
+**Abort verified at the INDI wire, and "PiFinder doesn't follow" root-caused - then corrected
+(2026-08-10, #217).** Raw INDI trace (no GUI - see `test_tools/multipoint_alignment_trace.py`)
 against `Telescope Simulator` confirmed `MULTI_POINT_ALIGN.ALIGN_STOP` correctly calls
 `abortMount()` and halts the sequence (0/4 points, mount position frozen after Stop) - the
-"can't abort" report traces to the missing dedicated GUI affordance noted just above, not a
-backend fault. Separately, a full run showed all 4 candidate points being skipped
-(`isPiFinderSolveFresh()` never true) because, on an indoor bench rig, PiFinder's own pre-solve
-sleep state machine (`main.py`'s `WARMUP`→sleep→`RETRY` cycle - no real stars in the camera's
-FOV, so no initial solve is ever reached) leaves `solve_source` stuck at `"IMU"` with a stale
-`last_solve_success`, not the required `"CAM"`. This is an environment limit of the test rig, not
-an alignment-logic bug, but it does expose a real reporting gap worth fixing separately: the
-sequence still reports `IPS_OK` ("sequence complete") even when 0/N points were actually synced -
-see #217 for the full trace, interpretation, and reproduction steps.
+"can't abort" report traces to the missing dedicated GUI affordance, not a backend fault.
+
+A first full run showed all 4 candidate points being skipped (`isPiFinderSolveFresh()` never
+true) because PiFinder itself was asleep with a stale, non-`"CAM"` solve. **First read of that as
+an unavoidable "indoor test rig has no real sky" limitation was wrong** -
+`test_tools/pifinder_truth_injector.py` already exists precisely for this (built for #178/
+Auto-correct testing): it polls an INDI device's position and re-POSTs it to
+`/api/fake_solve` on an interval, which `integrator.py`'s `_apply_successful_solve()` treats as a
+real `SolveSource.CAMERA` result with a continuously fresh `last_solve_success` - exactly what
+`isPiFinderSolveFresh()` needs, no different from a real continuously-resolving camera. Pointed
+at `Telescope Simulator` itself (`--indi-device "Telescope Simulator"`, so the simulated PiFinder
+always agrees with wherever the mount currently is - the idealized well-solving-camera case),
+the SETTLING→SYNC path completes end-to-end: `point 1/4 verified - synced...`, `point 2/4
+verified - synced...`, `point 3/4 verified - synced...`. The mechanism works; the earlier report
+just hadn't used the simulation tooling that already existed for this exact scenario.
+
+**New, unresolved finding from that corrected re-test:** points 2 and 3 synced to an RA exactly
+12h (180°) off the announced target (target 12.9000h/13.7917h → synced 0.9000h/1.7917h); point 1
+matched exactly. Position samples show the simulator passing through very large, sometimes
+negative RA jumps between samples, suggesting either a very high simulated slew rate or a
+sampling-lag interaction with the injector's 2s poll interval during fast motion. Not yet
+isolated as a real Mount Bridge sync-accuracy issue vs. a test-methodology artifact - open
+follow-up, not a blocker for either originally-reported finding. See #217 (including its
+correction comment) for the full trace and reproduction steps.
+
+Also surfaced, independent of the above: the sequence still reports `IPS_OK` ("sequence
+complete") even when 0/N points were actually synced (seen in the pre-correction run) - worth
+fixing separately so the terminal state distinguishes a real success from an all-skipped run.
 
 Once the full feature (catalog selection, median-of-N, KStars feed) is built, it inherits Mount
 Bridge's existing test surface (INDI Control Panel, `indi_getprop`/`indi_setprop`, the Control

--- a/docs/concepts/mount_bridge_multistar_alignment.md
+++ b/docs/concepts/mount_bridge_multistar_alignment.md
@@ -195,20 +195,33 @@ it too rather than maintaining two separate "teach a verified position" code pat
 
 ## 6. Installation / Test
 
-**Update (2026-08-10): a reduced PoC exists**, `feature/191-multipoint-alignment-poc` (not
-merged) — `MULTI_POINT_ALIGN` INDI switch (Start/Stop) on Mount Bridge, a fixed 4-point set (§4.3's
-core sequence, no §4.2 catalog selection, no §4.3 median-of-N, no §4.5 KStars feed). See the header
-comment on `MultiPointAlignSP`/`m_alignPoints` in `pifinder_mount_bridge.h` for the exact scope.
-Live-verified end to end against `Telescope Simulator`.
+**Update (2026-08-10): §4.2 is implemented, not just documented.** Branch
+`feature/191-multipoint-alignment-poc` (not merged) - `MULTI_POINT_ALIGN` INDI switch (Start/Stop)
+on Mount Bridge, `AlignConfigNP` (radius/count/min_altitude) exposing §3's relevant parameters,
+candidates fetched fresh on every Start from PiFinder's own new `/api/nearby_bright_stars` endpoint
+(companion patch, `diffs/api_extensions_py.diff` - its "Str" bright-named-star catalog, altitude-
+filtered server-side using PiFinder's own GPS location/time via skyfield). The originally-reduced
+PoC's fixed hardcoded 4-point set is gone. §4.3's median-of-N-solves and §4.5's KStars-model feed
+remain out of scope. Live-verified end to end against `Telescope Simulator`: correctly fetched real
+candidates and slewed to the first one (Alioth) rather than any hardcoded point.
 
-**Safety — PoC has no altitude/horizon awareness, do not run against a real mount.** Live-confirmed
-(User, 2026-08-10): the fixed points get Goto'd blindly regardless of current visibility — harmless
-against a simulator, a genuine mechanical collision risk against a real mount (cable wrap,
-counterweight/OTA into the pier or tripod), independent of and not caught by the mount's own coarse
-elevation limit (e.g. OnStep's "Slew elevation Limit", which only guards ~-10° altitude, not
-"technically above that but physically unreachable from here"). §4.2's catalog-driven,
-altitude-filtered selection is what would close this — deliberately left as a documented blocker
-rather than a partial fix for this PoC (User decision).
+**Horizon safety - now closed structurally, not just documented.** The original PoC's fixed points
+had no altitude/horizon awareness at all - live-confirmed (User, 2026-08-10) starting a sequence
+while the target sat below the horizon on PiFinder's own sky-map. §4.2's catalog-driven,
+altitude-filtered selection (now implemented, see above) closes this: candidates below the
+configured minimum altitude are never selected in the first place, not caught after the fact.
+**Not yet addressed**: candidate altitude filtering rules out "below the horizon" but not
+cable-wrap/meridian-flip risk for a given mount's current orientation - same class of gap as the
+still-open KStars-horizon-fencing item, unrelated to this fix.
+
+**No Control Center GUI yet (User decision, 2026-08-10) - INDI Control Panel only.** Deliberately
+not built this session ("erstmal nicht - Branch bleibt technisch/INDI-only") - no Start/Stop button,
+no progress display, no visible warning surface in the Control Center itself. Right now the only
+places to observe this feature at all are the INDI Control Panel's own properties/log (fetch
+failures go to `MULTI_POINT_ALIGN`'s `IPS_ALERT` + a `LOG_ERROR`; a skipped point logs a
+`LOG_WARN`) - a normal Control Center user has no way to see or use this feature yet. Revisit once
+§4.3/§4.5 (or at least a scoping decision to skip them) land, per the User's own stated preference
+to build GUI "in einem Rutsch" rather than piecemeal.
 
 **Waiting for a fresh solve at each point needs no special handling for real use** (User, 2026-08-10):
 the mount arrives, PiFinder's own continuous camera solve loop naturally produces a fresh solve once

--- a/gui_installer/help.html
+++ b/gui_installer/help.html
@@ -219,6 +219,16 @@
 </ul>
 <p>Only shown while coupling is actively watching drift (Verify/Alert or Auto-correct) and connected - hidden otherwise. The short status line below the diagram (a colored dot plus a one-line label) reflects the same state in words; click "Details" next to it for the full explanation instead of it being shown inline, which used to change the row's height and shift the rest of the page around every time the text changed length.</p>
 
+<h3 id="multi-point-alignment">Multi-Point Alignment</h3>
+<p>An automated version of a classic multi-star alignment: instead of manually centering several known stars in the eyepiece and confirming each on a hand controller, PiFinder's own plate-solving determines where the mount is actually pointing at several sky positions, and each result goes straight to the mount as a Sync. Independent of the Coupling mode above - a one-shot "improve the model now" action, not a standing mode.</p>
+<ul>
+  <li><strong>Multi-Point Alignment</strong> (Start): fetches a fresh set of bright, named candidate stars from PiFinder's own catalog - centered on PiFinder's current position, filtered by the settings below - then works through them one at a time: slew, wait for arrival, wait for a fresh PiFinder solve, Sync. Points where no fresh solve arrives in time are skipped, not retried.</li>
+  <li><strong>Stop alignment</strong>: aborts the sequence and stops the mount immediately - only enabled while a sequence is actually running.</li>
+  <li>The progress line under the buttons shows the current point ("Aligning: point 2/4, 1 verified so far…") while running, and a short summary once it stops or completes.</li>
+</ul>
+<p><strong>Search radius / Points / Min altitude</strong>: how candidates are chosen. Radius and altitude are both centered on the sky as PiFinder currently sees it (not the mount's own position) - a wider radius or lower altitude offers more candidates but weaker ones (fainter or closer to the horizon). Changes apply on the next Start, not to a sequence already in progress.</p>
+<p><strong>Known limitation</strong>: candidates are filtered by altitude at selection time, but the <em>slew path between two points</em> isn't checked for horizon or cable-wrap safety - a mount's specific axis geometry can carry it through a below-horizon orientation mid-slew even when both endpoints are safely above the horizon. Keep an eye on the mount while a sequence runs, same as any other Goto.</p>
+
 <p class="close-note">This help page is a static file served alongside the Control Center - it isn't kept open or polled by the main page, so it's safe to leave it in its own tab while you work.</p>
 </body>
 </html>

--- a/gui_installer/indi_client.py
+++ b/gui_installer/indi_client.py
@@ -282,6 +282,9 @@ def mount_bridge_status(
             "pifinder_mount_type": None,
             "pifinder_screen_direction": None,
             "orientation_state": None,
+            "align_radius": None,
+            "align_count": None,
+            "align_min_altitude": None,
         }
 
     active_devices = device_props.get("ACTIVE_DEVICES", {}).get("elements", {})
@@ -289,6 +292,7 @@ def mount_bridge_status(
     drift_status_prop = device_props.get("DRIFT_STATUS", {})
     drift_status = drift_status_prop.get("elements", {})
     drift_threshold_elements = device_props.get("DRIFT_THRESHOLD", {}).get("elements", {})
+    align_config_elements = device_props.get("ALIGN_CONFIG", {}).get("elements", {})
     bridge_settings = device_props.get("BRIDGE_SETTINGS", {}).get("elements", {})
 
     coupling_mode = next((name for name, val in bridge_mode.items() if val == "On"), None)
@@ -375,6 +379,13 @@ def mount_bridge_status(
         "pifinder_mount_type": orientation_elements.get("MOUNT_TYPE") or None,
         "pifinder_screen_direction": orientation_elements.get("SCREEN_DIRECTION") or None,
         "orientation_state": orientation_prop.get("state"),
+        # #191/#217: pre-fills the Multi-Point Alignment config fields on
+        # load, same reasoning as drift_threshold above - without this a
+        # page reload always showed the HTML defaults regardless of what
+        # was actually saved/set on the driver.
+        "align_radius": float(align_config_elements["RADIUS_DEG"]) if align_config_elements.get("RADIUS_DEG") not in (None, "") else None,
+        "align_count": float(align_config_elements["POINT_COUNT"]) if align_config_elements.get("POINT_COUNT") not in (None, "") else None,
+        "align_min_altitude": float(align_config_elements["MIN_ALTITUDE_DEG"]) if align_config_elements.get("MIN_ALTITUDE_DEG") not in (None, "") else None,
     }
 
 

--- a/gui_installer/indi_client.py
+++ b/gui_installer/indi_client.py
@@ -423,6 +423,9 @@ def mount_bridge_drift(
             "align_point_index": None,
             "align_point_count": None,
             "align_point_synced": None,
+            "align_radius": None,
+            "align_count": None,
+            "align_min_altitude": None,
         }
 
     bridge_mode = device_props.get("BRIDGE_MODE", {}).get("elements", {})
@@ -446,6 +449,15 @@ def mount_bridge_drift(
     # multi-second cadence as drift while a sequence is running.
     align_state = device_props.get("MULTI_POINT_ALIGN", {}).get("state")
     align_progress = device_props.get("ALIGN_PROGRESS", {}).get("elements", {})
+    # #191/#217: found live (2026-08-10, direct feedback - "die Werte werden
+    # immer wieder auf Default gesetzt") that relying solely on
+    # mount_bridge_status() (gated behind role/wmServerRunning checks in the
+    # frontend, 20s cadence) left the config fields stuck on their HTML
+    # defaults whenever that slower poll's own gating didn't fire for
+    # whatever reason - added here too, on the same always-on fast poll the
+    # Threshold/drift fields already trust, so reading them back is as
+    # reliable as everything else on this row.
+    align_config_elements = device_props.get("ALIGN_CONFIG", {}).get("elements", {})
 
     def _int_or_none(raw):
         return int(float(raw)) if raw not in (None, "") else None
@@ -472,6 +484,9 @@ def mount_bridge_drift(
         "align_point_index": _int_or_none(align_progress.get("POINT_INDEX")),
         "align_point_count": _int_or_none(align_progress.get("POINT_COUNT")),
         "align_point_synced": _int_or_none(align_progress.get("POINT_SYNCED")),
+        "align_radius": float(align_config_elements["RADIUS_DEG"]) if align_config_elements.get("RADIUS_DEG") not in (None, "") else None,
+        "align_count": float(align_config_elements["POINT_COUNT"]) if align_config_elements.get("POINT_COUNT") not in (None, "") else None,
+        "align_min_altitude": float(align_config_elements["MIN_ALTITUDE_DEG"]) if align_config_elements.get("MIN_ALTITUDE_DEG") not in (None, "") else None,
     }
 
 

--- a/gui_installer/indi_client.py
+++ b/gui_installer/indi_client.py
@@ -408,6 +408,10 @@ def mount_bridge_drift(
             "drift_arcmin": None,
             "mount_reject_active": False,
             "mount_reject_message": None,
+            "align_state": None,
+            "align_point_index": None,
+            "align_point_count": None,
+            "align_point_synced": None,
         }
 
     bridge_mode = device_props.get("BRIDGE_MODE", {}).get("elements", {})
@@ -421,6 +425,19 @@ def mount_bridge_drift(
     mount_reject_prop = device_props.get("MOUNT_REJECT", {})
     mount_reject_active = mount_reject_prop.get("state") == "Alert"
     mount_reject_message = mount_reject_prop.get("elements", {}).get("MESSAGE") or None
+
+    # #191/#217: Multi-Point Alignment's own coarse state (MULTI_POINT_ALIGN
+    # itself has no numeric elements worth reading - it's a Start/Stop
+    # switch pair, "align_state" here is its *vector* state Idle/Busy/Ok/
+    # Alert) plus ALIGN_PROGRESS's poll-friendly point-by-point numbers -
+    # added alongside drift/coupling_mode in this same fast-poll companion
+    # (not mount_bridge_status()) because progress changes on the same
+    # multi-second cadence as drift while a sequence is running.
+    align_state = device_props.get("MULTI_POINT_ALIGN", {}).get("state")
+    align_progress = device_props.get("ALIGN_PROGRESS", {}).get("elements", {})
+
+    def _int_or_none(raw):
+        return int(float(raw)) if raw not in (None, "") else None
 
     return {
         "running": True,
@@ -440,6 +457,10 @@ def mount_bridge_drift(
         # old.
         "drift_state": drift_status_prop.get("state"),
         "drift_arcmin": float(drift_raw) if drift_raw not in (None, "") else None,
+        "align_state": align_state,
+        "align_point_index": _int_or_none(align_progress.get("POINT_INDEX")),
+        "align_point_count": _int_or_none(align_progress.get("POINT_COUNT")),
+        "align_point_synced": _int_or_none(align_progress.get("POINT_SYNCED")),
     }
 
 
@@ -743,3 +764,28 @@ def trigger_abort_mount(
     Coupling mode (or Off) is active, and independent of whether PiFinder's
     own side is ready/available. See #179."""
     set_switch("PiFinder Mount Bridge", "ABORT_MOUNT", "ABORT_MOUNT_NOW", host, port, timeout)
+
+
+def trigger_multipoint_align_start(
+    host: str = DEFAULT_HOST,
+    port: int = DEFAULT_PORT,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> None:
+    """Starts a #191 Multi-Point Alignment sequence (MULTI_POINT_ALIGN's
+    ALIGN_START element): fetches fresh candidate points from PiFinder's own
+    /api/nearby_bright_stars and works through them one at a time (Goto,
+    wait for arrival, wait for a fresh PiFinder solve, Sync). Independent of
+    Coupling mode - works whether Coupling is Off or any other preset."""
+    set_switch("PiFinder Mount Bridge", "MULTI_POINT_ALIGN", "ALIGN_START", host, port, timeout)
+
+
+def trigger_multipoint_align_stop(
+    host: str = DEFAULT_HOST,
+    port: int = DEFAULT_PORT,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> None:
+    """Aborts an in-progress #191 Multi-Point Alignment sequence
+    (MULTI_POINT_ALIGN's ALIGN_STOP element) - reuses the same ABORT_MOUNT
+    path as the emergency-stop button, so any current mount motion also
+    stops immediately, not just the sequence's own bookkeeping."""
+    set_switch("PiFinder Mount Bridge", "MULTI_POINT_ALIGN", "ALIGN_STOP", host, port, timeout)

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -994,6 +994,62 @@ def _mb_log(line: str):
         _mb_lines.append(f"{time.strftime('%H:%M:%S')} {line}")
 
 
+# #191/#217: PiFinder Truth Injector toggle - feeds "Telescope Simulator"'s
+# own position into PiFinder's /api/fake_solve on an interval (see
+# test_tools/pifinder_truth_injector.py), so Multi-Point Alignment's
+# solve-freshness gate can be exercised end-to-end against the Simulator
+# without real sky. Deliberately a tracked subprocess.Popen, NOT a systemd
+# unit like KEYBOARD_BRIDGE_SERVICE above: that one is meant to survive
+# reboots (its whole point), this one must NOT - it's test-only and would
+# silently corrupt a real observing session if it ever auto-started outside
+# an explicit simulator test. Scoped to this Control Center process's own
+# lifetime; a Control Center restart always starts back OFF.
+TRUTH_INJECTOR_SCRIPT = REPO_ROOT / "test_tools" / "pifinder_truth_injector.py"
+TRUTH_INJECTOR_DEVICE = "Telescope Simulator"
+_truth_injector_proc = None  # subprocess.Popen or None
+_truth_injector_desired = False  # True once the user has toggled it on - the watchdog below re-starts it if it dies while this is still True
+_truth_injector_lock = threading.Lock()
+
+
+def _truth_injector_alive() -> bool:
+    return _truth_injector_proc is not None and _truth_injector_proc.poll() is None
+
+
+def _truth_injector_start():
+    global _truth_injector_proc
+    _truth_injector_proc = subprocess.Popen(
+        ["python3", str(TRUTH_INJECTOR_SCRIPT), "--indi-device", TRUTH_INJECTOR_DEVICE, "--interval", "2.0"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+
+
+def _truth_injector_stop():
+    global _truth_injector_proc
+    if _truth_injector_proc is not None:
+        _truth_injector_proc.terminate()
+        try:
+            _truth_injector_proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            _truth_injector_proc.kill()
+        _truth_injector_proc = None
+
+
+def _truth_injector_watchdog(interval=5):
+    """'Muss dann zuverlässig laufen' (direct feedback, 2026-08-10): once
+    toggled on, the injector must not silently stay dead if its process
+    exits for any reason - same reliability bar as
+    _pifinder_lx200_reconnect_watchdog() above, same reasoning."""
+    while True:
+        time.sleep(interval)
+        with _truth_injector_lock:
+            if _truth_injector_desired and not _truth_injector_alive():
+                _mb_log("PiFinder Truth Injector died unexpectedly - restarting...")
+                try:
+                    _truth_injector_start()
+                except Exception as e:  # a watchdog thread must never die silently
+                    _mb_log(f"  failed to restart: {e}")
+
+
 def _parse_threshold(raw: str) -> float:
     """European keyboards/locales often produce a comma decimal separator
     (e.g. "0,5") - Python's float() only accepts a period and raises
@@ -2279,6 +2335,16 @@ class Handler(BaseHTTPRequestHandler):
             self._send_json(drift)
             return
 
+        if parsed.path == "/api/truth_injector_status":
+            # Polled by the toggle button's own status dot - reports the
+            # user's last desired state plus whether the process is
+            # actually, currently alive right now, so the GUI can show
+            # "should be on but died" (red) distinctly from "on and
+            # confirmed alive" (green), not just a single on/off bit.
+            with _truth_injector_lock:
+                self._send_json({"desired": _truth_injector_desired, "alive": _truth_injector_alive()})
+            return
+
         if parsed.path == "/api/webmanager/profiles":
             # Phase 2 of the Mount Bridge web integration (see
             # docs/concepts/mount_bridge_web_integration.md) - UC3 (profile
@@ -3216,6 +3282,34 @@ class Handler(BaseHTTPRequestHandler):
             self._send_json({"success": True})
             return
 
+        if parsed.path == "/api/truth_injector_toggle":
+            global _truth_injector_desired
+            with _truth_injector_lock:
+                if _truth_injector_desired:
+                    _truth_injector_desired = False
+                    _mb_log("stopping PiFinder Truth Injector...")
+                    try:
+                        _truth_injector_stop()
+                    except Exception as e:
+                        _mb_log(f"  failed: {e}")
+                        self._send_json({"success": False, "error": str(e)}, status=502)
+                        return
+                    _mb_log("  done.")
+                else:
+                    _truth_injector_desired = True
+                    _mb_log(f"starting PiFinder Truth Injector (feeding '{TRUTH_INJECTOR_DEVICE}''s "
+                             "position into PiFinder's /api/fake_solve, simulator testing only)...")
+                    try:
+                        _truth_injector_start()
+                    except Exception as e:
+                        _truth_injector_desired = False
+                        _mb_log(f"  failed: {e}")
+                        self._send_json({"success": False, "error": str(e)}, status=502)
+                        return
+                    _mb_log("  started.")
+            self._send_json({"success": True})
+            return
+
         self.send_error(404)
 
 
@@ -3241,6 +3335,10 @@ def main():
     # pifinder.service restart - see _pifinder_lx200_reconnect_watchdog()'s
     # own docstring.
     threading.Thread(target=_pifinder_lx200_reconnect_watchdog, daemon=True).start()
+    # #191/#217: keeps the PiFinder Truth Injector running once toggled on -
+    # starts idle (desired=False), only ever spawns anything after an
+    # explicit /api/truth_injector_toggle call.
+    threading.Thread(target=_truth_injector_watchdog, daemon=True).start()
     # One-time check, not a watchdog: an already-running pifinder.service
     # left over from before this Control Center's own start (e.g. surviving
     # an Update run from before the setup script's start->restart fix, or a

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -3183,6 +3183,39 @@ class Handler(BaseHTTPRequestHandler):
             self._send_json({"success": True})
             return
 
+        if parsed.path == "/api/mount_bridge_multialign_start":
+            # #191/#217: kicks off a Multi-Point Alignment sequence. Fresh
+            # candidates are fetched by the driver itself on every Start
+            # (fetchAlignmentCandidates()) - nothing to pass from here.
+            # Independent of Coupling mode, same as Manual Sync/Abort above.
+            _mb_log("starting Multi-Point Alignment...")
+            try:
+                indi_client.trigger_multipoint_align_start()
+            except indi_client.INDIClientError as e:
+                _mb_log(f"  failed: {e}")
+                self._send_json({"success": False, "error": str(e)}, status=502)
+                return
+            _mb_log("  started - see the Alignment progress readout for per-point status.")
+            self._send_json({"success": True})
+            return
+
+        if parsed.path == "/api/mount_bridge_multialign_stop":
+            # #217: verified live against Telescope Simulator that this
+            # correctly aborts an in-progress sequence at the INDI level
+            # (stopMultiPointAlignment() -> abortMount()) - the earlier
+            # "can't abort" report traced to this button not existing in the
+            # GUI at all, not to a backend fault.
+            _mb_log("stopping Multi-Point Alignment...")
+            try:
+                indi_client.trigger_multipoint_align_stop()
+            except indi_client.INDIClientError as e:
+                _mb_log(f"  failed: {e}")
+                self._send_json({"success": False, "error": str(e)}, status=502)
+                return
+            _mb_log("  done.")
+            self._send_json({"success": True})
+            return
+
         self.send_error(404)
 
 

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -3202,6 +3202,38 @@ class Handler(BaseHTTPRequestHandler):
             self._send_json({"success": True})
             return
 
+        if parsed.path == "/api/mount_bridge_align_config":
+            # #191/#217: search radius/point count/min altitude for
+            # candidate selection - these already existed as INDI properties
+            # (AlignConfigNP) but had no GUI control at all until now (direct
+            # feedback, 2026-08-10). Same one-field-at-a-time pattern as
+            # /api/mount_bridge_threshold above.
+            qs = parse_qs(parsed.query)
+            try:
+                values = {}
+                if "radius" in qs:
+                    values["RADIUS_DEG"] = _parse_threshold(qs["radius"][0])
+                if "count" in qs:
+                    values["POINT_COUNT"] = _parse_threshold(qs["count"][0])
+                if "min_altitude" in qs:
+                    values["MIN_ALTITUDE_DEG"] = _parse_threshold(qs["min_altitude"][0])
+            except ValueError as e:
+                self._send_json({"success": False, "error": f"invalid value: {e}"}, status=400)
+                return
+            if not values:
+                self._send_json({"success": False, "error": "no radius/count/min_altitude given"}, status=400)
+                return
+            _mb_log(f"setting alignment point selection ({values})...")
+            try:
+                indi_client.set_number("PiFinder Mount Bridge", "ALIGN_CONFIG", values)
+            except indi_client.INDIClientError as e:
+                _mb_log(f"  failed: {e}")
+                self._send_json({"success": False, "error": str(e)}, status=502)
+                return
+            _mb_log("  done.")
+            self._send_json({"success": True})
+            return
+
         if parsed.path == "/api/mount_bridge_manual_sync":
             # Manual, immediate one-shot: syncs the mount to PiFinder's
             # current solved position right now, regardless of Coupling

--- a/gui_installer/server.py
+++ b/gui_installer/server.py
@@ -3367,9 +3367,23 @@ def main():
     # pifinder.service restart - see _pifinder_lx200_reconnect_watchdog()'s
     # own docstring.
     threading.Thread(target=_pifinder_lx200_reconnect_watchdog, daemon=True).start()
-    # #191/#217: keeps the PiFinder Truth Injector running once toggled on -
-    # starts idle (desired=False), only ever spawns anything after an
-    # explicit /api/truth_injector_toggle call.
+    # #191/#217: found live (2026-08-10) - this unit's own KillMode=process
+    # (see its own comment in the .service file, needed for Uninstall's
+    # --selfmove continuation) means a restart/redeploy does NOT kill this
+    # process's subprocess children, only the main process itself. A Truth
+    # Injector left running from a previous instance survives as an orphan,
+    # invisible to this fresh instance's own _truth_injector_desired=False -
+    # directly contradicting this feature's own documented guarantee
+    # ("always starts back OFF... never persists across reboots") and, worse,
+    # silently keeps feeding PiFinder a synthetic solve indefinitely with no
+    # visible control anywhere. Enforce the guarantee for real: kill any
+    # stray instance by command line before the watchdog (which only manages
+    # processes THIS instance itself started) takes over.
+    killed = subprocess.run(
+        ["pkill", "-f", "test_tools/pifinder_truth_injector.py"],
+    ).returncode == 0
+    if killed:
+        _mb_log("killed a stray PiFinder Truth Injector process left over from before this restart.")
     threading.Thread(target=_truth_injector_watchdog, daemon=True).start()
     # One-time check, not a watchdog: an already-running pifinder.service
     # left over from before this Control Center's own start (e.g. surviving

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -1581,6 +1581,22 @@
         <button id="mb-multialign-stop-btn" class="mb-big-action-btn mb-abort-btn" onclick="triggerMultiAlignStop()" disabled title="Aborts the running alignment sequence and stops the mount immediately (same underlying stop as the emergency Stop movement button above).">Stop alignment</button>
       </div>
       <div id="mb-multialign-progress" class="mb-hint" style="display:none;"></div>
+      <!-- #191/#217: candidate-selection settings already existed as INDI
+           properties (AlignConfigNP) since the catalog-driven selection
+           landed, but had no GUI control at all - direct feedback,
+           2026-08-10 ("kein Bug, aber warum kein GUI dafür"). Same
+           debounced-input pattern as the Threshold field above. Preferred
+           cardinal direction is deliberately NOT here - it doesn't exist
+           anywhere yet (no INDI property either), a real new feature to
+           design separately, not bolted on alongside these three. -->
+      <div class="mb-row" id="mb-align-config-row" title="Candidate point selection for Multi-Point Alignment (#191) - applies on the next Start, not retroactively to a running sequence.">
+        <span class="mb-row-label">Search radius:</span>
+        <input type="number" id="mb-align-radius-input" class="pf-num-input" value="60" min="5" max="180" step="5" style="width:4em;" onchange="applyAlignConfigChange()" oninput="scheduleAlignConfigChange()"> deg
+        <span class="mb-row-label" style="margin-left:0.6rem;">Points:</span>
+        <input type="number" id="mb-align-count-input" class="pf-num-input" value="4" min="1" max="10" step="1" style="width:3em;" onchange="applyAlignConfigChange()" oninput="scheduleAlignConfigChange()">
+        <span class="mb-row-label" style="margin-left:0.6rem;">Min altitude:</span>
+        <input type="number" id="mb-align-min-altitude-input" class="pf-num-input" value="20" min="0" max="80" step="5" style="width:3em;" onchange="applyAlignConfigChange()" oninput="scheduleAlignConfigChange()"> deg
+      </div>
       <div class="mb-row" id="mb-threshold-manual-row">
         <span id="mb-threshold-wrap" title="Used by Verify/Alert and the two Auto-correct presets: how far off before they warn/correct.">
           <span class="mb-row-label">Threshold:</span>
@@ -1706,8 +1722,23 @@
             <span class="status-dot dot-unconfirmed" id="debug-solve-dot"></span>Solve Simulation (PiFinder built-in): <span id="debug-solve-text">unknown</span>
             <button id="debug-solve-btn" class="ql-small-btn" onclick="toggleDebugSolve()" disabled>Toggle</button>
           </div>
+          <!-- Unified 2026-08-10 (direct feedback): Injected Solve (manual
+               one-shot seed) and the Truth Injector (continuous, below)
+               both ultimately drive the exact same PiFinder-side
+               fake_solve_active flag - showing two independently-tracked
+               dots for one shared piece of state was actively misleading
+               (found live: an orphaned manual-test injector process kept
+               this flag true while the new Truth Injector toggle correctly
+               said "off", since it was tracking a different process it
+               never started). One status line now answers "is a synthetic
+               solve active, and via which mechanism" - the two rows below
+               are just two different ways to drive it, not two
+               independent things to keep straight. -->
+          <div class="hw-row" id="synth-solve-status-row" title="Whether PiFinder's currently-reported solve is synthetic (via /api/fake_solve) rather than a real camera plate-solve, and which of the two controls below is driving it right now.">
+            <span class="status-dot dot-unconfirmed" id="synth-solve-dot"></span>Synthetic Solve: <span id="synth-solve-text">unknown</span>
+          </div>
           <div class="hw-row" id="fake-solve-row" title="A synthetic RA/Dec injected via PiFinder's /api/fake_solve (see #106) - real IMU dead-reckoning takes over from there, exactly as it would from a real solve. Distinct from Solve Simulation above (which only swaps the camera image) and from a real solve - the reported position is not backed by an actual plate-solve while this is active. Turning it on seeds a one-time position from the currently coupled mount (via Mount Bridge), not a continuous follow - but doesn't just drift forever: whenever real IMU motion settles, the current dead-reckoned estimate is re-anchored as a fresh 'solve', same as a real solve landing right after you stop panning. That re-anchor trusts PiFinder's own estimate, with nothing independent to check it against. See Help for details.">
-            <span class="status-dot dot-unconfirmed" id="fake-solve-dot"></span>Injected Solve (Dead Reckoning): <span id="fake-solve-text">unknown</span>
+            Manual one-shot seed:
             <button id="fake-solve-btn" class="ql-small-btn" onclick="toggleFakeSolve()" disabled>Toggle</button>
             <button id="fake-solve-reseed-btn" class="ql-small-btn" onclick="reseedFakeSolve()" style="display:none;" disabled title="Re-read the coupled mount's current position and re-inject it, without turning Injected Solve off first (#205).">Re-seed from mount</button>
           </div>
@@ -1724,12 +1755,14 @@
                the piece needed to test Multi-Point Alignment's SETTLING/
                Sync step end-to-end without real sky. Bigger button + the
                same white/yellow/green/red status-dot scheme as the Mount
-               Bridge tile's own buttons (direct feedback, 2026-08-10) -
-               this one is easy to leave on by accident and forget about,
-               so its real, server-confirmed state (not just "I clicked it
-               once") needs to be obvious at a glance. -->
+               Bridge tile's own buttons (direct feedback, 2026-08-10).
+               This row's own dot is scoped narrowly to "is the background
+               process itself alive" (distinct from the combined Synthetic
+               Solve line above) - still useful on its own, since a dead
+               process is a reliability problem even in the rare instant
+               where the flag it drives hasn't gone stale yet. -->
           <div class="hw-row" id="truth-injector-row" title="Feeds &quot;Telescope Simulator&quot;'s own position into PiFinder's /api/fake_solve every 2s, keeping solve_source=CAM and last_solve_success continuously fresh - simulator testing only (Multi-Point Alignment, Auto-correct/Verify-Alert) with no real sky. A background watchdog restarts it automatically if it ever dies while toggled on. Always starts back OFF after a Control Center restart - never persists across reboots.">
-            <span class="status-dot dot-white" id="truth-injector-dot"></span>PiFinder Truth Injector (from Telescope Simulator): <span id="truth-injector-text">off</span>
+            <span class="status-dot dot-white" id="truth-injector-dot"></span>Continuous, from Telescope Simulator: <span id="truth-injector-text">off</span>
             <button id="truth-injector-btn" class="mb-big-action-btn mb-big-sync-btn" style="min-width:6rem; min-height:auto; padding:0.4rem 0.9rem; margin-left:0.4rem;" onclick="toggleTruthInjector()">Toggle</button>
           </div>
         </div>
@@ -2191,7 +2224,7 @@ function refreshSystemLoad() {
 const HW_AMPEL_ICON_IDS = {
   'hw-camera-dot': 'mode-ampel-camera-icon',
   'solve-status-dot': 'mode-ampel-solve-icon',
-  'fake-solve-dot': 'mode-ampel-fake-solve-icon',
+  'synth-solve-dot': 'mode-ampel-fake-solve-icon',
   'hw-imu-dot': 'mode-ampel-imu-icon',
   'hw-gps-dot': 'mode-ampel-gps-icon',
 };
@@ -2285,10 +2318,51 @@ let lastFakeSolveActive = null;
 // stomped the pulsing "in progress" dot back to a stale white/red before
 // the operation had actually finished.
 let fakeSolveToggleInFlight = false;
+let lastFakeSolveRa = null;
+let lastFakeSolveDec = null;
+let lastFakeSolveSince = null;
+
+// Unified 2026-08-10 (direct feedback): Injected Solve (manual one-shot,
+// this section) and the Truth Injector (continuous, see
+// refreshTruthInjectorStatus() below) both ultimately flip the same
+// PiFinder-side fake_solve_active flag - this is the single place that
+// reconciles both and renders the one combined #synth-solve-status-row.
+// Called from both pollers, in whichever order they happen to land.
+function updateSynthSolveStatusLine() {
+  const dotEl = document.getElementById('synth-solve-dot');
+  const textEl = document.getElementById('synth-solve-text');
+  if (lastFakeSolveActive !== true && lastFakeSolveActive !== false) {
+    setHwDot(dotEl, 'status-dot dot-unconfirmed');
+    textEl.textContent = 'unknown';
+    return;
+  }
+  if (!lastFakeSolveActive) {
+    setHwDot(dotEl, 'status-dot dot-white');
+    textEl.textContent = 'off';
+    return;
+  }
+  setHwDot(dotEl, 'status-dot dot-green');
+  // Attribution is a best-effort guess, not a guaranteed-correct source
+  // tag: the Truth Injector's own "desired" flag is the best signal
+  // available for "which control turned this on", but a manual seed
+  // followed by turning the injector on afterwards would show the
+  // injector here even though the very first seed came from the manual
+  // control - harmless either way, since both write the exact same
+  // underlying position.
+  let text = lastTruthInjectorDesired === true ? 'active - continuous from Telescope Simulator' : 'active - manual seed, dead-reckoning';
+  if (typeof lastFakeSolveRa === 'number' && typeof lastFakeSolveDec === 'number') {
+    text += ` (RA ${lastFakeSolveRa.toFixed(1)}°/Dec ${lastFakeSolveDec.toFixed(1)}°`;
+    if (typeof lastFakeSolveSince === 'number') {
+      const minutes = Math.max(0, Math.round((Date.now() / 1000 - lastFakeSolveSince) / 60));
+      text += minutes === 0 ? ', just now)' : `, ${minutes} min ago)`;
+    } else {
+      text += ')';
+    }
+  }
+  textEl.textContent = text;
+}
 
 function applyFakeSolveStatus(data) {
-  const dotEl = document.getElementById('fake-solve-dot');
-  const textEl = document.getElementById('fake-solve-text');
   const btn = document.getElementById('fake-solve-btn');
   const reseedBtn = document.getElementById('fake-solve-reseed-btn');
   const manualBtn = document.getElementById('fake-solve-manual-btn');
@@ -2297,55 +2371,35 @@ function applyFakeSolveStatus(data) {
   if (data.fake_solve_active !== true && data.fake_solve_active !== false) {
     // Unconfirmed (unreachable/failed poll, or no confirmation yet at all
     // on initial page load). Leave the badge and button as they were last
-    // confirmed, only the text/dot say we can't currently tell - but the
-    // dot must be set explicitly here, not left alone: its HTML default is
-    // the pulsing dot-unconfirmed class, and unlike every other row this
-    // one never otherwise clears that on a plain "nothing confirmed yet"
-    // state, so it pulsed forever until the first real answer arrived.
+    // confirmed - the combined status line above says "unknown" itself
+    // via updateSynthSolveStatusLine()'s own unconfirmed branch.
     if (!fakeSolveToggleInFlight) {
-      textEl.textContent = lastFakeSolveActive === true ? 'active (unconfirmed)' : 'unknown';
       btn.disabled = true;
       manualBtn.disabled = true;
       reseedBtn.style.display = 'none';
-      setHwDot(dotEl, lastFakeSolveActive === true ? 'status-dot dot-green dot-unconfirmed' : 'status-dot dot-white');
     }
+    updateSynthSolveStatusLine();
     return;
   }
 
   lastFakeSolveActive = data.fake_solve_active;
+  lastFakeSolveRa = typeof data.fake_solve_ra === 'number' ? data.fake_solve_ra : null;
+  lastFakeSolveDec = typeof data.fake_solve_dec === 'number' ? data.fake_solve_dec : null;
+  lastFakeSolveSince = typeof data.last_solve_success === 'number' ? data.last_solve_success : null;
   badge.style.display = lastFakeSolveActive ? '' : 'none';
-  if (fakeSolveToggleInFlight) return;
-  btn.disabled = false;
-  manualBtn.disabled = false;
-  // Re-seed only makes sense while already active - turning it on fresh
-  // already seeds once, and the manual field above covers "set to a
-  // specific position" for either state (#205).
-  reseedBtn.style.display = lastFakeSolveActive ? '' : 'none';
-  reseedBtn.disabled = false;
-
-  if (!lastFakeSolveActive) {
-    setHwDot(dotEl, 'status-dot dot-white');
-    textEl.textContent = 'off';
-    btn.textContent = 'Toggle';
-    return;
+  if (!fakeSolveToggleInFlight) {
+    btn.disabled = false;
+    manualBtn.disabled = false;
+    // Re-seed only makes sense while already active - turning it on fresh
+    // already seeds once, and the manual field above covers "set to a
+    // specific position" for either state (#205).
+    reseedBtn.style.display = lastFakeSolveActive ? '' : 'none';
+    reseedBtn.disabled = false;
+    btn.textContent = lastFakeSolveActive
+      ? (lastTruthInjectorDesired === true ? 'Turn off (stops Injector too)' : 'Turn off')
+      : 'Toggle';
   }
-
-  setHwDot(dotEl, 'status-dot dot-green');
-  btn.textContent = 'Turn off';
-  const ra = data.fake_solve_ra;
-  const dec = data.fake_solve_dec;
-  const since = data.last_solve_success;
-  let text = 'active';
-  if (typeof ra === 'number' && typeof dec === 'number') {
-    text = `active (RA ${ra.toFixed(1)}°/Dec ${dec.toFixed(1)}°`;
-    if (typeof since === 'number') {
-      const minutes = Math.max(0, Math.round((Date.now() / 1000 - since) / 60));
-      text += minutes === 0 ? ', just now)' : `, ${minutes} min ago)`;
-    } else {
-      text += ')';
-    }
-  }
-  textEl.textContent = text;
+  updateSynthSolveStatusLine();
 }
 
 // #191/#217: PiFinder Truth Injector toggle - polled independently of (and
@@ -2386,6 +2440,7 @@ async function refreshTruthInjectorStatus() {
     // best-effort poll - leave the last-known state showing rather than
     // flashing to "unknown" on one missed request.
   }
+  updateSynthSolveStatusLine();
 }
 setInterval(refreshTruthInjectorStatus, 4000);
 refreshTruthInjectorStatus();
@@ -2394,17 +2449,28 @@ async function toggleTruthInjector() {
   const dotEl = document.getElementById('truth-injector-dot');
   const textEl = document.getElementById('truth-injector-text');
   const btn = document.getElementById('truth-injector-btn');
+  const turningOff = lastTruthInjectorDesired === true;
   truthInjectorToggleInFlight = true;
   btn.disabled = true;
   setHwDot(dotEl, 'status-dot dot-yellow dot-unconfirmed');
-  textEl.textContent = lastTruthInjectorDesired ? 'stopping…' : 'starting…';
+  textEl.textContent = turningOff ? 'stopping…' : 'starting…';
   try {
     await fetch('/api/truth_injector_toggle', { method: 'POST' });
+    if (turningOff) {
+      // Stopping the process alone only stops *refreshing* the shared
+      // fake_solve_active flag - it stays true (just aging) until
+      // something explicitly clears it. Clear it here too so the combined
+      // Synthetic Solve line goes to "off" immediately instead of lingering
+      // as a stale "active, N min ago" (direct feedback, 2026-08-10 - the
+      // two controls share one flag, "off" here should mean off).
+      await fetch('/api/fake_solve_disable', { method: 'POST' });
+    }
   } catch (e) {
     // fall through - the poll below shows whatever's actually true now
   }
   truthInjectorToggleInFlight = false;
   await refreshTruthInjectorStatus();
+  await refreshDebugSolve();
 }
 
 async function refreshDebugSolve() {
@@ -2661,8 +2727,8 @@ async function toggleFakeSolve() {
   if (!pifinderScreenUrl) return;
   const port = new URL(pifinderScreenUrl).port || '80';
   const btn = document.getElementById('fake-solve-btn');
-  const textEl = document.getElementById('fake-solve-text');
-  const dotEl = document.getElementById('fake-solve-dot');
+  const textEl = document.getElementById('synth-solve-text');
+  const dotEl = document.getElementById('synth-solve-dot');
   const turningOn = lastFakeSolveActive !== true;
   const endpoint = turningOn ? '/api/fake_solve_enable_from_mount' : '/api/fake_solve_disable';
   fakeSolveToggleInFlight = true;
@@ -2675,6 +2741,13 @@ async function toggleFakeSolve() {
   // right at the very end (User feedback).
   document.getElementById('mode-ampel-fake-solve-badge').style.display = '';
   try {
+    if (!turningOn && lastTruthInjectorDesired === true) {
+      // Turning off here must also stop the Truth Injector - it shares
+      // the exact same fake_solve_active flag, so leaving it running would
+      // just re-activate this within its next 2s tick (direct feedback,
+      // 2026-08-10).
+      await fetch('/api/truth_injector_toggle', { method: 'POST' });
+    }
     const resp = await fetch(`${endpoint}?port=${port}`, { method: 'POST' });
     const result = await resp.json();
     if (turningOn && result.success !== true) {
@@ -2701,6 +2774,7 @@ async function toggleFakeSolve() {
   // above was a no-op for this row while in flight, by design.
   fakeSolveToggleInFlight = false;
   await refreshDebugSolve();
+  await refreshTruthInjectorStatus();
   if (!landed) btn.disabled = false;
 }
 
@@ -2713,8 +2787,8 @@ async function reseedFakeSolve() {
   if (!pifinderScreenUrl) return;
   const port = new URL(pifinderScreenUrl).port || '80';
   const btn = document.getElementById('fake-solve-reseed-btn');
-  const textEl = document.getElementById('fake-solve-text');
-  const dotEl = document.getElementById('fake-solve-dot');
+  const textEl = document.getElementById('synth-solve-text');
+  const dotEl = document.getElementById('synth-solve-dot');
   fakeSolveToggleInFlight = true;
   btn.disabled = true;
   textEl.textContent = 'Reading mount position…';
@@ -4334,6 +4408,7 @@ function updateMbDiagram(data) {
   setMbNodeDot('mb-icon-mount', data.mount_connected);
   updateBridgeSettingsInfo(data);
   syncThresholdInputFromDriver(data.drift_threshold);
+  syncAlignConfigInputsFromDriver(data.align_radius, data.align_count, data.align_min_altitude);
   applyMbDriftAndMode(data.coupling_mode, data.correction_action, data.drift_arcmin, data.drift_state);
   updateTargetSourceBadge(data.coupling_mode, data.target_source);
   updateOnStepWebLink(data.mount_web_ip);
@@ -4504,6 +4579,47 @@ function syncThresholdInputFromDriver(driftThreshold) {
   const input = document.getElementById('wm-threshold-input');
   if (document.activeElement === input || thresholdChangeDebounce) return;
   input.value = driftThreshold;
+}
+
+// #191/#217: same "don't stomp on an in-progress edit" reasoning as
+// syncThresholdInputFromDriver() above, one field at a time (a user editing
+// Points shouldn't have Radius silently reset under them by the same poll).
+let alignConfigChangeDebounce = null;
+function syncAlignConfigInputsFromDriver(radius, count, minAltitude) {
+  const fields = [
+    ['mb-align-radius-input', radius],
+    ['mb-align-count-input', count],
+    ['mb-align-min-altitude-input', minAltitude],
+  ];
+  for (const [id, value] of fields) {
+    if (value === null || value === undefined) continue;
+    const input = document.getElementById(id);
+    if (document.activeElement === input || alignConfigChangeDebounce) continue;
+    input.value = value;
+  }
+}
+
+async function applyAlignConfigChange() {
+  const radius = parseFloat(document.getElementById('mb-align-radius-input').value.replace(',', '.'));
+  const count = parseFloat(document.getElementById('mb-align-count-input').value.replace(',', '.'));
+  const minAltitude = parseFloat(document.getElementById('mb-align-min-altitude-input').value.replace(',', '.'));
+  if (!Number.isFinite(radius) || !Number.isFinite(count) || !Number.isFinite(minAltitude)) return;
+  setMbActionStatus('⏳ Updating alignment point selection…');
+  try {
+    await fetch(`/api/mount_bridge_align_config?radius=${radius}&count=${count}&min_altitude=${minAltitude}`, { method: 'POST' });
+  } catch (e) {
+    // fall through - the next refreshMountBridgeStatus() poll reflects whatever actually took effect
+  }
+  pollMbLog();
+  clearMbActionStatus();
+}
+
+function scheduleAlignConfigChange() {
+  if (alignConfigChangeDebounce) clearTimeout(alignConfigChangeDebounce);
+  alignConfigChangeDebounce = setTimeout(() => {
+    alignConfigChangeDebounce = null;
+    applyAlignConfigChange();
+  }, 600);
 }
 
 // Server-side log of every Mount Bridge action this tile has triggered

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -1570,6 +1570,17 @@
         <button id="mb-manual-sync-btn" class="mb-big-action-btn mb-big-sync-btn" onclick="triggerManualSync()" title="One-shot: syncs the mount to PiFinder's current solved position right now, regardless of Coupling mode. Useful after moving the mount by hand - none of the Coupling presets react to that on their own.">Sync mount from PiFinder</button>
         <button id="mb-abort-btn" class="mb-big-action-btn mb-abort-btn" onclick="triggerAbortMount()" title="Emergency stop: immediately aborts any mount motion AND sets Coupling to Off, so nothing re-triggers another correction afterward. Works even if PiFinder's own side is unavailable.">Stop movement</button>
       </div>
+      <!-- #191/#217: automatic Multi-Point Alignment. Own row, not merged
+           into mb-big-actions-row above - this is a multi-step sequence
+           with its own progress readout, not a one-shot action, and the
+           Stop button here only matters (is enabled) while a sequence is
+           actually running, unlike Sync/Stop movement which are always
+           live. -->
+      <div class="mb-row" id="mb-multialign-row" title="Automatic Multi-Point Alignment (#191): fetches N bright-star candidates from PiFinder's own catalog, slews to each in turn, waits for a fresh PiFinder solve, and syncs the mount there. Independent of Coupling mode.">
+        <button id="mb-multialign-start-btn" class="mb-big-action-btn mb-big-sync-btn" onclick="triggerMultiAlignStart()">Multi-Point Alignment</button>
+        <button id="mb-multialign-stop-btn" class="mb-big-action-btn mb-abort-btn" onclick="triggerMultiAlignStop()" disabled title="Aborts the running alignment sequence and stops the mount immediately (same underlying stop as the emergency Stop movement button above).">Stop alignment</button>
+      </div>
+      <div id="mb-multialign-progress" class="mb-hint" style="display:none;"></div>
       <div class="mb-row" id="mb-threshold-manual-row">
         <span id="mb-threshold-wrap" title="Used by Verify/Alert and the two Auto-correct presets: how far off before they warn/correct.">
           <span class="mb-row-label">Threshold:</span>
@@ -4727,6 +4738,42 @@ function updateMountRejectWarning(active, message) {
   toggle.style.display = '';
 }
 
+// #191/#217: Multi-Point Alignment progress, on the same fast/best-effort
+// poll as drift above - progress changes on the same multi-second cadence
+// while a sequence is running. multiAlignActionInFlight is separate from
+// mbActionInFlight (not gated on it) so the Start/Stop buttons' own
+// disabled-state juggling during a click doesn't also freeze the drift
+// number, same reasoning as this whole poll being ungated on
+// mbStatusUnconfirmed above.
+let multiAlignActionInFlight = false;
+function updateMultiAlignProgress(alignState, pointIndex, pointCount, pointSynced) {
+  const startBtn = document.getElementById('mb-multialign-start-btn');
+  const stopBtn = document.getElementById('mb-multialign-stop-btn');
+  const progressEl = document.getElementById('mb-multialign-progress');
+  const running = alignState === 'Busy';
+  if (!multiAlignActionInFlight) {
+    startBtn.disabled = running;
+    stopBtn.disabled = !running;
+  }
+  if (!pointCount) {
+    progressEl.style.display = 'none';
+    return;
+  }
+  progressEl.style.display = '';
+  progressEl.classList.toggle('mb-hint-ok', alignState === 'Ok' && pointSynced > 0);
+  if (running) {
+    progressEl.textContent = `Aligning: point ${pointIndex}/${pointCount} (${pointSynced} verified so far)…`;
+  } else if (alignState === 'Ok') {
+    progressEl.textContent = `Last run: ${pointSynced}/${pointCount} point(s) verified and synced.`;
+  } else if (alignState === 'Alert') {
+    progressEl.textContent = pointSynced > 0
+      ? `Stopped at point ${pointIndex}/${pointCount} - ${pointSynced} point(s) verified before stopping.`
+      : `Last run: 0/${pointCount} point(s) verified - stopped or nothing synced (no fresh PiFinder solve?).`;
+  } else {
+    progressEl.style.display = 'none';
+  }
+}
+
 async function refreshMbDrift() {
   if (mbDriftPollInFlight || mbActionInFlight) return;
   mbDriftPollInFlight = true;
@@ -4736,6 +4783,7 @@ async function refreshMbDrift() {
     if (data.running) {
       applyMbDriftAndMode(data.coupling_mode, data.correction_action, data.drift_arcmin, data.drift_state);
       updateMountRejectWarning(data.mount_reject_active, data.mount_reject_message);
+      updateMultiAlignProgress(data.align_state, data.align_point_index, data.align_point_count, data.align_point_synced);
     }
   } catch (e) {
     // best-effort - a miss here just means the number doesn't tick this cycle
@@ -4918,6 +4966,43 @@ async function triggerAbortMount() {
   btn.disabled = false;
   pollMbLog();
   await refreshMountBridgeStatus();
+  clearMbActionStatus();
+}
+
+async function triggerMultiAlignStart() {
+  multiAlignActionInFlight = true;
+  setMbActionStatus('⏳ Starting Multi-Point Alignment…');
+  const btn = document.getElementById('mb-multialign-start-btn');
+  btn.disabled = true;
+  document.getElementById('mb-multialign-stop-btn').disabled = false;
+  try {
+    const resp = await fetch('/api/mount_bridge_multialign_start', { method: 'POST' });
+    const data = await resp.json();
+    if (!data.success) throw new Error(data.error || 'failed');
+  } catch (e) {
+    // fall through - errors show up via pollMbLog() below, same pattern as
+    // the other manual action buttons.
+  }
+  pollMbLog();
+  multiAlignActionInFlight = false;
+  clearMbActionStatus();
+}
+
+async function triggerMultiAlignStop() {
+  // Same deliberately-no-confirm()/no-mbActionInFlight-gate reasoning as
+  // triggerAbortMount() - a stop needs to fire immediately, every time.
+  setMbActionStatus('🛑 Stopping Multi-Point Alignment…');
+  const btn = document.getElementById('mb-multialign-stop-btn');
+  btn.disabled = true;
+  try {
+    const resp = await fetch('/api/mount_bridge_multialign_stop', { method: 'POST' });
+    const data = await resp.json();
+    if (!data.success) throw new Error(data.error || 'failed');
+  } catch (e) {
+    // fall through - errors show up via pollMbLog() below
+  }
+  document.getElementById('mb-multialign-start-btn').disabled = false;
+  pollMbLog();
   clearMbActionStatus();
 }
 

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -5123,6 +5123,7 @@ async function refreshMbDrift() {
       applyMbDriftAndMode(data.coupling_mode, data.correction_action, data.drift_arcmin, data.drift_state);
       updateMountRejectWarning(data.mount_reject_active, data.mount_reject_message);
       updateMultiAlignProgress(data.align_state, data.align_point_index, data.align_point_count, data.align_point_synced);
+      syncAlignConfigInputsFromDriver(data.align_radius, data.align_count, data.align_min_altitude);
     }
   } catch (e) {
     // best-effort - a miss here just means the number doesn't tick this cycle

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -2528,6 +2528,14 @@ async function toggleTruthInjector() {
   } catch (e) {
     // fall through - the poll below shows whatever's actually true now
   }
+  // The toggle POST itself resolves almost instantly (just spawns/kills a
+  // subprocess) - without this wait, yellow was only visible for a
+  // fraction of a second before immediately being overwritten by the
+  // refresh below, which already saw the settled state (direct feedback,
+  // 2026-08-10: "der gelbe status während 'rampup' und 'rampdown' fehlt").
+  // 2.5s matches the injector's own --interval default, giving at least
+  // one real poll cycle time to actually land before claiming settled.
+  await new Promise((r) => setTimeout(r, 2500));
   truthInjectorToggleInFlight = false;
   await refreshTruthInjectorStatus();
   await refreshDebugSolve();

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -301,6 +301,11 @@
   }
   #choices button.danger { background: #a33; }
   #choices button:hover, #start-fresh:hover { filter: brightness(1.15); }
+  /* Same muted red-tinted disabled look as .mb-abort-btn:disabled
+     (2026-08-10, direct feedback) - previously fell through to no rule at
+     all here, leaving a disabled destructive button visually identical to
+     an enabled one except for the cursor. */
+  #choices button:disabled, #start-fresh:disabled { background: #3a1414; color: #ff8a80; border: 1px solid #5a2020; cursor: default; filter: none; }
   .choice-btn { margin: 0 0.6rem 0.6rem 0; }
   #log.log-placeholder {
     color: #666;
@@ -565,7 +570,12 @@
   #power-poweroff-btn { background: #a33; }
   #install-uninstall-btn { background: #a33; }
   .power-btn:hover { filter: brightness(1.15); }
-  .power-btn:disabled { background: #444; cursor: default; filter: none; }
+  /* Same muted red-tinted disabled look as .mb-abort-btn:disabled
+     (2026-08-10, direct feedback) - a plain gray here made a disabled
+     Reboot/Shutdown/Uninstall lose its "this is a dangerous action" red
+     identity entirely, inconsistent with how Stop movement/Stop alignment
+     stay visibly red-tinted while disabled. */
+  .power-btn:disabled { background: #3a1414; color: #ff8a80; border: 1px solid #5a2020; cursor: default; filter: none; }
   #install-groups { display: flex; gap: 1rem; align-items: flex-start; margin: 0.3rem 0 0.8rem; }
   #install-heading-row { display: flex; align-items: center; justify-content: space-between; gap: 0.6rem; margin-bottom: 0.5rem; cursor: pointer; }
   #install-heading-row .tile-heading { margin: 0; }
@@ -587,7 +597,10 @@
     cursor: pointer;
     margin-left: 0.5rem;
   }
-  #mode-toggle-btn:disabled { background: #444; cursor: default; }
+  /* Same muted red-tinted disabled look as .mb-abort-btn:disabled
+     (2026-08-10, direct feedback) - see .power-btn:disabled's own comment
+     for the reasoning. */
+  #mode-toggle-btn:disabled { background: #3a1414; color: #ff8a80; border: 1px solid #5a2020; cursor: default; }
   #mode-toggle-btn:not(:disabled):hover { filter: brightness(1.15); }
   /* Deliberately more muted than the bigger action/accent buttons
      (.mb-coupling-btn, mode-toggle-btn, ...) - per direct feedback, this
@@ -1570,33 +1583,6 @@
         <button id="mb-manual-sync-btn" class="mb-big-action-btn mb-big-sync-btn" onclick="triggerManualSync()" title="One-shot: syncs the mount to PiFinder's current solved position right now, regardless of Coupling mode. Useful after moving the mount by hand - none of the Coupling presets react to that on their own.">Sync mount from PiFinder</button>
         <button id="mb-abort-btn" class="mb-big-action-btn mb-abort-btn" onclick="triggerAbortMount()" title="Emergency stop: immediately aborts any mount motion AND sets Coupling to Off, so nothing re-triggers another correction afterward. Works even if PiFinder's own side is unavailable.">Stop movement</button>
       </div>
-      <!-- #191/#217: automatic Multi-Point Alignment. Own row, not merged
-           into mb-big-actions-row above - this is a multi-step sequence
-           with its own progress readout, not a one-shot action, and the
-           Stop button here only matters (is enabled) while a sequence is
-           actually running, unlike Sync/Stop movement which are always
-           live. -->
-      <div class="mb-row" id="mb-multialign-row" title="Automatic Multi-Point Alignment (#191): fetches N bright-star candidates from PiFinder's own catalog, slews to each in turn, waits for a fresh PiFinder solve, and syncs the mount there. Independent of Coupling mode.">
-        <button id="mb-multialign-start-btn" class="mb-big-action-btn mb-big-sync-btn" onclick="triggerMultiAlignStart()">Multi-Point Alignment</button>
-        <button id="mb-multialign-stop-btn" class="mb-big-action-btn mb-abort-btn" onclick="triggerMultiAlignStop()" disabled title="Aborts the running alignment sequence and stops the mount immediately (same underlying stop as the emergency Stop movement button above).">Stop alignment</button>
-      </div>
-      <div id="mb-multialign-progress" class="mb-hint" style="display:none;"></div>
-      <!-- #191/#217: candidate-selection settings already existed as INDI
-           properties (AlignConfigNP) since the catalog-driven selection
-           landed, but had no GUI control at all - direct feedback,
-           2026-08-10 ("kein Bug, aber warum kein GUI dafür"). Same
-           debounced-input pattern as the Threshold field above. Preferred
-           cardinal direction is deliberately NOT here - it doesn't exist
-           anywhere yet (no INDI property either), a real new feature to
-           design separately, not bolted on alongside these three. -->
-      <div class="mb-row" id="mb-align-config-row" title="Candidate point selection for Multi-Point Alignment (#191) - applies on the next Start, not retroactively to a running sequence.">
-        <span class="mb-row-label">Search radius:</span>
-        <input type="number" id="mb-align-radius-input" class="pf-num-input" value="60" min="5" max="180" step="5" style="width:4em;" onchange="applyAlignConfigChange()" oninput="scheduleAlignConfigChange()"> deg
-        <span class="mb-row-label" style="margin-left:0.6rem;">Points:</span>
-        <input type="number" id="mb-align-count-input" class="pf-num-input" value="4" min="1" max="10" step="1" style="width:3em;" onchange="applyAlignConfigChange()" oninput="scheduleAlignConfigChange()">
-        <span class="mb-row-label" style="margin-left:0.6rem;">Min altitude:</span>
-        <input type="number" id="mb-align-min-altitude-input" class="pf-num-input" value="20" min="0" max="80" step="5" style="width:3em;" onchange="applyAlignConfigChange()" oninput="scheduleAlignConfigChange()"> deg
-      </div>
       <div class="mb-row" id="mb-threshold-manual-row">
         <span id="mb-threshold-wrap" title="Used by Verify/Alert and the two Auto-correct presets: how far off before they warn/correct.">
           <span class="mb-row-label">Threshold:</span>
@@ -1632,6 +1618,42 @@
       <div class="mb-row" id="mb-thisdevice-ip-row" style="display:none;" title="Enter this address on the control host device (its Control host role card asks for it) so it can reach this PiFinder.">
         <span class="mb-row-label">This device's IP:</span>
         <span id="pfhost-ip">checking&hellip;</span>
+      </div>
+
+      <div class="hgroup-divider"></div>
+
+      <!-- #191/#217: own collapsible section, not squeezed into
+           #mb-operate-rows above (direct feedback, 2026-08-10: pushed the
+           Threshold field down, and this is a distinct enough feature to
+           deserve its own "wie gewohnt" collapsible like Setup checklist
+           below, not another inline row). Positioned above Setup checklist
+           & diagnostics, same tier of collapsible section. -->
+      <div class="collapsible-toggle" onclick="toggleCollapsibleSection('mb-multialign-details', 'mb-multialign-chevron')">
+        <span>Multi-Point Alignment<a class="help-link" href="/help.html#multi-point-alignment" target="_blank" rel="noopener" title="Help" onclick="event.stopPropagation()">i</a></span>
+        <span id="mb-multialign-chevron">&#9660; show</span>
+      </div>
+      <div id="mb-multialign-details" style="display:none;">
+        <div class="mb-row" id="mb-multialign-row" title="Automatic Multi-Point Alignment (#191): fetches N bright-star candidates from PiFinder's own catalog, slews to each in turn, waits for a fresh PiFinder solve, and syncs the mount there. Independent of Coupling mode.">
+          <button id="mb-multialign-start-btn" class="mb-big-action-btn mb-big-sync-btn" onclick="triggerMultiAlignStart()">Multi-Point Alignment</button>
+          <button id="mb-multialign-stop-btn" class="mb-big-action-btn mb-abort-btn" onclick="triggerMultiAlignStop()" disabled title="Aborts the running alignment sequence and stops the mount immediately (same underlying stop as the emergency Stop movement button above).">Stop alignment</button>
+        </div>
+        <div id="mb-multialign-progress" class="mb-hint" style="display:none;"></div>
+        <!-- #191/#217: candidate-selection settings already existed as INDI
+             properties (AlignConfigNP) since the catalog-driven selection
+             landed, but had no GUI control at all - direct feedback,
+             2026-08-10 ("kein Bug, aber warum kein GUI dafür"). Same
+             debounced-input pattern as the Threshold field above. Preferred
+             cardinal direction is deliberately NOT here - it doesn't exist
+             anywhere yet (no INDI property either), a real new feature to
+             design separately, not bolted on alongside these three. -->
+        <div class="mb-row" id="mb-align-config-row" title="Candidate point selection for Multi-Point Alignment (#191) - applies on the next Start, not retroactively to a running sequence.">
+          <span class="mb-row-label">Search radius:</span>
+          <input type="number" id="mb-align-radius-input" class="pf-num-input" value="60" min="5" max="180" step="5" style="width:4em;" onchange="applyAlignConfigChange()" oninput="scheduleAlignConfigChange()"> deg
+          <span class="mb-row-label" style="margin-left:0.6rem;">Points:</span>
+          <input type="number" id="mb-align-count-input" class="pf-num-input" value="4" min="1" max="10" step="1" style="width:3em;" onchange="applyAlignConfigChange()" oninput="scheduleAlignConfigChange()">
+          <span class="mb-row-label" style="margin-left:0.6rem;">Min altitude:</span>
+          <input type="number" id="mb-align-min-altitude-input" class="pf-num-input" value="20" min="0" max="80" step="5" style="width:3em;" onchange="applyAlignConfigChange()" oninput="scheduleAlignConfigChange()"> deg
+        </div>
       </div>
 
       <div class="collapsible-toggle" onclick="toggleCollapsibleSection('mb-details', 'mb-details-chevron')">
@@ -4080,6 +4102,7 @@ function restoreCollapsibleSections() {
     ['hw-details', 'hw-details-chevron', 'block'],
     ['ext-hw-status', 'ext-hw-chevron', 'block'],
     ['mode-power-groups', 'mode-power-chevron', 'flex'],
+    ['mb-multialign-details', 'mb-multialign-chevron', 'block'],
     ['mb-details', 'mb-details-chevron', 'block'],
     ['mb-mode-details', 'mb-mode-details-chevron', 'block'],
     ['mb-reject-warning-details', 'mb-reject-warning-chevron', 'block'],

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -625,6 +625,19 @@
   .ql-small-btn:disabled { background: #1a1a1a; color: #666; border-color: #333; cursor: default; }
   .ql-small-btn:not(:disabled):hover { border-color: #777; color: #fff; }
   .ql-small-btn.mb-btn-active { border-color: #4caf50; background: #1c2a1c; color: #4caf50; }
+  /* Traffic-light button coloring (2026-08-10, direct feedback: a
+     quick-access button that carries its own state via background color
+     alone, no status text needed next to it - "man sieht ja das icon oben
+     und dessen Status"). Same white/yellow/green/red palette as the
+     .status-dot classes, applied to a button's background/border/text
+     instead of a small circle - .ql-small-btn-green intentionally
+     duplicates .mb-btn-active's values rather than reusing that class name,
+     since "active" there means something more specific (a selected Coupling
+     preset) than "currently on" here. */
+  .ql-small-btn-white { border-color: #666; background: #2a2a2a; color: #ccc; }
+  .ql-small-btn-yellow { border-color: #f5a623; background: #3a2f10; color: #f5a623; }
+  .ql-small-btn-green { border-color: #4caf50; background: #1c2a1c; color: #4caf50; }
+  .ql-small-btn-red { border-color: #e53935; background: #3a1414; color: #ff8a80; }
   /* Browsers only let one window.open() through per click by default and
      silently block the rest (2026-08-09, found live: "Open all links" only
      ever opened the first tab, PiFinder Remote) - openAllQuickLinks() below
@@ -1771,7 +1784,7 @@
         </div>
         <div id="mode-tile-body">
         <div class="collapsible-toggle" onclick="toggleCollapsibleSection('sim-testing-details', 'sim-testing-chevron')">
-          <span>Simulation and testing<a class="help-link" href="/help.html#simulation-and-testing" target="_blank" rel="noopener" title="Help" onclick="event.stopPropagation()">i</a></span>
+          <span>Simulation and testing<a class="help-link" href="/help.html#simulation-and-testing" target="_blank" rel="noopener" title="Help" onclick="event.stopPropagation()">i</a><button id="sim-quick-injector-btn" class="ql-small-btn ql-small-btn-white" onclick="event.stopPropagation(); toggleTruthInjector();" title="Quick access to the Synthetic Solve toggle below (no need to expand this section first) - button color is the status: white=off, yellow=starting/stopping, green=running, red=died/watchdog recovering.">Injected Solve</button></span>
           <span id="sim-testing-chevron">&#9660; show</span>
         </div>
         <div id="sim-testing-details" style="display:none;" title="Three independent levels, each replacing a different piece while everything else stays real - see the Help link above for details.">
@@ -2434,6 +2447,21 @@ function applyFakeSolveStatus(data) {
 let truthInjectorToggleInFlight = false;
 let lastTruthInjectorDesired = null;
 
+// #191/#217: quick-access duplicate of the Toggle button, in the
+// "Simulation and testing" heading row itself (direct feedback, 2026-08-10:
+// "Das ist das meist benutzte hier" - reaching it shouldn't require
+// expanding the section first). No status text on this one, deliberately -
+// the button's own background color IS the status (white/yellow/green/red,
+// same 4 states as the dot below), same "info via button coloring alone"
+// request as elsewhere. Stays in sync via the exact same two functions,
+// just touching one more element.
+function applyQuickInjectorButtonState(stateClass) {
+  const btn = document.getElementById('sim-quick-injector-btn');
+  if (!btn) return;
+  btn.classList.remove('ql-small-btn-white', 'ql-small-btn-yellow', 'ql-small-btn-green', 'ql-small-btn-red');
+  btn.classList.add(stateClass);
+}
+
 async function refreshTruthInjectorStatus() {
   if (truthInjectorToggleInFlight) return;
   const dotEl = document.getElementById('truth-injector-dot');
@@ -2445,12 +2473,16 @@ async function refreshTruthInjectorStatus() {
     lastTruthInjectorDesired = data.desired;
     btn.disabled = false;
     btn.textContent = data.desired ? 'Turn off' : 'Toggle';
+    const quickBtn = document.getElementById('sim-quick-injector-btn');
+    if (quickBtn) quickBtn.disabled = false;
     if (!data.desired) {
       setHwDot(dotEl, 'status-dot dot-white');
       textEl.textContent = 'off';
+      applyQuickInjectorButtonState('ql-small-btn-white');
     } else if (data.alive) {
       setHwDot(dotEl, 'status-dot dot-green');
       textEl.textContent = 'running';
+      applyQuickInjectorButtonState('ql-small-btn-green');
     } else {
       // Desired on, but the process isn't alive right now - the server's
       // own watchdog will restart it within a few seconds; shown as red
@@ -2458,6 +2490,7 @@ async function refreshTruthInjectorStatus() {
       // PiFinder a fresh solve right now", not just an in-flight click.
       setHwDot(dotEl, 'status-dot dot-red');
       textEl.textContent = 'restarting… (died unexpectedly, watchdog is recovering it)';
+      applyQuickInjectorButtonState('ql-small-btn-red');
     }
   } catch (e) {
     // best-effort poll - leave the last-known state showing rather than
@@ -2474,7 +2507,10 @@ async function toggleTruthInjector() {
   const turningOff = lastTruthInjectorDesired === true;
   truthInjectorToggleInFlight = true;
   btn.disabled = true;
+  const quickBtn = document.getElementById('sim-quick-injector-btn');
+  if (quickBtn) quickBtn.disabled = true;
   setHwDot(dotEl, 'status-dot dot-yellow dot-unconfirmed');
+  applyQuickInjectorButtonState('ql-small-btn-yellow');
   textEl.textContent = turningOff ? 'stopping…' : 'starting…';
   try {
     await fetch('/api/truth_injector_toggle', { method: 'POST' });

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -1717,6 +1717,21 @@
             <button id="fake-solve-manual-btn" class="ql-small-btn" onclick="setFakeSolveManual()" disabled>Set position</button>
             <span id="fake-solve-manual-status"></span>
           </div>
+          <!-- #191/#217: keeps PiFinder's solve continuously "fresh" from
+               wherever the Telescope Simulator currently points, via
+               test_tools/pifinder_truth_injector.py as a managed background
+               process (see server.py's own _truth_injector_* comments) -
+               the piece needed to test Multi-Point Alignment's SETTLING/
+               Sync step end-to-end without real sky. Bigger button + the
+               same white/yellow/green/red status-dot scheme as the Mount
+               Bridge tile's own buttons (direct feedback, 2026-08-10) -
+               this one is easy to leave on by accident and forget about,
+               so its real, server-confirmed state (not just "I clicked it
+               once") needs to be obvious at a glance. -->
+          <div class="hw-row" id="truth-injector-row" title="Feeds &quot;Telescope Simulator&quot;'s own position into PiFinder's /api/fake_solve every 2s, keeping solve_source=CAM and last_solve_success continuously fresh - simulator testing only (Multi-Point Alignment, Auto-correct/Verify-Alert) with no real sky. A background watchdog restarts it automatically if it ever dies while toggled on. Always starts back OFF after a Control Center restart - never persists across reboots.">
+            <span class="status-dot dot-white" id="truth-injector-dot"></span>PiFinder Truth Injector (from Telescope Simulator): <span id="truth-injector-text">off</span>
+            <button id="truth-injector-btn" class="mb-big-action-btn mb-big-sync-btn" style="min-width:6rem; min-height:auto; padding:0.4rem 0.9rem; margin-left:0.4rem;" onclick="toggleTruthInjector()">Toggle</button>
+          </div>
         </div>
         <div class="collapsible-toggle" onclick="toggleCollapsibleSection('hw-details', 'hw-details-chevron')">
           <span>Hardware test and details<a class="help-link" href="/help.html#hardware-test-and-details" target="_blank" rel="noopener" title="Help" onclick="event.stopPropagation()">i</a></span>
@@ -2331,6 +2346,65 @@ function applyFakeSolveStatus(data) {
     }
   }
   textEl.textContent = text;
+}
+
+// #191/#217: PiFinder Truth Injector toggle - polled independently of (and
+// faster than) the 20s refreshDebugSolve() cadence below, same reasoning as
+// refreshMbDrift()'s own separate 2s interval: this reflects a background
+// process that can die on its own between polls, and "must run reliably"
+// (direct feedback) means the dot has to catch that promptly, not up to
+// 20s late.
+let truthInjectorToggleInFlight = false;
+let lastTruthInjectorDesired = null;
+
+async function refreshTruthInjectorStatus() {
+  if (truthInjectorToggleInFlight) return;
+  const dotEl = document.getElementById('truth-injector-dot');
+  const textEl = document.getElementById('truth-injector-text');
+  const btn = document.getElementById('truth-injector-btn');
+  try {
+    const resp = await fetch('/api/truth_injector_status', { cache: 'no-store' });
+    const data = await resp.json();
+    lastTruthInjectorDesired = data.desired;
+    btn.disabled = false;
+    btn.textContent = data.desired ? 'Turn off' : 'Toggle';
+    if (!data.desired) {
+      setHwDot(dotEl, 'status-dot dot-white');
+      textEl.textContent = 'off';
+    } else if (data.alive) {
+      setHwDot(dotEl, 'status-dot dot-green');
+      textEl.textContent = 'running';
+    } else {
+      // Desired on, but the process isn't alive right now - the server's
+      // own watchdog will restart it within a few seconds; shown as red
+      // (not yellow) because this genuinely means "not actually feeding
+      // PiFinder a fresh solve right now", not just an in-flight click.
+      setHwDot(dotEl, 'status-dot dot-red');
+      textEl.textContent = 'restarting… (died unexpectedly, watchdog is recovering it)';
+    }
+  } catch (e) {
+    // best-effort poll - leave the last-known state showing rather than
+    // flashing to "unknown" on one missed request.
+  }
+}
+setInterval(refreshTruthInjectorStatus, 4000);
+refreshTruthInjectorStatus();
+
+async function toggleTruthInjector() {
+  const dotEl = document.getElementById('truth-injector-dot');
+  const textEl = document.getElementById('truth-injector-text');
+  const btn = document.getElementById('truth-injector-btn');
+  truthInjectorToggleInFlight = true;
+  btn.disabled = true;
+  setHwDot(dotEl, 'status-dot dot-yellow dot-unconfirmed');
+  textEl.textContent = lastTruthInjectorDesired ? 'stopping…' : 'starting…';
+  try {
+    await fetch('/api/truth_injector_toggle', { method: 'POST' });
+  } catch (e) {
+    // fall through - the poll below shows whatever's actually true now
+  }
+  truthInjectorToggleInFlight = false;
+  await refreshTruthInjectorStatus();
 }
 
 async function refreshDebugSolve() {

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -207,17 +207,13 @@
   .tile-heading-row {
     display: flex;
     align-items: center;
+    justify-content: space-between;
     gap: 0.6rem;
     cursor: pointer;
     margin: 0 0 0.5rem;
   }
-  .tile-heading-row .tile-heading { margin: 0; flex-shrink: 0; }
-  /* margin-left:auto (rather than the row's own justify-content:
-     space-between, removed 2026-08-10) so a heading row can carry a third,
-     optional element (e.g. #mb-action-status) between the title and the
-     chevron without needing its own layout rule - the chevron just always
-     ends up flush right regardless of what else is in the row. */
-  .tile-chevron { color: #888; font-size: 0.8rem; flex-shrink: 0; user-select: none; margin-left: auto; }
+  .tile-heading-row .tile-heading { margin: 0; }
+  .tile-chevron { color: #888; font-size: 0.8rem; flex-shrink: 0; user-select: none; }
   .tile-heading-row:hover .tile-chevron { color: #ccc; }
   .help-link {
     display: inline-block;

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -1633,11 +1633,22 @@
         <span id="mb-multialign-chevron">&#9660; show</span>
       </div>
       <div id="mb-multialign-details" style="display:none;">
+        <!-- Follows this project's documented status-row convention
+           (Readme_ControlCenter.md "Design Principles" #1/#2, re-read
+           2026-08-10 after direct feedback that this row was missing it
+           entirely): <dot> Label: status, white/green/yellow/red. Adapted
+           for a discrete multi-step action rather than a component health
+           check - yellow means "running" here (there's no ongoing
+           degraded-but-working state for a one-shot sequence like there is
+           for e.g. hardware presence), green always carries a real
+           completion message (what was actually done), not just "Ok". -->
+        <div class="hw-row" id="mb-multialign-status-row" title="Status of the last (or currently running) Multi-Point Alignment sequence.">
+          <span class="status-dot dot-white" id="mb-multialign-dot"></span>Multi-Point Alignment: <span id="mb-multialign-status-text">not run yet</span>
+        </div>
         <div class="mb-row" id="mb-multialign-row" title="Automatic Multi-Point Alignment (#191): fetches N bright-star candidates from PiFinder's own catalog, slews to each in turn, waits for a fresh PiFinder solve, and syncs the mount there. Independent of Coupling mode.">
-          <button id="mb-multialign-start-btn" class="mb-big-action-btn mb-big-sync-btn" onclick="triggerMultiAlignStart()">Multi-Point Alignment</button>
+          <button id="mb-multialign-start-btn" class="mb-big-action-btn mb-big-sync-btn" onclick="triggerMultiAlignStart()">Start</button>
           <button id="mb-multialign-stop-btn" class="mb-big-action-btn mb-abort-btn" onclick="triggerMultiAlignStop()" disabled title="Aborts the running alignment sequence and stops the mount immediately (same underlying stop as the emergency Stop movement button above).">Stop alignment</button>
         </div>
-        <div id="mb-multialign-progress" class="mb-hint" style="display:none;"></div>
         <!-- #191/#217: candidate-selection settings already existed as INDI
              properties (AlignConfigNP) since the catalog-driven selection
              landed, but had no GUI control at all - direct feedback,
@@ -1744,48 +1755,38 @@
             <span class="status-dot dot-unconfirmed" id="debug-solve-dot"></span>Solve Simulation (PiFinder built-in): <span id="debug-solve-text">unknown</span>
             <button id="debug-solve-btn" class="ql-small-btn" onclick="toggleDebugSolve()" disabled>Toggle</button>
           </div>
-          <!-- Unified 2026-08-10 (direct feedback): Injected Solve (manual
-               one-shot seed) and the Truth Injector (continuous, below)
-               both ultimately drive the exact same PiFinder-side
-               fake_solve_active flag - showing two independently-tracked
-               dots for one shared piece of state was actively misleading
-               (found live: an orphaned manual-test injector process kept
-               this flag true while the new Truth Injector toggle correctly
-               said "off", since it was tracking a different process it
-               never started). One status line now answers "is a synthetic
-               solve active, and via which mechanism" - the two rows below
-               are just two different ways to drive it, not two
-               independent things to keep straight. -->
-          <div class="hw-row" id="synth-solve-status-row" title="Whether PiFinder's currently-reported solve is synthetic (via /api/fake_solve) rather than a real camera plate-solve, and which of the two controls below is driving it right now.">
-            <span class="status-dot dot-unconfirmed" id="synth-solve-dot"></span>Synthetic Solve: <span id="synth-solve-text">unknown</span>
+          <!-- Radically simplified 2026-08-10 (direct feedback: "Das ist
+               alles viel zu kompliziert!!! Was der Nutzer will: EINEN (!!!)
+               Toggle. Synthetic solve läuft oder läuft nicht. Und beides
+               zuverlässig."). ONE row, one dot, one button - the Truth
+               Injector's own start/stop (backed by the server-side
+               watchdog, so "zuverlässig" is a real property of this
+               control, not just a label) IS the toggle. The pre-existing
+               manual one-shot RA/Dec seed (#106/#205) still exists (real,
+               separately useful capability) but is demoted to its own
+               collapsed Advanced sub-section below, entirely out of the
+               primary flow - it is NOT reflected in this dot, on purpose,
+               to keep this one signal simple and trustworthy. -->
+          <div class="hw-row" id="synth-solve-status-row" title="Whether PiFinder's currently-reported solve is synthetic - continuously fed from &quot;Telescope Simulator&quot;'s own position via test_tools/pifinder_truth_injector.py, kept alive by a background watchdog - rather than a real camera plate-solve. Simulator testing only, no real sky.">
+            <span class="status-dot dot-white" id="truth-injector-dot"></span>Synthetic Solve: <span id="truth-injector-text">off</span>
+            <button id="truth-injector-btn" class="ql-small-btn" onclick="toggleTruthInjector()">Toggle</button>
           </div>
-          <div class="hw-row" id="fake-solve-row" title="A synthetic RA/Dec injected via PiFinder's /api/fake_solve (see #106) - real IMU dead-reckoning takes over from there, exactly as it would from a real solve. Distinct from Solve Simulation above (which only swaps the camera image) and from a real solve - the reported position is not backed by an actual plate-solve while this is active. Turning it on seeds a one-time position from the currently coupled mount (via Mount Bridge), not a continuous follow - but doesn't just drift forever: whenever real IMU motion settles, the current dead-reckoned estimate is re-anchored as a fresh 'solve', same as a real solve landing right after you stop panning. That re-anchor trusts PiFinder's own estimate, with nothing independent to check it against. See Help for details.">
-            Manual one-shot seed:
-            <button id="fake-solve-btn" class="ql-small-btn" onclick="toggleFakeSolve()" disabled>Toggle</button>
-            <button id="fake-solve-reseed-btn" class="ql-small-btn" onclick="reseedFakeSolve()" style="display:none;" disabled title="Re-read the coupled mount's current position and re-inject it, without turning Injected Solve off first (#205).">Re-seed from mount</button>
+          <div class="collapsible-toggle" onclick="toggleCollapsibleSection('fake-solve-advanced', 'fake-solve-advanced-chevron')">
+            <span>Advanced: manual one-shot seed</span>
+            <span id="fake-solve-advanced-chevron">&#9660; show</span>
           </div>
-          <div class="hw-detail" id="fake-solve-manual-row" title="Sets Injected Solve directly to a specific RA/Dec (JNow, degrees) via PiFinder's own /api/fake_solve - independent of any coupled mount. Turns Injected Solve on if it wasn't already (#205).">
-            <input type="number" id="fake-solve-manual-ra" step="0.01" min="0" max="360" placeholder="RA (deg)" style="width:5.5rem;">
-            <input type="number" id="fake-solve-manual-dec" step="0.01" min="-90" max="90" placeholder="Dec (deg)" style="width:5.5rem;">
-            <button id="fake-solve-manual-btn" class="ql-small-btn" onclick="setFakeSolveManual()" disabled>Set position</button>
-            <span id="fake-solve-manual-status"></span>
-          </div>
-          <!-- #191/#217: keeps PiFinder's solve continuously "fresh" from
-               wherever the Telescope Simulator currently points, via
-               test_tools/pifinder_truth_injector.py as a managed background
-               process (see server.py's own _truth_injector_* comments) -
-               the piece needed to test Multi-Point Alignment's SETTLING/
-               Sync step end-to-end without real sky. Bigger button + the
-               same white/yellow/green/red status-dot scheme as the Mount
-               Bridge tile's own buttons (direct feedback, 2026-08-10).
-               This row's own dot is scoped narrowly to "is the background
-               process itself alive" (distinct from the combined Synthetic
-               Solve line above) - still useful on its own, since a dead
-               process is a reliability problem even in the rare instant
-               where the flag it drives hasn't gone stale yet. -->
-          <div class="hw-row" id="truth-injector-row" title="Feeds &quot;Telescope Simulator&quot;'s own position into PiFinder's /api/fake_solve every 2s, keeping solve_source=CAM and last_solve_success continuously fresh - simulator testing only (Multi-Point Alignment, Auto-correct/Verify-Alert) with no real sky. A background watchdog restarts it automatically if it ever dies while toggled on. Always starts back OFF after a Control Center restart - never persists across reboots.">
-            <span class="status-dot dot-white" id="truth-injector-dot"></span>Continuous, from Telescope Simulator: <span id="truth-injector-text">off</span>
-            <button id="truth-injector-btn" class="mb-big-action-btn mb-big-sync-btn" style="min-width:6rem; min-height:auto; padding:0.4rem 0.9rem; margin-left:0.4rem;" onclick="toggleTruthInjector()">Toggle</button>
+          <div id="fake-solve-advanced" style="display:none;">
+            <div class="hw-row" id="fake-solve-row" title="A synthetic RA/Dec injected via PiFinder's /api/fake_solve (see #106) - real IMU dead-reckoning takes over from there, exactly as it would from a real solve. Distinct from Solve Simulation above (which only swaps the camera image) and from a real solve - the reported position is not backed by an actual plate-solve while this is active. Turning it on seeds a one-time position from the currently coupled mount (via Mount Bridge), not a continuous follow - but doesn't just drift forever: whenever real IMU motion settles, the current dead-reckoned estimate is re-anchored as a fresh 'solve', same as a real solve landing right after you stop panning. That re-anchor trusts PiFinder's own estimate, with nothing independent to check it against. Not reflected in the Synthetic Solve dot above, on purpose - see its own status text here instead.">
+              Manual one-shot seed: <span id="fake-solve-advanced-status">unknown</span>
+              <button id="fake-solve-btn" class="ql-small-btn" onclick="toggleFakeSolve()" disabled>Toggle</button>
+              <button id="fake-solve-reseed-btn" class="ql-small-btn" onclick="reseedFakeSolve()" style="display:none;" disabled title="Re-read the coupled mount's current position and re-inject it, without turning Injected Solve off first (#205).">Re-seed from mount</button>
+            </div>
+            <div class="hw-detail" id="fake-solve-manual-row" title="Sets Injected Solve directly to a specific RA/Dec (JNow, degrees) via PiFinder's own /api/fake_solve - independent of any coupled mount. Turns Injected Solve on if it wasn't already (#205).">
+              <input type="number" id="fake-solve-manual-ra" step="0.01" min="0" max="360" placeholder="RA (deg)" style="width:5.5rem;">
+              <input type="number" id="fake-solve-manual-dec" step="0.01" min="-90" max="90" placeholder="Dec (deg)" style="width:5.5rem;">
+              <button id="fake-solve-manual-btn" class="ql-small-btn" onclick="setFakeSolveManual()" disabled>Set position</button>
+              <span id="fake-solve-manual-status"></span>
+            </div>
           </div>
         </div>
         <div class="collapsible-toggle" onclick="toggleCollapsibleSection('hw-details', 'hw-details-chevron')">
@@ -2246,7 +2247,7 @@ function refreshSystemLoad() {
 const HW_AMPEL_ICON_IDS = {
   'hw-camera-dot': 'mode-ampel-camera-icon',
   'solve-status-dot': 'mode-ampel-solve-icon',
-  'synth-solve-dot': 'mode-ampel-fake-solve-icon',
+  'truth-injector-dot': 'mode-ampel-fake-solve-icon',
   'hw-imu-dot': 'mode-ampel-imu-icon',
   'hw-gps-dot': 'mode-ampel-gps-icon',
 };
@@ -2340,51 +2341,14 @@ let lastFakeSolveActive = null;
 // stomped the pulsing "in progress" dot back to a stale white/red before
 // the operation had actually finished.
 let fakeSolveToggleInFlight = false;
-let lastFakeSolveRa = null;
-let lastFakeSolveDec = null;
-let lastFakeSolveSince = null;
 
-// Unified 2026-08-10 (direct feedback): Injected Solve (manual one-shot,
-// this section) and the Truth Injector (continuous, see
-// refreshTruthInjectorStatus() below) both ultimately flip the same
-// PiFinder-side fake_solve_active flag - this is the single place that
-// reconciles both and renders the one combined #synth-solve-status-row.
-// Called from both pollers, in whichever order they happen to land.
-function updateSynthSolveStatusLine() {
-  const dotEl = document.getElementById('synth-solve-dot');
-  const textEl = document.getElementById('synth-solve-text');
-  if (lastFakeSolveActive !== true && lastFakeSolveActive !== false) {
-    setHwDot(dotEl, 'status-dot dot-unconfirmed');
-    textEl.textContent = 'unknown';
-    return;
-  }
-  if (!lastFakeSolveActive) {
-    setHwDot(dotEl, 'status-dot dot-white');
-    textEl.textContent = 'off';
-    return;
-  }
-  setHwDot(dotEl, 'status-dot dot-green');
-  // Attribution is a best-effort guess, not a guaranteed-correct source
-  // tag: the Truth Injector's own "desired" flag is the best signal
-  // available for "which control turned this on", but a manual seed
-  // followed by turning the injector on afterwards would show the
-  // injector here even though the very first seed came from the manual
-  // control - harmless either way, since both write the exact same
-  // underlying position.
-  let text = lastTruthInjectorDesired === true ? 'active - continuous from Telescope Simulator' : 'active - manual seed, dead-reckoning';
-  if (typeof lastFakeSolveRa === 'number' && typeof lastFakeSolveDec === 'number') {
-    text += ` (RA ${lastFakeSolveRa.toFixed(1)}°/Dec ${lastFakeSolveDec.toFixed(1)}°`;
-    if (typeof lastFakeSolveSince === 'number') {
-      const minutes = Math.max(0, Math.round((Date.now() / 1000 - lastFakeSolveSince) / 60));
-      text += minutes === 0 ? ', just now)' : `, ${minutes} min ago)`;
-    } else {
-      text += ')';
-    }
-  }
-  textEl.textContent = text;
-}
-
+// Simplified 2026-08-10 (direct feedback): the primary #synth-solve-status-row
+// dot/text is now driven entirely by refreshTruthInjectorStatus() below (see
+// that function) - ONE reliable signal, nothing here reconciles two sources
+// anymore. This function only updates the demoted Advanced sub-section's own
+// small text status, not any dot.
 function applyFakeSolveStatus(data) {
+  const statusEl = document.getElementById('fake-solve-advanced-status');
   const btn = document.getElementById('fake-solve-btn');
   const reseedBtn = document.getElementById('fake-solve-reseed-btn');
   const manualBtn = document.getElementById('fake-solve-manual-btn');
@@ -2392,36 +2356,45 @@ function applyFakeSolveStatus(data) {
 
   if (data.fake_solve_active !== true && data.fake_solve_active !== false) {
     // Unconfirmed (unreachable/failed poll, or no confirmation yet at all
-    // on initial page load). Leave the badge and button as they were last
-    // confirmed - the combined status line above says "unknown" itself
-    // via updateSynthSolveStatusLine()'s own unconfirmed branch.
+    // on initial page load).
     if (!fakeSolveToggleInFlight) {
+      statusEl.textContent = 'unknown';
       btn.disabled = true;
       manualBtn.disabled = true;
       reseedBtn.style.display = 'none';
     }
-    updateSynthSolveStatusLine();
     return;
   }
 
   lastFakeSolveActive = data.fake_solve_active;
-  lastFakeSolveRa = typeof data.fake_solve_ra === 'number' ? data.fake_solve_ra : null;
-  lastFakeSolveDec = typeof data.fake_solve_dec === 'number' ? data.fake_solve_dec : null;
-  lastFakeSolveSince = typeof data.last_solve_success === 'number' ? data.last_solve_success : null;
   badge.style.display = lastFakeSolveActive ? '' : 'none';
-  if (!fakeSolveToggleInFlight) {
-    btn.disabled = false;
-    manualBtn.disabled = false;
-    // Re-seed only makes sense while already active - turning it on fresh
-    // already seeds once, and the manual field above covers "set to a
-    // specific position" for either state (#205).
-    reseedBtn.style.display = lastFakeSolveActive ? '' : 'none';
-    reseedBtn.disabled = false;
-    btn.textContent = lastFakeSolveActive
-      ? (lastTruthInjectorDesired === true ? 'Turn off (stops Injector too)' : 'Turn off')
-      : 'Toggle';
+  if (fakeSolveToggleInFlight) return;
+  btn.disabled = false;
+  manualBtn.disabled = false;
+  // Re-seed only makes sense while already active - turning it on fresh
+  // already seeds once, and the manual field above covers "set to a
+  // specific position" for either state (#205).
+  reseedBtn.style.display = lastFakeSolveActive ? '' : 'none';
+  reseedBtn.disabled = false;
+  btn.textContent = lastFakeSolveActive ? 'Turn off' : 'Toggle';
+  if (!lastFakeSolveActive) {
+    statusEl.textContent = 'off';
+    return;
   }
-  updateSynthSolveStatusLine();
+  const ra = data.fake_solve_ra;
+  const dec = data.fake_solve_dec;
+  const since = data.last_solve_success;
+  let text = 'active';
+  if (typeof ra === 'number' && typeof dec === 'number') {
+    text = `active (RA ${ra.toFixed(1)}°/Dec ${dec.toFixed(1)}°`;
+    if (typeof since === 'number') {
+      const minutes = Math.max(0, Math.round((Date.now() / 1000 - since) / 60));
+      text += minutes === 0 ? ', just now)' : `, ${minutes} min ago)`;
+    } else {
+      text += ')';
+    }
+  }
+  statusEl.textContent = text;
 }
 
 // #191/#217: PiFinder Truth Injector toggle - polled independently of (and
@@ -2462,7 +2435,6 @@ async function refreshTruthInjectorStatus() {
     // best-effort poll - leave the last-known state showing rather than
     // flashing to "unknown" on one missed request.
   }
-  updateSynthSolveStatusLine();
 }
 setInterval(refreshTruthInjectorStatus, 4000);
 refreshTruthInjectorStatus();
@@ -2749,14 +2721,12 @@ async function toggleFakeSolve() {
   if (!pifinderScreenUrl) return;
   const port = new URL(pifinderScreenUrl).port || '80';
   const btn = document.getElementById('fake-solve-btn');
-  const textEl = document.getElementById('synth-solve-text');
-  const dotEl = document.getElementById('synth-solve-dot');
+  const textEl = document.getElementById('fake-solve-advanced-status');
   const turningOn = lastFakeSolveActive !== true;
   const endpoint = turningOn ? '/api/fake_solve_enable_from_mount' : '/api/fake_solve_disable';
   fakeSolveToggleInFlight = true;
   btn.disabled = true;
   textEl.textContent = turningOn ? 'Reading mount position…' : 'Turning off…';
-  setHwDot(dotEl, 'status-dot dot-yellow dot-unconfirmed');
   // Badge follows the row's dot immediately, not just once confirmed -
   // otherwise it stayed invisible for the whole in-flight window (several
   // seconds, given the mount-read+inject round trip) and only popped in
@@ -2809,12 +2779,10 @@ async function reseedFakeSolve() {
   if (!pifinderScreenUrl) return;
   const port = new URL(pifinderScreenUrl).port || '80';
   const btn = document.getElementById('fake-solve-reseed-btn');
-  const textEl = document.getElementById('synth-solve-text');
-  const dotEl = document.getElementById('synth-solve-dot');
+  const textEl = document.getElementById('fake-solve-advanced-status');
   fakeSolveToggleInFlight = true;
   btn.disabled = true;
   textEl.textContent = 'Reading mount position…';
-  setHwDot(dotEl, 'status-dot dot-yellow dot-unconfirmed');
   try {
     const resp = await fetch(`/api/fake_solve_enable_from_mount?port=${port}`, { method: 'POST' });
     const result = await resp.json();
@@ -4099,6 +4067,7 @@ function restoreCollapsibleSections() {
   const sections = [
     ['ql-links', 'ql-links-chevron', 'block'],
     ['sim-testing-details', 'sim-testing-chevron', 'block'],
+    ['fake-solve-advanced', 'fake-solve-advanced-chevron', 'block'],
     ['hw-details', 'hw-details-chevron', 'block'],
     ['ext-hw-status', 'ext-hw-chevron', 'block'],
     ['mode-power-groups', 'mode-power-chevron', 'flex'],
@@ -4951,39 +4920,52 @@ function updateMountRejectWarning(active, message) {
   toggle.style.display = '';
 }
 
-// #191/#217: Multi-Point Alignment progress, on the same fast/best-effort
+// #191/#217: Multi-Point Alignment status, on the same fast/best-effort
 // poll as drift above - progress changes on the same multi-second cadence
 // while a sequence is running. multiAlignActionInFlight is separate from
 // mbActionInFlight (not gated on it) so the Start/Stop buttons' own
 // disabled-state juggling during a click doesn't also freeze the drift
 // number, same reasoning as this whole poll being ungated on
 // mbStatusUnconfirmed above.
+//
+// Follows this project's documented status-row convention
+// (Readme_ControlCenter.md "Design Principles" #1/#2, re-read 2026-08-10
+// after direct feedback this row was missing it entirely): <dot> Label:
+// status, white/green/yellow/red - adapted for a discrete multi-step
+// action rather than a component health check: yellow means "running"
+// here (a one-shot sequence has no ongoing degraded-but-working state the
+// way e.g. hardware presence does), green always carries a real
+// completion message, not just "Ok".
 let multiAlignActionInFlight = false;
 function updateMultiAlignProgress(alignState, pointIndex, pointCount, pointSynced) {
   const startBtn = document.getElementById('mb-multialign-start-btn');
   const stopBtn = document.getElementById('mb-multialign-stop-btn');
-  const progressEl = document.getElementById('mb-multialign-progress');
+  const dotEl = document.getElementById('mb-multialign-dot');
+  const textEl = document.getElementById('mb-multialign-status-text');
   const running = alignState === 'Busy';
   if (!multiAlignActionInFlight) {
     startBtn.disabled = running;
     stopBtn.disabled = !running;
   }
   if (!pointCount) {
-    progressEl.style.display = 'none';
+    setHwDot(dotEl, 'status-dot dot-white');
+    textEl.textContent = 'not run yet';
     return;
   }
-  progressEl.style.display = '';
-  progressEl.classList.toggle('mb-hint-ok', alignState === 'Ok' && pointSynced > 0);
   if (running) {
-    progressEl.textContent = `Aligning: point ${pointIndex}/${pointCount} (${pointSynced} verified so far)…`;
+    setHwDot(dotEl, 'status-dot dot-yellow');
+    textEl.textContent = `running - point ${pointIndex}/${pointCount} (${pointSynced} verified so far)…`;
   } else if (alignState === 'Ok') {
-    progressEl.textContent = `Last run: ${pointSynced}/${pointCount} point(s) verified and synced.`;
+    setHwDot(dotEl, 'status-dot dot-green');
+    textEl.textContent = `completed - ${pointSynced}/${pointCount} point(s) verified and synced.`;
   } else if (alignState === 'Alert') {
-    progressEl.textContent = pointSynced > 0
-      ? `Stopped at point ${pointIndex}/${pointCount} - ${pointSynced} point(s) verified before stopping.`
-      : `Last run: 0/${pointCount} point(s) verified - stopped or nothing synced (no fresh PiFinder solve?).`;
+    setHwDot(dotEl, 'status-dot dot-red');
+    textEl.textContent = pointSynced > 0
+      ? `stopped at point ${pointIndex}/${pointCount} - ${pointSynced} point(s) verified before stopping.`
+      : `failed - 0/${pointCount} point(s) verified (stopped, or no fresh PiFinder solve arrived).`;
   } else {
-    progressEl.style.display = 'none';
+    setHwDot(dotEl, 'status-dot dot-white');
+    textEl.textContent = 'not run yet';
   }
 }
 

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -207,13 +207,17 @@
   .tile-heading-row {
     display: flex;
     align-items: center;
-    justify-content: space-between;
     gap: 0.6rem;
     cursor: pointer;
     margin: 0 0 0.5rem;
   }
-  .tile-heading-row .tile-heading { margin: 0; }
-  .tile-chevron { color: #888; font-size: 0.8rem; flex-shrink: 0; user-select: none; }
+  .tile-heading-row .tile-heading { margin: 0; flex-shrink: 0; }
+  /* margin-left:auto (rather than the row's own justify-content:
+     space-between, removed 2026-08-10) so a heading row can carry a third,
+     optional element (e.g. #mb-action-status) between the title and the
+     chevron without needing its own layout rule - the chevron just always
+     ends up flush right regardless of what else is in the row. */
+  .tile-chevron { color: #888; font-size: 0.8rem; flex-shrink: 0; user-select: none; margin-left: auto; }
   .tile-heading-row:hover .tile-chevron { color: #ccc; }
   .help-link {
     display: inline-block;
@@ -939,20 +943,27 @@
      Reserving the space plus a short opacity transition fixes both: the
      rest of the tile never jumps, and the message arrives/leaves smoothly. */
   #mb-action-status {
-    height: 1.9rem;
+    height: 1.5rem;
     box-sizing: border-box;
     background: #1a3a5c;
     color: #7ec8ff;
     border-radius: 6px;
-    padding: 0.4rem 0.7rem;
-    font-size: 0.8rem;
+    padding: 0.25rem 0.6rem;
+    font-size: 0.72rem;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     opacity: 0;
     transition: opacity 0.15s ease;
+    min-width: 0;
+    flex: 0 1 auto;
   }
   #mb-action-status.mb-action-status-visible { opacity: 1; }
+  /* Own compact flex row for the (i)-labelled heading plus its action
+     status pill (2026-08-10, direct feedback - see the HTML comment at this
+     row's own markup) - .group-label itself stays a plain block everywhere
+     else, this ID-scoped override doesn't affect other group-label rows. */
+  #mb-diagram-heading-row { display: flex; align-items: center; justify-content: space-between; gap: 0.6rem; margin-bottom: 0.4rem; }
   .mb-row { margin-bottom: 0.5rem; color: #ccc; font-size: 0.78rem; }
   .mb-row-label { color: #888; margin-right: 0.4rem; }
   /* The 1.-5. checklist rows: label lengths differ ("KStars Link:" vs
@@ -1046,6 +1057,14 @@
     font-weight: bold;
     line-height: 1;
     color: #888;
+    /* Matches .mb-icon's fixed 32.5px exactly (2026-08-10, "Kosmetik": Drift
+       badge wasn't quite the same height as Bridge/PiFinder/Mount) - without
+       this, the big number's own line-height alone renders shorter than an
+       icon, so the badge as a whole came out a few px shorter despite
+       identical padding/gap on both. */
+    min-height: 32.5px;
+    display: flex;
+    align-items: center;
   }
   #mb-drift-badge.mb-drift-green { border-color: #4caf50; }
   #mb-drift-badge.mb-drift-green #mb-drift-value { color: #4caf50; }
@@ -1489,7 +1508,17 @@
            only their position moved - see updateProfileRoleLine() for the
            "PiFinder host" role hiding this whole group too. -->
       <div class="hgroup-divider"></div>
-      <div class="group-label">Mount Bridge<a class="help-link" href="/help.html#mount-bridge" target="_blank" rel="noopener" title="Help">i</a></div>
+      <!-- #mb-action-status moved here 2026-08-10 (direct feedback: "Da ist
+           Platz. Also direkt neben dem (i). Das wird so drunter geklatscht"
+           - it used to sit full-width below the whole diagram/drift-badge/
+           warning block, well past the (i) it's most related to). Own flex
+           row rather than changing .group-label itself, which is a shared
+           utility class used by many unrelated section labels elsewhere on
+           this page. -->
+      <div class="group-label" id="mb-diagram-heading-row">
+        <span>Mount Bridge<a class="help-link" href="/help.html#mount-bridge" target="_blank" rel="noopener" title="Help">i</a></span>
+        <div id="mb-action-status"></div>
+      </div>
       <div id="mb-diagram">
         <div class="mb-node" id="mb-node-lx200" title="PiFinder">
           <svg class="mb-icon" id="mb-icon-lx200" viewBox="0 0 24 24" aria-hidden="true">
@@ -1535,7 +1564,6 @@
       <div id="mb-mode-details" style="display:none;"></div>
       <div id="mb-status-row">
         <div id="mb-status-line"><span class="status-dot dot-white" id="mount-bridge-dot"></span><span id="mount-bridge-text">checking&hellip;</span><span id="mount-bridge-unconfirmed" style="display:none;" title="Our own status check couldn't reach Mount Bridge just now - this is very likely just that check's own timing, not a real disconnect (see Help). Showing the last confirmed state below; interactive buttons are paused until we can confirm again."> (unconfirmed)</span><span id="mb-reject-warning-toggle" style="display:none;" onclick="toggleCollapsibleSection('mb-reject-warning-details', 'mb-reject-warning-chevron')" title="The mount's own driver reported that it refused the last Goto/Sync - most likely an elevation or cable-wrap/axis limit. Not retrying the same command automatically - check the mount and its limit settings.">&#9888; Warning - Details <span id="mb-reject-warning-chevron">&#9660;</span></span></div>
-        <div id="mb-action-status"></div>
       </div>
       <div id="mb-reject-warning-details" style="display:none;"><span id="mb-reject-warning-text"></span></div>
       </div>

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -635,7 +635,13 @@
      since "active" there means something more specific (a selected Coupling
      preset) than "currently on" here. */
   .ql-small-btn-white { border-color: #666; background: #2a2a2a; color: #ccc; }
-  .ql-small-btn-yellow { border-color: #f5a623; background: #3a2f10; color: #f5a623; }
+  /* Yellow only ever means "in-flight, not yet confirmed" for this button
+     (the only place that applies it is toggleTruthInjector()'s own
+     starting/stopping window) - pulses like every other in-flight signal
+     on this page (.dot-unconfirmed's own mb-status-pulse) rather than
+     sitting static, per direct feedback (2026-08-10) that it wasn't
+     blinking while green hadn't been reached yet. */
+  .ql-small-btn-yellow { border-color: #f5a623; background: #3a2f10; color: #f5a623; animation: mb-status-pulse 1.1s ease-in-out infinite; }
   .ql-small-btn-green { border-color: #4caf50; background: #1c2a1c; color: #4caf50; }
   .ql-small-btn-red { border-color: #e53935; background: #3a1414; color: #ff8a80; }
   /* Browsers only let one window.open() through per click by default and

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -2464,36 +2464,54 @@ function applyQuickInjectorButtonState(stateClass) {
   btn.classList.add(stateClass);
 }
 
-async function refreshTruthInjectorStatus() {
-  if (truthInjectorToggleInFlight) return;
+// Single place that renders a confirmed (desired, alive) pair OR an
+// explicit error string - shared by the periodic poll and
+// toggleTruthInjector()'s own settling loop below, so both always agree on
+// what each state looks like (2026-08-10, direct feedback pass #2: the
+// fixed 2.5s hold from the previous fix was a guess, not an actual "wait
+// until really settled" - replaced with a real poll-until-target loop that
+// needed this shared renderer to stay in sync with the periodic poll).
+function applyTruthInjectorState(desired, alive, errorText) {
   const dotEl = document.getElementById('truth-injector-dot');
   const textEl = document.getElementById('truth-injector-text');
+  const btn = document.getElementById('truth-injector-btn');
+  const quickBtn = document.getElementById('sim-quick-injector-btn');
+  if (errorText) {
+    setHwDot(dotEl, 'status-dot dot-red');
+    textEl.textContent = errorText;
+    applyQuickInjectorButtonState('ql-small-btn-red');
+    return;
+  }
+  btn.textContent = desired ? 'Turn off' : 'Toggle';
+  if (!desired) {
+    setHwDot(dotEl, 'status-dot dot-white');
+    textEl.textContent = 'off';
+    applyQuickInjectorButtonState('ql-small-btn-white');
+  } else if (alive) {
+    setHwDot(dotEl, 'status-dot dot-green');
+    textEl.textContent = 'running';
+    applyQuickInjectorButtonState('ql-small-btn-green');
+  } else {
+    // Desired on, but the process isn't alive right now - the server's own
+    // watchdog will restart it within a few seconds; shown as red (not
+    // yellow) because this genuinely means "not actually feeding PiFinder
+    // a fresh solve right now", not just an in-flight click.
+    setHwDot(dotEl, 'status-dot dot-red');
+    textEl.textContent = 'restarting… (died unexpectedly, watchdog is recovering it)';
+    applyQuickInjectorButtonState('ql-small-btn-red');
+  }
+  if (quickBtn) quickBtn.disabled = false;
+}
+
+async function refreshTruthInjectorStatus() {
+  if (truthInjectorToggleInFlight) return;
   const btn = document.getElementById('truth-injector-btn');
   try {
     const resp = await fetch('/api/truth_injector_status', { cache: 'no-store' });
     const data = await resp.json();
     lastTruthInjectorDesired = data.desired;
     btn.disabled = false;
-    btn.textContent = data.desired ? 'Turn off' : 'Toggle';
-    const quickBtn = document.getElementById('sim-quick-injector-btn');
-    if (quickBtn) quickBtn.disabled = false;
-    if (!data.desired) {
-      setHwDot(dotEl, 'status-dot dot-white');
-      textEl.textContent = 'off';
-      applyQuickInjectorButtonState('ql-small-btn-white');
-    } else if (data.alive) {
-      setHwDot(dotEl, 'status-dot dot-green');
-      textEl.textContent = 'running';
-      applyQuickInjectorButtonState('ql-small-btn-green');
-    } else {
-      // Desired on, but the process isn't alive right now - the server's
-      // own watchdog will restart it within a few seconds; shown as red
-      // (not yellow) because this genuinely means "not actually feeding
-      // PiFinder a fresh solve right now", not just an in-flight click.
-      setHwDot(dotEl, 'status-dot dot-red');
-      textEl.textContent = 'restarting… (died unexpectedly, watchdog is recovering it)';
-      applyQuickInjectorButtonState('ql-small-btn-red');
-    }
+    applyTruthInjectorState(data.desired, data.alive, null);
   } catch (e) {
     // best-effort poll - leave the last-known state showing rather than
     // flashing to "unknown" on one missed request.
@@ -2502,42 +2520,94 @@ async function refreshTruthInjectorStatus() {
 setInterval(refreshTruthInjectorStatus, 4000);
 refreshTruthInjectorStatus();
 
+// Real poll-until-target-reached control loop (2026-08-10, direct feedback
+// pass #2: "so lange (!) nach dem Drücken der Status nicht erreicht ist:
+// gelb blinken" / "geht etwas schief: rot! ... zeige was schief gelaufen
+// ist" / "genau das Gleiche beim Ausschalten. Wir brauchen da eine klare
+// Kontrolle!") - replaces the previous fixed-delay guess entirely, and is
+// now symmetric for both directions:
+//   1. POST the toggle. If the server itself reports failure (success !==
+//      true - e.g. the subprocess couldn't be spawned), go straight to red
+//      with the real error message and stop. No guessing.
+//   2. Otherwise poll /api/truth_injector_status roughly once a second,
+//      staying yellow/pulsing, until the target state is actually
+//      confirmed reached (desired===false for "turning off",
+//      desired===true && alive===true for "turning on").
+//   3. If TOGGLE_SETTLE_TIMEOUT_MS passes without reaching the target, that
+//      is itself an error - stop, show red with an explicit timeout
+//      message (most likely cause: indiserver/Telescope Simulator not
+//      reachable, or the injector script can't resolve the device) rather
+//      than silently falling back to whatever the last poll happened to say.
+const TRUTH_INJECTOR_SETTLE_TIMEOUT_MS = 15000;
+const TRUTH_INJECTOR_POLL_INTERVAL_MS = 1000;
+
 async function toggleTruthInjector() {
-  const dotEl = document.getElementById('truth-injector-dot');
-  const textEl = document.getElementById('truth-injector-text');
   const btn = document.getElementById('truth-injector-btn');
   const turningOff = lastTruthInjectorDesired === true;
   truthInjectorToggleInFlight = true;
   btn.disabled = true;
   const quickBtn = document.getElementById('sim-quick-injector-btn');
   if (quickBtn) quickBtn.disabled = true;
-  setHwDot(dotEl, 'status-dot dot-yellow dot-unconfirmed');
+  setHwDot(document.getElementById('truth-injector-dot'), 'status-dot dot-yellow dot-unconfirmed');
   applyQuickInjectorButtonState('ql-small-btn-yellow');
-  textEl.textContent = turningOff ? 'stopping…' : 'starting…';
+  document.getElementById('truth-injector-text').textContent = turningOff ? 'stopping…' : 'starting…';
+
+  let toggleError = null;
   try {
-    await fetch('/api/truth_injector_toggle', { method: 'POST' });
-    if (turningOff) {
+    const resp = await fetch('/api/truth_injector_toggle', { method: 'POST' });
+    const result = await resp.json();
+    if (result.success !== true) {
+      toggleError = result.error || 'unknown error';
+    } else if (turningOff) {
       // Stopping the process alone only stops *refreshing* the shared
       // fake_solve_active flag - it stays true (just aging) until
-      // something explicitly clears it. Clear it here too so the combined
-      // Synthetic Solve line goes to "off" immediately instead of lingering
-      // as a stale "active, N min ago" (direct feedback, 2026-08-10 - the
-      // two controls share one flag, "off" here should mean off).
+      // something explicitly clears it. Clear it here too so "off" here
+      // actually means off, not just "not being refreshed anymore".
       await fetch('/api/fake_solve_disable', { method: 'POST' });
     }
   } catch (e) {
-    // fall through - the poll below shows whatever's actually true now
+    toggleError = 'could not reach the server';
   }
-  // The toggle POST itself resolves almost instantly (just spawns/kills a
-  // subprocess) - without this wait, yellow was only visible for a
-  // fraction of a second before immediately being overwritten by the
-  // refresh below, which already saw the settled state (direct feedback,
-  // 2026-08-10: "der gelbe status während 'rampup' und 'rampdown' fehlt").
-  // 2.5s matches the injector's own --interval default, giving at least
-  // one real poll cycle time to actually land before claiming settled.
-  await new Promise((r) => setTimeout(r, 2500));
+
+  if (toggleError) {
+    applyTruthInjectorState(lastTruthInjectorDesired, false, `failed to ${turningOff ? 'stop' : 'start'}: ${toggleError}`);
+    truthInjectorToggleInFlight = false;
+    btn.disabled = false;
+    if (quickBtn) quickBtn.disabled = false;
+    return;
+  }
+
+  const deadline = Date.now() + TRUTH_INJECTOR_SETTLE_TIMEOUT_MS;
+  let settled = false;
+  let lastData = null;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, TRUTH_INJECTOR_POLL_INTERVAL_MS));
+    try {
+      const resp = await fetch('/api/truth_injector_status', { cache: 'no-store' });
+      lastData = await resp.json();
+    } catch (e) {
+      continue; // best-effort - just try again next tick, still within budget
+    }
+    const target = turningOff ? lastData.desired === false : (lastData.desired === true && lastData.alive === true);
+    if (target) {
+      settled = true;
+      break;
+    }
+  }
+
   truthInjectorToggleInFlight = false;
-  await refreshTruthInjectorStatus();
+  if (settled && lastData) {
+    lastTruthInjectorDesired = lastData.desired;
+    applyTruthInjectorState(lastData.desired, lastData.alive, null);
+  } else {
+    applyTruthInjectorState(
+      lastTruthInjectorDesired,
+      false,
+      `timed out waiting to ${turningOff ? 'stop' : 'start'} - check indiserver/Telescope Simulator connection`
+    );
+  }
+  btn.disabled = false;
+  if (quickBtn) quickBtn.disabled = false;
   await refreshDebugSolve();
 }
 

--- a/gui_installer/status_page.html
+++ b/gui_installer/status_page.html
@@ -1510,7 +1510,7 @@
             <span>PiFinder</span>
           </div>
           <div id="pifinder-glance-status-stack">
-            <div id="pifinder-status-line" title="Reflects the web server/OLED mirror answering - PiFinder can be &quot;running&quot; on the software side even with hardware missing (see PiFinder Mode, Test and Power below)."><span class="status-dot dot-white" id="pifinder-status-dot"></span><span id="pifinder-status-text">PiFinder not detected yet</span></div>
+            <div id="pifinder-status-line" title="Reflects the web server/OLED mirror answering - PiFinder can be &quot;running&quot; on the software side even with hardware missing (see Simulation, Test and Power below)."><span class="status-dot dot-white" id="pifinder-status-dot"></span><span id="pifinder-status-text">PiFinder not detected yet</span></div>
             <div id="system-load-line" title="CPU load average relative to core count - not an error, just a heads-up: a genuinely busy Pi can make PiFinder's own position server briefly slow to answer (see the LX200/Mount Bridge docs for details)."><span class="status-dot dot-white" id="system-load-dot"></span><span id="system-load-text">Checking system load…</span></div>
           </div>
         </div>
@@ -1781,7 +1781,7 @@
     </div>
     <div id="mode-tile">
         <div class="tile-heading-row" onclick="toggleTileBody('mode-tile-body', 'mode-tile-chevron')">
-          <h3 class="tile-heading" title="Real Mode uses actual PiFinder hardware (camera/IMU/GPS). Fake Mode runs a separate headless instance with everything simulated, for testing without hardware.">PiFinder Mode, Test and Power<a class="help-link" href="/help.html#mode-power" target="_blank" rel="noopener" title="Help" onclick="event.stopPropagation()">i</a></h3>
+          <h3 class="tile-heading" title="Real Mode uses actual PiFinder hardware (camera/IMU/GPS). Fake Mode runs a separate headless instance with everything simulated, for testing without hardware.">Simulation, Test and Power<a class="help-link" href="/help.html#mode-power" target="_blank" rel="noopener" title="Help" onclick="event.stopPropagation()">i</a></h3>
           <span class="tile-chevron" id="mode-tile-chevron">&#9650;</span>
         </div>
         <div id="mode-tile-body">
@@ -2220,7 +2220,7 @@ function updatePiFinderStatusAndWizardLink() {
       // (same known upstream issue the mode tile already accounts for).
       // Mirror that tile's wording here instead of contradicting it.
       dotEl.className = 'status-dot dot-yellow';
-      textEl.textContent = `PiFinder is running, but not functional (${missingHardwareLabel()} missing - see PiFinder Mode, Test and Power)`;
+      textEl.textContent = `PiFinder is running, but not functional (${missingHardwareLabel()} missing - see Simulation, Test and Power)`;
     } else {
       dotEl.className = 'status-dot dot-green';
       textEl.textContent = 'PiFinder is running';

--- a/indi_pifinder_bridge/pifinder_mount_bridge.cpp
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.cpp
@@ -2122,6 +2122,14 @@ bool PiFinderMountBridge::saveConfigItems(FILE *fp)
     IUSaveConfigNumber(fp, &DriftThresholdNP);
     IUSaveConfigNumber(fp, &MaxSyncDriftNP);
     IUSaveConfigNumber(fp, &SolveFreshnessMaxAgeNP);
+    // #191/#217: was missing here despite ISNewNumber() already calling
+    // saveConfig(true, AlignConfigNP.name) on every change - that call only
+    // *triggers* a save, saveConfigItems() (this function) is what actually
+    // decides what gets written. Without this line, radius/count/
+    // min_altitude silently never persisted across a driver restart/reboot,
+    // always resetting to the IUFillNumber defaults - found live, 2026-08-10,
+    // in response to "Überleben diese Werte einen Reload/Reboot?".
+    IUSaveConfigNumber(fp, &AlignConfigNP);
     return true;
 }
 

--- a/indi_pifinder_bridge/pifinder_mount_bridge.cpp
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.cpp
@@ -217,6 +217,11 @@ bool PiFinderMountBridge::initProperties()
     IUFillSwitchVector(&AbortMountSP, AbortMountS, 1, getDeviceName(), "ABORT_MOUNT",
                        "Emergency stop", "Main Control", IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
 
+    IUFillSwitch(&MultiPointAlignS[ALIGN_START], "ALIGN_START", "Start", ISS_OFF);
+    IUFillSwitch(&MultiPointAlignS[ALIGN_STOP], "ALIGN_STOP", "Stop", ISS_OFF);
+    IUFillSwitchVector(&MultiPointAlignSP, MultiPointAlignS, 2, getDeviceName(), "MULTI_POINT_ALIGN",
+                       "Multi-Point Alignment (#191 PoC)", "Main Control", IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
+
     IUFillSwitch(&RepositionConfirmS[REPOSITION_CONFIRM_YES], "REPOSITION_CONFIRM_YES", "Adopt new position", ISS_OFF);
     IUFillSwitch(&RepositionConfirmS[REPOSITION_CONFIRM_NO], "REPOSITION_CONFIRM_NO", "Revert to held target", ISS_OFF);
     IUFillSwitchVector(&RepositionConfirmSP, RepositionConfirmS, 2, getDeviceName(), "REPOSITION_CONFIRM",
@@ -289,6 +294,7 @@ bool PiFinderMountBridge::updateProperties()
         defineProperty(&CorrectionActionSP);
         defineProperty(&ManualTriggerSP);
         defineProperty(&AbortMountSP);
+        defineProperty(&MultiPointAlignSP);
         defineProperty(&DriftThresholdNP);
         defineProperty(&MaxSyncDriftNP);
         defineProperty(&SolveFreshnessMaxAgeNP);
@@ -316,6 +322,7 @@ bool PiFinderMountBridge::updateProperties()
         deleteProperty(CorrectionActionSP.name);
         deleteProperty(ManualTriggerSP.name);
         deleteProperty(AbortMountSP.name);
+        deleteProperty(MultiPointAlignSP.name);
         deleteProperty(DriftThresholdNP.name);
         deleteProperty(MaxSyncDriftNP.name);
         deleteProperty(SolveFreshnessMaxAgeNP.name);
@@ -733,6 +740,13 @@ void PiFinderMountBridge::TimerHit()
         return;
     }
     m_bindingGiveUpLogged = false;
+
+    // #191 PoC - independent of Coupling mode entirely (a one-shot action,
+    // not a standing coupling mode - see the concept doc's own "Abgrenzung
+    // zu bestehenden Coupling-Modi"), so it ticks unconditionally here
+    // rather than through the BridgeModeSP dispatch below. Own state
+    // machine, no-ops immediately when IDLE/DONE.
+    handleMultiPointAlignment();
 
     // Drift is computed and published whenever the bridge is ready
     // (PiFinder solving, mount connected), regardless of Coupling mode -
@@ -1371,6 +1385,158 @@ void PiFinderMountBridge::handleAutoCorrectGoto(bool exceeded, double piRA, doub
     }
 }
 
+// #191 PoC - see the header comment on MultiPointAlignSP and
+// docs/concepts/mount_bridge_multistar_alignment.md for the full design
+// this is a deliberately reduced slice of.
+bool PiFinderMountBridge::gotoAlignPoint(size_t index)
+{
+    const double ra = m_alignPoints[index].first;
+    const double dec = m_alignPoints[index].second;
+    double mountRA, mountDec;
+    applySlewRateForDrift(m_client->getMountRADE(mountRA, mountDec)
+                               ? angularSeparationArcmin(ra, dec, mountRA, mountDec)
+                               : SLEW_RATE_FAR_THRESHOLD_ARCMIN + 1.0);
+    if (!m_client->sendMountCoords(ra, dec, "TRACK"))
+    {
+        LOGF_ERROR("Multi-Point Alignment: failed to send Goto for point %zu/%zu (RA %.4fh, DEC %.4f deg).",
+                   index + 1, m_alignPoints.size(), ra, dec);
+        return false;
+    }
+    LOGF_INFO("Multi-Point Alignment: slewing to point %zu/%zu (RA %.4fh, DEC %.4f deg).",
+              index + 1, m_alignPoints.size(), ra, dec);
+    m_alignState = AlignState::SLEWING;
+    return true;
+}
+
+void PiFinderMountBridge::startMultiPointAlignment()
+{
+    if (m_alignState != AlignState::IDLE && m_alignState != AlignState::DONE)
+    {
+        LOG_WARN("Multi-Point Alignment: already running.");
+        MultiPointAlignSP.s = IPS_ALERT;
+        IDSetSwitch(&MultiPointAlignSP, nullptr);
+        return;
+    }
+    if (!m_client->isReady())
+    {
+        LOG_ERROR("Multi-Point Alignment: PiFinder/mount not ready - cannot start.");
+        MultiPointAlignSP.s = IPS_ALERT;
+        IDSetSwitch(&MultiPointAlignSP, nullptr);
+        return;
+    }
+
+    LOGF_INFO("Multi-Point Alignment: starting a %zu-point sequence (PoC - fixed points, single "
+              "solve per point, Sync only - see #191).",
+              m_alignPoints.size());
+    m_alignPointIndex = 0;
+    if (gotoAlignPoint(m_alignPointIndex))
+    {
+        MultiPointAlignSP.s = IPS_BUSY;
+    }
+    else
+    {
+        m_alignState = AlignState::IDLE;
+        MultiPointAlignSP.s = IPS_ALERT;
+    }
+    IDSetSwitch(&MultiPointAlignSP, nullptr);
+}
+
+void PiFinderMountBridge::stopMultiPointAlignment(const char *reason)
+{
+    if (m_alignState == AlignState::IDLE)
+        return;
+
+    LOGF_WARN("Multi-Point Alignment: stopped (%s) after %zu/%zu points.", reason, m_alignPointIndex,
+              m_alignPoints.size());
+    m_alignState = AlignState::IDLE;
+    // Reuses the existing panic-button path (#179) rather than a bespoke
+    // stop mechanism - matches UC4 in the concept doc exactly.
+    m_client->abortMount();
+    MultiPointAlignSP.s = IPS_ALERT;
+    IDSetSwitch(&MultiPointAlignSP, nullptr);
+}
+
+void PiFinderMountBridge::handleMultiPointAlignment()
+{
+    switch (m_alignState)
+    {
+        case AlignState::IDLE:
+        case AlignState::DONE:
+            return;
+
+        case AlignState::SLEWING:
+        {
+            if (!m_client->isMountSlewing())
+            {
+                m_alignSettleTicksRemaining = SETTLE_TICKS;
+                m_alignFreshnessWaitTicksRemaining = MAX_FRESHNESS_WAIT_TICKS;
+                m_alignState = AlignState::SETTLING;
+                LOGF_INFO("Multi-Point Alignment: arrived at point %zu/%zu, waiting for a fresh "
+                          "PiFinder solve to verify.",
+                          m_alignPointIndex + 1, m_alignPoints.size());
+            }
+            break;
+        }
+
+        case AlignState::SETTLING:
+        {
+            if (m_alignSettleTicksRemaining > 0)
+            {
+                --m_alignSettleTicksRemaining;
+                break;
+            }
+
+            if (!isPiFinderSolveFresh(SolveFreshnessMaxAgeN[0].value))
+            {
+                if (--m_alignFreshnessWaitTicksRemaining <= 0)
+                {
+                    LOGF_WARN("Multi-Point Alignment: no fresh solve at point %zu/%zu within the "
+                              "wait budget - skipping this point (see §4.4).",
+                              m_alignPointIndex + 1, m_alignPoints.size());
+                    advanceAlignPoint();
+                }
+                break;
+            }
+
+            double piRA, piDec;
+            if (m_client->getPiFinderRADE(piRA, piDec) && m_client->sendMountCoords(piRA, piDec, "SYNC"))
+            {
+                LOGF_INFO("Multi-Point Alignment: point %zu/%zu verified - synced mount to RA %.4fh, "
+                          "DEC %.4f deg (fresh PiFinder solve).",
+                          m_alignPointIndex + 1, m_alignPoints.size(), piRA, piDec);
+            }
+            else
+            {
+                LOGF_WARN("Multi-Point Alignment: could not sync at point %zu/%zu - skipping.",
+                          m_alignPointIndex + 1, m_alignPoints.size());
+            }
+            advanceAlignPoint();
+            break;
+        }
+    }
+}
+
+void PiFinderMountBridge::advanceAlignPoint()
+{
+    ++m_alignPointIndex;
+    if (m_alignPointIndex >= m_alignPoints.size())
+    {
+        LOGF_INFO("Multi-Point Alignment: sequence complete (%zu point(s) attempted).",
+                  m_alignPoints.size());
+        m_alignState = AlignState::DONE;
+        MultiPointAlignSP.s = IPS_OK;
+        IDSetSwitch(&MultiPointAlignSP, nullptr);
+        return;
+    }
+
+    if (!gotoAlignPoint(m_alignPointIndex))
+    {
+        m_alignState = AlignState::IDLE;
+        MultiPointAlignSP.s = IPS_ALERT;
+        IDSetSwitch(&MultiPointAlignSP, nullptr);
+    }
+}
+
 bool PiFinderMountBridge::ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
@@ -1545,6 +1711,20 @@ bool PiFinderMountBridge::ISNewSwitch(const char *dev, const char *name, ISState
 
             IUResetSwitch(&AbortMountSP);
             IDSetSwitch(&AbortMountSP, nullptr);
+            return true;
+        }
+
+        if (strcmp(name, MultiPointAlignSP.name) == 0)
+        {
+            IUUpdateSwitch(&MultiPointAlignSP, states, names, n);
+
+            if (MultiPointAlignS[ALIGN_START].s == ISS_ON)
+                startMultiPointAlignment();
+            else if (MultiPointAlignS[ALIGN_STOP].s == ISS_ON)
+                stopMultiPointAlignment("stopped by user");
+
+            IUResetSwitch(&MultiPointAlignSP);
+            IDSetSwitch(&MultiPointAlignSP, nullptr);
             return true;
         }
 

--- a/indi_pifinder_bridge/pifinder_mount_bridge.cpp
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdio>
 #include <cstring>
 #include <ctime>
 #include <memory>
@@ -138,6 +139,76 @@ bool httpGetPiFinderOrientation(const std::string &url, std::string &mountType, 
     }
 }
 
+// #191 - fetches candidate alignment points from PiFinder's own
+// /api/nearby_bright_stars (its "Str" bright-named-star catalog, already
+// altitude-filtered server-side using PiFinder's own GPS location/time -
+// see docs/concepts/mount_bridge_multistar_alignment.md §4.2). No ra/dec
+// query params are sent - the endpoint centers on PiFinder's own current
+// solved position itself, matching §4.2's own decision to anchor on
+// PiFinder's view rather than the mount's (possibly wrong) one. RA comes
+// back in degrees (this endpoint's own convention, matching every other
+// CompositeObject-shaped PiFinder API) - converted to hours here to match
+// sendMountCoords()'s convention, same as everywhere else in this file.
+// Returns false (with outError set) on any request/parse failure or a
+// zero-candidate response.
+bool httpGetNearbyBrightStars(const std::string &url, double radius, int count, double minAltitude,
+                               std::vector<std::pair<double, double>> &outPoints, std::string &outError)
+{
+    CURL *curl = curl_easy_init();
+    if (curl == nullptr)
+    {
+        outError = "curl_easy_init failed";
+        return false;
+    }
+
+    char fullUrl[256];
+    std::snprintf(fullUrl, sizeof(fullUrl), "%s?radius=%.1f&count=%d&min_altitude=%.1f",
+                  url.c_str(), radius, count, minAltitude);
+
+    std::string body;
+    curl_easy_setopt(curl, CURLOPT_URL, fullUrl);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, appendToString);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &body);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, 3000L);
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+
+    const CURLcode res = curl_easy_perform(curl);
+    long httpCode = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpCode);
+    curl_easy_cleanup(curl);
+
+    if (res != CURLE_OK)
+    {
+        outError = curl_easy_strerror(res);
+        return false;
+    }
+    if (httpCode != 200)
+    {
+        outError = "HTTP " + std::to_string(httpCode) + ": " + body;
+        return false;
+    }
+
+    try
+    {
+        const auto parsed = nlohmann::json::parse(body);
+        const auto &candidates = parsed.at("candidates");
+        outPoints.clear();
+        for (const auto &c : candidates)
+            outPoints.emplace_back(c.at("ra").get<double>() / 15.0, c.at("dec").get<double>());
+        if (outPoints.empty())
+        {
+            outError = "0 candidates returned";
+            return false;
+        }
+        return true;
+    }
+    catch (const nlohmann::json::exception &e)
+    {
+        outError = std::string("JSON parse error: ") + e.what();
+        return false;
+    }
+}
+
 bool isPiFinderSolveFresh(double maxAgeSeconds)
 {
     std::string solveSource;
@@ -220,7 +291,13 @@ bool PiFinderMountBridge::initProperties()
     IUFillSwitch(&MultiPointAlignS[ALIGN_START], "ALIGN_START", "Start", ISS_OFF);
     IUFillSwitch(&MultiPointAlignS[ALIGN_STOP], "ALIGN_STOP", "Stop", ISS_OFF);
     IUFillSwitchVector(&MultiPointAlignSP, MultiPointAlignS, 2, getDeviceName(), "MULTI_POINT_ALIGN",
-                       "Multi-Point Alignment (#191 PoC)", "Main Control", IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
+                       "Multi-Point Alignment (#191)", "Main Control", IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
+
+    IUFillNumber(&AlignConfigN[ALIGN_RADIUS], "RADIUS_DEG", "Search radius (deg)", "%.0f", 5, 180, 5, 60);
+    IUFillNumber(&AlignConfigN[ALIGN_COUNT], "POINT_COUNT", "Number of points", "%.0f", 1, 10, 1, 4);
+    IUFillNumber(&AlignConfigN[ALIGN_MIN_ALTITUDE], "MIN_ALTITUDE_DEG", "Min altitude (deg)", "%.0f", 0, 80, 5, 20);
+    IUFillNumberVector(&AlignConfigNP, AlignConfigN, 3, getDeviceName(), "ALIGN_CONFIG",
+                       "Alignment point selection", "Main Control", IP_RW, 60, IPS_IDLE);
 
     IUFillSwitch(&RepositionConfirmS[REPOSITION_CONFIRM_YES], "REPOSITION_CONFIRM_YES", "Adopt new position", ISS_OFF);
     IUFillSwitch(&RepositionConfirmS[REPOSITION_CONFIRM_NO], "REPOSITION_CONFIRM_NO", "Revert to held target", ISS_OFF);
@@ -295,6 +372,7 @@ bool PiFinderMountBridge::updateProperties()
         defineProperty(&ManualTriggerSP);
         defineProperty(&AbortMountSP);
         defineProperty(&MultiPointAlignSP);
+        defineProperty(&AlignConfigNP);
         defineProperty(&DriftThresholdNP);
         defineProperty(&MaxSyncDriftNP);
         defineProperty(&SolveFreshnessMaxAgeNP);
@@ -323,6 +401,7 @@ bool PiFinderMountBridge::updateProperties()
         deleteProperty(ManualTriggerSP.name);
         deleteProperty(AbortMountSP.name);
         deleteProperty(MultiPointAlignSP.name);
+        deleteProperty(AlignConfigNP.name);
         deleteProperty(DriftThresholdNP.name);
         deleteProperty(MaxSyncDriftNP.name);
         deleteProperty(SolveFreshnessMaxAgeNP.name);
@@ -1408,6 +1487,29 @@ bool PiFinderMountBridge::gotoAlignPoint(size_t index)
     return true;
 }
 
+bool PiFinderMountBridge::fetchAlignmentCandidates()
+{
+    const double radius = AlignConfigN[ALIGN_RADIUS].value;
+    const int count = static_cast<int>(AlignConfigN[ALIGN_COUNT].value);
+    const double minAltitude = AlignConfigN[ALIGN_MIN_ALTITUDE].value;
+
+    std::string error;
+    const bool ok =
+        httpGetNearbyBrightStars("http://127.0.0.1/api/nearby_bright_stars", radius, count, minAltitude,
+                                  m_alignPoints, error) ||
+        httpGetNearbyBrightStars("http://127.0.0.1:8080/api/nearby_bright_stars", radius, count, minAltitude,
+                                  m_alignPoints, error);
+    if (!ok)
+    {
+        LOGF_ERROR("Multi-Point Alignment: could not get candidate points from PiFinder (%s).", error.c_str());
+        return false;
+    }
+    LOGF_INFO("Multi-Point Alignment: got %zu candidate point(s) from PiFinder (radius %.0f deg, "
+              "min altitude %.0f deg).",
+              m_alignPoints.size(), radius, minAltitude);
+    return true;
+}
+
 void PiFinderMountBridge::startMultiPointAlignment()
 {
     if (m_alignState != AlignState::IDLE && m_alignState != AlignState::DONE)
@@ -1424,9 +1526,16 @@ void PiFinderMountBridge::startMultiPointAlignment()
         IDSetSwitch(&MultiPointAlignSP, nullptr);
         return;
     }
+    if (!fetchAlignmentCandidates())
+    {
+        // fetchAlignmentCandidates() already logged why.
+        MultiPointAlignSP.s = IPS_ALERT;
+        IDSetSwitch(&MultiPointAlignSP, nullptr);
+        return;
+    }
 
-    LOGF_INFO("Multi-Point Alignment: starting a %zu-point sequence (PoC - fixed points, single "
-              "solve per point, Sync only - see #191).",
+    LOGF_INFO("Multi-Point Alignment: starting a %zu-point sequence (single solve per point, "
+              "Sync only - see #191).",
               m_alignPoints.size());
     m_alignPointIndex = 0;
     if (gotoAlignPoint(m_alignPointIndex))
@@ -1933,6 +2042,15 @@ bool PiFinderMountBridge::ISNewNumber(const char *dev, const char *name, double 
             // nothing in the GUI explaining why. Same auto-save-on-change
             // pattern as those, just missing here.
             saveConfig(true, DriftThresholdNP.name);
+            return true;
+        }
+
+        if (strcmp(name, AlignConfigNP.name) == 0)
+        {
+            IUUpdateNumber(&AlignConfigNP, values, names, n);
+            AlignConfigNP.s = IPS_OK;
+            IDSetNumber(&AlignConfigNP, nullptr);
+            saveConfig(true, AlignConfigNP.name);
             return true;
         }
 

--- a/indi_pifinder_bridge/pifinder_mount_bridge.cpp
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.cpp
@@ -299,6 +299,12 @@ bool PiFinderMountBridge::initProperties()
     IUFillNumberVector(&AlignConfigNP, AlignConfigN, 3, getDeviceName(), "ALIGN_CONFIG",
                        "Alignment point selection", "Main Control", IP_RW, 60, IPS_IDLE);
 
+    IUFillNumber(&AlignProgressN[ALIGN_POINT_INDEX], "POINT_INDEX", "Current point (1-based)", "%.0f", 0, 10, 1, 0);
+    IUFillNumber(&AlignProgressN[ALIGN_POINT_COUNT], "POINT_COUNT", "Total points", "%.0f", 0, 10, 1, 0);
+    IUFillNumber(&AlignProgressN[ALIGN_POINT_SYNCED], "POINT_SYNCED", "Points verified/synced", "%.0f", 0, 10, 1, 0);
+    IUFillNumberVector(&AlignProgressNP, AlignProgressN, 3, getDeviceName(), "ALIGN_PROGRESS",
+                       "Alignment progress", "Main Control", IP_RO, 60, IPS_IDLE);
+
     IUFillSwitch(&RepositionConfirmS[REPOSITION_CONFIRM_YES], "REPOSITION_CONFIRM_YES", "Adopt new position", ISS_OFF);
     IUFillSwitch(&RepositionConfirmS[REPOSITION_CONFIRM_NO], "REPOSITION_CONFIRM_NO", "Revert to held target", ISS_OFF);
     IUFillSwitchVector(&RepositionConfirmSP, RepositionConfirmS, 2, getDeviceName(), "REPOSITION_CONFIRM",
@@ -373,6 +379,7 @@ bool PiFinderMountBridge::updateProperties()
         defineProperty(&AbortMountSP);
         defineProperty(&MultiPointAlignSP);
         defineProperty(&AlignConfigNP);
+        defineProperty(&AlignProgressNP);
         defineProperty(&DriftThresholdNP);
         defineProperty(&MaxSyncDriftNP);
         defineProperty(&SolveFreshnessMaxAgeNP);
@@ -402,6 +409,7 @@ bool PiFinderMountBridge::updateProperties()
         deleteProperty(AbortMountSP.name);
         deleteProperty(MultiPointAlignSP.name);
         deleteProperty(AlignConfigNP.name);
+        deleteProperty(AlignProgressNP.name);
         deleteProperty(DriftThresholdNP.name);
         deleteProperty(MaxSyncDriftNP.name);
         deleteProperty(SolveFreshnessMaxAgeNP.name);
@@ -1484,6 +1492,9 @@ bool PiFinderMountBridge::gotoAlignPoint(size_t index)
     LOGF_INFO("Multi-Point Alignment: slewing to point %zu/%zu (RA %.4fh, DEC %.4f deg).",
               index + 1, m_alignPoints.size(), ra, dec);
     m_alignState = AlignState::SLEWING;
+    AlignProgressN[ALIGN_POINT_INDEX].value = static_cast<double>(index + 1);
+    AlignProgressNP.s = IPS_BUSY;
+    IDSetNumber(&AlignProgressNP, nullptr);
     return true;
 }
 
@@ -1538,6 +1549,9 @@ void PiFinderMountBridge::startMultiPointAlignment()
               "Sync only - see #191).",
               m_alignPoints.size());
     m_alignPointIndex = 0;
+    m_alignSyncedCount = 0;
+    AlignProgressN[ALIGN_POINT_COUNT].value = static_cast<double>(m_alignPoints.size());
+    AlignProgressN[ALIGN_POINT_SYNCED].value = 0;
     if (gotoAlignPoint(m_alignPointIndex))
     {
         MultiPointAlignSP.s = IPS_BUSY;
@@ -1546,6 +1560,8 @@ void PiFinderMountBridge::startMultiPointAlignment()
     {
         m_alignState = AlignState::IDLE;
         MultiPointAlignSP.s = IPS_ALERT;
+        AlignProgressNP.s = IPS_ALERT;
+        IDSetNumber(&AlignProgressNP, nullptr);
     }
     IDSetSwitch(&MultiPointAlignSP, nullptr);
 }
@@ -1555,14 +1571,19 @@ void PiFinderMountBridge::stopMultiPointAlignment(const char *reason)
     if (m_alignState == AlignState::IDLE)
         return;
 
-    LOGF_WARN("Multi-Point Alignment: stopped (%s) after %zu/%zu points.", reason, m_alignPointIndex,
-              m_alignPoints.size());
+    LOGF_WARN("Multi-Point Alignment: stopped (%s) after %zu/%zu points (%zu verified/synced).", reason,
+              m_alignPointIndex, m_alignPoints.size(), m_alignSyncedCount);
     m_alignState = AlignState::IDLE;
     // Reuses the existing panic-button path (#179) rather than a bespoke
     // stop mechanism - matches UC4 in the concept doc exactly.
     m_client->abortMount();
     MultiPointAlignSP.s = IPS_ALERT;
     IDSetSwitch(&MultiPointAlignSP, nullptr);
+    // Left at its last live values (not reset to 0) - "stopped at 2/4, 1
+    // synced" is more useful post-mortem info for the GUI than a blank
+    // readout. The next Start resets it fresh (see startMultiPointAlignment()).
+    AlignProgressNP.s = IPS_ALERT;
+    IDSetNumber(&AlignProgressNP, nullptr);
 }
 
 void PiFinderMountBridge::handleMultiPointAlignment()
@@ -1613,6 +1634,9 @@ void PiFinderMountBridge::handleMultiPointAlignment()
                 LOGF_INFO("Multi-Point Alignment: point %zu/%zu verified - synced mount to RA %.4fh, "
                           "DEC %.4f deg (fresh PiFinder solve).",
                           m_alignPointIndex + 1, m_alignPoints.size(), piRA, piDec);
+                ++m_alignSyncedCount;
+                AlignProgressN[ALIGN_POINT_SYNCED].value = static_cast<double>(m_alignSyncedCount);
+                IDSetNumber(&AlignProgressNP, nullptr);
             }
             else
             {
@@ -1630,11 +1654,18 @@ void PiFinderMountBridge::advanceAlignPoint()
     ++m_alignPointIndex;
     if (m_alignPointIndex >= m_alignPoints.size())
     {
-        LOGF_INFO("Multi-Point Alignment: sequence complete (%zu point(s) attempted).",
-                  m_alignPoints.size());
+        LOGF_INFO("Multi-Point Alignment: sequence complete (%zu/%zu point(s) verified/synced).",
+                  m_alignSyncedCount, m_alignPoints.size());
         m_alignState = AlignState::DONE;
-        MultiPointAlignSP.s = IPS_OK;
+        // Found via #217's GUI-facing follow-up: a run where every single
+        // point got skipped (no fresh PiFinder solve ever arrived) still
+        // reported IPS_OK ("sequence complete") before this fix - identical
+        // to a real success at a glance. 0 verified points is a failure to
+        // report as one, not a completed alignment.
+        MultiPointAlignSP.s = (m_alignSyncedCount > 0) ? IPS_OK : IPS_ALERT;
         IDSetSwitch(&MultiPointAlignSP, nullptr);
+        AlignProgressNP.s = (m_alignSyncedCount > 0) ? IPS_OK : IPS_ALERT;
+        IDSetNumber(&AlignProgressNP, nullptr);
         return;
     }
 

--- a/indi_pifinder_bridge/pifinder_mount_bridge.h
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.h
@@ -209,6 +209,20 @@ class PiFinderMountBridge : public INDI::DefaultDevice
         INumber AlignConfigN[3];
         enum { ALIGN_RADIUS, ALIGN_COUNT, ALIGN_MIN_ALTITUDE };
 
+        // Poll-friendly progress readout for the Control Center GUI - a
+        // one-shot getProperties can't observe LOGF_INFO/LOGF_WARN messages
+        // (those are ephemeral <message> elements, not a queryable
+        // property), so a client that only polls properties (no persistent
+        // listening connection) would otherwise see no per-point progress
+        // at all, just the coarse MULTI_POINT_ALIGN Idle/Busy/Ok/Alert
+        // state. POINT_INDEX is 1-based (0 = no sequence has run yet this
+        // session), frozen at its last value once the sequence stops/
+        // completes/errors - not reset on Stop, so "stopped at 2/4" stays
+        // readable until the next Start.
+        INumberVectorProperty AlignProgressNP;
+        INumber AlignProgressN[3];
+        enum { ALIGN_POINT_INDEX, ALIGN_POINT_COUNT, ALIGN_POINT_SYNCED };
+
         enum class AlignState { IDLE, SLEWING, SETTLING, DONE };
         AlignState m_alignState = AlignState::IDLE;
         // RA (hours) / Dec (degrees) - populated fresh by
@@ -216,6 +230,15 @@ class PiFinderMountBridge : public INDI::DefaultDevice
         // hardcoded. Empty until a sequence has actually been started.
         std::vector<std::pair<double, double>> m_alignPoints;
         size_t m_alignPointIndex = 0;
+        // How many of m_alignPoints actually got a verified Sync (not just
+        // attempted/skipped) - drives both AlignProgressN[ALIGN_POINT_SYNCED]
+        // and advanceAlignPoint()'s final IPS_OK vs IPS_ALERT choice: a
+        // sequence that skipped every single point (e.g. no fresh PiFinder
+        // solve ever arrived) previously still reported IPS_OK ("sequence
+        // complete"), indistinguishable from a real success - found during
+        // #217's GUI-facing follow-up, where that ambiguity would otherwise
+        // show up as a false "green" result.
+        size_t m_alignSyncedCount = 0;
         int m_alignSettleTicksRemaining = 0;
         int m_alignFreshnessWaitTicksRemaining = 0;
 

--- a/indi_pifinder_bridge/pifinder_mount_bridge.h
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.h
@@ -189,6 +189,23 @@ class PiFinderMountBridge : public INDI::DefaultDevice
         // flagged there as separate/research-first). Reuses the same
         // Sync-only approach the concept's own ADR (§5) settled on for a
         // first OnStep-scoped implementation - no new "Align" primitive.
+        //
+        // *** PoC ONLY - DO NOT run this against a real mount. ***
+        // m_alignPoints below has NO altitude/horizon awareness at all - it
+        // blindly Gotos each fixed point regardless of whether it's
+        // actually above the horizon right now. Live-confirmed (User,
+        // 2026-08-10, against Telescope Simulator): PiFinder's own sky-map
+        // marker sat visibly below the horizon line and the sequence
+        // started anyway. Harmless against a simulator; against a real
+        // mount this is a genuine mechanical collision risk (cable wrap,
+        // counterweight/OTA into the pier or tripod, unrelated to and not
+        // caught by the mount's own coarse elevation limit, e.g. OnStep's
+        // "Slew elevation Limit" - that only guards ~-10°, not "technically
+        // above the mount's own limit but physically unreachable from
+        // here"). §4.2's catalog-driven, altitude-filtered point selection
+        // is what would actually close this gap - explicitly out of scope
+        // for this PoC, deliberately left as documentation rather than a
+        // quick partial fix (User decision, 2026-08-10).
         ISwitchVectorProperty MultiPointAlignSP;
         ISwitch MultiPointAlignS[2];
         enum { ALIGN_START, ALIGN_STOP };
@@ -197,10 +214,21 @@ class PiFinderMountBridge : public INDI::DefaultDevice
         AlignState m_alignState = AlignState::IDLE;
         // RA (hours) / Dec (degrees) - spread across RA quadrants at a
         // moderate declination, avoiding the pole (per the concept's own
-        // "Pol und Horizont-Nähe meiden" note). No altitude/visibility
-        // filtering (§4.2's catalog-selection scope, not part of this PoC) -
-        // fine against the Simulator, would need real horizon-awareness
-        // before ever pointing at a real sky.
+        // "Pol und Horizont-Nähe meiden" note). See the safety warning on
+        // MultiPointAlignSP above - no altitude/visibility filtering here.
+        //
+        // Waiting for isPiFinderSolveFresh() at each point is correct as-is
+        // and needs no special handling for the real use case: the mount
+        // arrives, PiFinder's own continuous camera solve loop naturally
+        // produces a fresh solve once it's stationary, same as it always
+        // does - nothing here needs to poke or re-seed anything. The only
+        // place this doesn't self-resolve is testing against Telescope
+        // Simulator + Injected Solve (no real camera in the loop at all,
+        // so nothing ever re-solves on its own) - a testing-environment
+        // limitation, not a gap in this code. Without a real solve, a point
+        // simply waits out MAX_FRESHNESS_WAIT_TICKS and gets skipped
+        // (§4.4's existing skip behavior); test against real sky/hardware
+        // for meaningful end-to-end verification of this PoC.
         std::vector<std::pair<double, double>> m_alignPoints = {
             {0.0, 30.0}, {6.0, 30.0}, {12.0, 30.0}, {18.0, 30.0},
         };

--- a/indi_pifinder_bridge/pifinder_mount_bridge.h
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.h
@@ -180,61 +180,54 @@ class PiFinderMountBridge : public INDI::DefaultDevice
         ISwitchVectorProperty AbortMountSP;
         ISwitch AbortMountS[1];
 
-        // #191 PoC - automatic multi-point alignment, see
-        // docs/concepts/mount_bridge_multistar_alignment.md. Deliberately
-        // scoped down from the full concept for a feature-branch proof of
-        // concept: a fixed, hardcoded point set instead of catalog-driven
-        // selection (§4.2), a single fresh solve per point instead of a
-        // median of several (§4.3), no KStars-model feed (§4.5, explicitly
-        // flagged there as separate/research-first). Reuses the same
-        // Sync-only approach the concept's own ADR (§5) settled on for a
-        // first OnStep-scoped implementation - no new "Align" primitive.
+        // #191 - automatic multi-point alignment, see
+        // docs/concepts/mount_bridge_multistar_alignment.md. §4.3's core
+        // sequence and §5's Sync-only ADR (already confirmed sufficient for
+        // OnStep - repeated Syncs build a real multi-point model there) are
+        // implemented. §4.2's candidate selection is real: points come from
+        // PiFinder's own /api/nearby_bright_stars (its "Str" bright-named-
+        // star catalog, altitude-filtered server-side using PiFinder's own
+        // GPS location/time via skyfield) - not a fixed hardcoded set.
+        // Still out of scope: §4.3's median-of-N-solves (one fresh solve
+        // per point, same as everywhere else in this file), §4.5's KStars-
+        // model feed (explicitly flagged there as separate/research-first).
         //
-        // *** PoC ONLY - DO NOT run this against a real mount. ***
-        // m_alignPoints below has NO altitude/horizon awareness at all - it
-        // blindly Gotos each fixed point regardless of whether it's
-        // actually above the horizon right now. Live-confirmed (User,
-        // 2026-08-10, against Telescope Simulator): PiFinder's own sky-map
-        // marker sat visibly below the horizon line and the sequence
-        // started anyway. Harmless against a simulator; against a real
-        // mount this is a genuine mechanical collision risk (cable wrap,
-        // counterweight/OTA into the pier or tripod, unrelated to and not
-        // caught by the mount's own coarse elevation limit, e.g. OnStep's
-        // "Slew elevation Limit" - that only guards ~-10°, not "technically
-        // above the mount's own limit but physically unreachable from
-        // here"). §4.2's catalog-driven, altitude-filtered point selection
-        // is what would actually close this gap - explicitly out of scope
-        // for this PoC, deliberately left as documentation rather than a
-        // quick partial fix (User decision, 2026-08-10).
+        // Remaining safety caveat: altitude filtering rules out "below the
+        // horizon", but NOT cable-wrap/meridian-flip risk - a candidate
+        // star can be well above the horizon and still be in a mechanically
+        // awkward hour-angle/RA-wind position for a given mount's current
+        // orientation, which this does not model. Same class of gap as the
+        // still-open KStars-horizon-fencing item.
         ISwitchVectorProperty MultiPointAlignSP;
         ISwitch MultiPointAlignS[2];
         enum { ALIGN_START, ALIGN_STOP };
 
+        // §3's configuration parameters - only the three that gate
+        // candidate selection (§4.2). Median-solve-count and the KStars-
+        // feed checkbox aren't implemented yet, so aren't exposed here.
+        INumberVectorProperty AlignConfigNP;
+        INumber AlignConfigN[3];
+        enum { ALIGN_RADIUS, ALIGN_COUNT, ALIGN_MIN_ALTITUDE };
+
         enum class AlignState { IDLE, SLEWING, SETTLING, DONE };
         AlignState m_alignState = AlignState::IDLE;
-        // RA (hours) / Dec (degrees) - spread across RA quadrants at a
-        // moderate declination, avoiding the pole (per the concept's own
-        // "Pol und Horizont-Nähe meiden" note). See the safety warning on
-        // MultiPointAlignSP above - no altitude/visibility filtering here.
-        //
-        // Waiting for isPiFinderSolveFresh() at each point is correct as-is
-        // and needs no special handling for the real use case: the mount
-        // arrives, PiFinder's own continuous camera solve loop naturally
-        // produces a fresh solve once it's stationary, same as it always
-        // does - nothing here needs to poke or re-seed anything. The only
-        // place this doesn't self-resolve is testing against Telescope
-        // Simulator + Injected Solve (no real camera in the loop at all,
-        // so nothing ever re-solves on its own) - a testing-environment
-        // limitation, not a gap in this code. Without a real solve, a point
-        // simply waits out MAX_FRESHNESS_WAIT_TICKS and gets skipped
-        // (§4.4's existing skip behavior); test against real sky/hardware
-        // for meaningful end-to-end verification of this PoC.
-        std::vector<std::pair<double, double>> m_alignPoints = {
-            {0.0, 30.0}, {6.0, 30.0}, {12.0, 30.0}, {18.0, 30.0},
-        };
+        // RA (hours) / Dec (degrees) - populated fresh by
+        // fetchAlignmentCandidates() every time Start is clicked, not
+        // hardcoded. Empty until a sequence has actually been started.
+        std::vector<std::pair<double, double>> m_alignPoints;
         size_t m_alignPointIndex = 0;
         int m_alignSettleTicksRemaining = 0;
         int m_alignFreshnessWaitTicksRemaining = 0;
+
+        // Calls PiFinder's own /api/nearby_bright_stars (no ra/dec params -
+        // it centers on PiFinder's own current solved position itself, per
+        // §4.2's own decision) with AlignConfigN's radius/count/
+        // min_altitude, and populates m_alignPoints from the response.
+        // Returns false (having already logged why) on any request/parse
+        // failure or a zero-candidate response - callers must not start a
+        // sequence with stale/empty m_alignPoints left over from a
+        // previous attempt.
+        bool fetchAlignmentCandidates();
 
         void handleMultiPointAlignment();
         void startMultiPointAlignment();

--- a/indi_pifinder_bridge/pifinder_mount_bridge.h
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.h
@@ -19,6 +19,8 @@
 #include <cmath>
 #include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 class PiFinderBridgeClient;
 
@@ -177,6 +179,40 @@ class PiFinderMountBridge : public INDI::DefaultDevice
         // repeatedly).
         ISwitchVectorProperty AbortMountSP;
         ISwitch AbortMountS[1];
+
+        // #191 PoC - automatic multi-point alignment, see
+        // docs/concepts/mount_bridge_multistar_alignment.md. Deliberately
+        // scoped down from the full concept for a feature-branch proof of
+        // concept: a fixed, hardcoded point set instead of catalog-driven
+        // selection (§4.2), a single fresh solve per point instead of a
+        // median of several (§4.3), no KStars-model feed (§4.5, explicitly
+        // flagged there as separate/research-first). Reuses the same
+        // Sync-only approach the concept's own ADR (§5) settled on for a
+        // first OnStep-scoped implementation - no new "Align" primitive.
+        ISwitchVectorProperty MultiPointAlignSP;
+        ISwitch MultiPointAlignS[2];
+        enum { ALIGN_START, ALIGN_STOP };
+
+        enum class AlignState { IDLE, SLEWING, SETTLING, DONE };
+        AlignState m_alignState = AlignState::IDLE;
+        // RA (hours) / Dec (degrees) - spread across RA quadrants at a
+        // moderate declination, avoiding the pole (per the concept's own
+        // "Pol und Horizont-Nähe meiden" note). No altitude/visibility
+        // filtering (§4.2's catalog-selection scope, not part of this PoC) -
+        // fine against the Simulator, would need real horizon-awareness
+        // before ever pointing at a real sky.
+        std::vector<std::pair<double, double>> m_alignPoints = {
+            {0.0, 30.0}, {6.0, 30.0}, {12.0, 30.0}, {18.0, 30.0},
+        };
+        size_t m_alignPointIndex = 0;
+        int m_alignSettleTicksRemaining = 0;
+        int m_alignFreshnessWaitTicksRemaining = 0;
+
+        void handleMultiPointAlignment();
+        void startMultiPointAlignment();
+        void stopMultiPointAlignment(const char *reason);
+        bool gotoAlignPoint(size_t index);
+        void advanceAlignPoint();
 
         INumberVectorProperty DriftThresholdNP;
         INumber DriftThresholdN[1];

--- a/test_tools/multipoint_alignment_trace.py
+++ b/test_tools/multipoint_alignment_trace.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""
+Traces Mount Bridge's Multi-Point Alignment (#191) end to end, straight
+against raw INDI XML on port 7624 - deliberately NOT through the Control
+Center or any Python wrapper module, so what's captured is exactly what
+INDI/KStars itself would show (matches TC-PFSM-191-01's own requirement).
+
+What it does, in order:
+  1. Baseline trace (no alignment running) for --baseline-secs, to capture
+     the starting-condition mismatch between PiFinder's reported position
+     and the mount's actual position before anything is touched.
+  2. Triggers MULTI_POINT_ALIGN Start, keeps tracing until the sequence
+     reaches Ok/Alert or --timeout-secs elapses.
+  3. If --test-abort is given, starts a second run and sends ALIGN_STOP
+     partway through, to verify the sequence actually stops (mount position
+     and MULTI_POINT_ALIGN state both stop changing afterward).
+
+Every observation is timestamped and printed live AND collected into a
+report printed at the end - the report is what should be pasted into the
+TC/TE issue, not just "it worked"/"it didn't".
+
+Usage:
+    python3 test_tools/multipoint_alignment_trace.py
+    python3 test_tools/multipoint_alignment_trace.py --test-abort
+    python3 test_tools/multipoint_alignment_trace.py --host localhost --port 7624
+"""
+
+import argparse
+import re
+import socket
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+
+
+MOUNT_BRIDGE = "PiFinder Mount Bridge"
+PIFINDER_DEV = "PiFinder LX200"
+
+
+def connect(host: str, port: int) -> socket.socket:
+    s = socket.create_connection((host, port), timeout=10)
+    s.settimeout(2.0)
+    return s
+
+
+def get_properties(host: str, port: int, device: str, wait: float = 1.5) -> str:
+    """One-shot getProperties for a single device - returns raw XML text."""
+    s = connect(host, port)
+    s.sendall(f'<getProperties version="1.7" device="{device}"/>'.encode())
+    time.sleep(wait)
+    buf = b""
+    deadline = time.time() + wait
+    while time.time() < deadline:
+        try:
+            chunk = s.recv(1 << 16)
+            if not chunk:
+                break
+            buf += chunk
+        except socket.timeout:
+            break
+    s.close()
+    return buf.decode(errors="replace")
+
+
+def get_num(text: str, vector: str, elem: str):
+    m = re.search(
+        r'<def(Number)Vector[^>]*name="' + vector + r'"[^>]*>(.*?)</def\1Vector>',
+        text,
+        re.S,
+    )
+    if not m:
+        return None
+    m2 = re.search(r'<def(?:Number)? name="' + elem + r'"[^>]*>\s*([\-0-9.eE]+)', m.group(2))
+    return float(m2.group(1)) if m2 else None
+
+
+def get_switch_state(text: str, vector: str):
+    m = re.search(r'<def(Switch)Vector[^>]*name="' + vector + r'"[^>]*state="(\w+)"', text)
+    return m.group(2) if m else None
+
+
+def get_active_mount(mb_text: str):
+    m = re.search(
+        r'<defTextVector[^>]*name="ACTIVE_DEVICES"[^>]*>(.*?)</defTextVector>', mb_text, re.S
+    )
+    if not m:
+        return None
+    m2 = re.search(r'<defText name="ACTIVE_MOUNT"[^>]*>\s*([^\s<][^<]*)', m.group(1))
+    return m2.group(1).strip() if m2 else None
+
+
+def send_switch(host: str, port: int, device: str, vector: str, switch: str):
+    s = connect(host, port)
+    s.sendall(
+        (
+            f'<newSwitchVector device="{device}" name="{vector}">'
+            f'<oneSwitch name="{switch}">On</oneSwitch></newSwitchVector>'
+        ).encode()
+    )
+    time.sleep(1.5)
+    s.close()
+
+
+@dataclass
+class Sample:
+    t: float
+    pifinder_ra: float
+    pifinder_dec: float
+    mount_name: str
+    mount_ra: float
+    mount_dec: float
+    drift_arcmin: float
+    drift_state: str
+    align_state: str
+
+
+@dataclass
+class WireEvent:
+    t: float
+    line: str
+
+
+class WireCapture:
+    """Persistent raw-socket listener - captures every setNumberVector/
+    message frame from the mount device and Mount Bridge for the duration
+    of the run, so the actual sequence of commanded Goto targets can be
+    reconstructed afterward (Mount Bridge's own LOG_INFO/WARN messages are
+    NOT reliable in indiserver's own log for this driver - see
+    basic-memory/pifinder-stellarmate/00089 - so this captures the wire
+    traffic directly instead of trusting log lines)."""
+
+    def __init__(self, host: str, port: int):
+        self.host = host
+        self.port = port
+        self.events: list[WireEvent] = []
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._start_time = time.time()
+
+    def start(self):
+        self._thread.start()
+        time.sleep(0.5)  # let the connection establish before returning
+
+    def stop(self):
+        self._stop.set()
+        self._thread.join(timeout=3)
+
+    def _run(self):
+        s = connect(self.host, self.port)
+        s.sendall(f'<getProperties version="1.7" device="{MOUNT_BRIDGE}"/>'.encode())
+        s.sendall(f'<getProperties version="1.7" device="{PIFINDER_DEV}"/>'.encode())
+        buf = ""
+        pattern = re.compile(r"<(setNumberVector|setSwitchVector|message)\b[^>]*(?:/>|>.*?</\1>)", re.S)
+        while not self._stop.is_set():
+            try:
+                chunk = s.recv(1 << 16)
+                if not chunk:
+                    break
+                buf += chunk.decode(errors="replace")
+            except socket.timeout:
+                continue
+            # Consume complete top-level elements as they arrive, tracking
+            # how far into buf we've successfully parsed - re-scanning from
+            # position 0 on every recv() (the original bug here) re-matches
+            # and re-appends every already-seen event again each time,
+            # producing O(n^2) duplicate "events" for what's really a
+            # handful of distinct ones. Only the trailing partial fragment
+            # (an element split across two recv() calls) is kept for the
+            # next iteration.
+            last_end = 0
+            for m in pattern.finditer(buf):
+                frag = m.group(0)
+                if MOUNT_BRIDGE in frag or PIFINDER_DEV in frag:
+                    self.events.append(WireEvent(t=time.time() - self._start_time, line=frag))
+                last_end = m.end()
+            buf = buf[last_end:]
+        s.close()
+
+
+def take_sample(host: str, port: int, t0: float, mount_name: str) -> Sample:
+    pf_text = get_properties(host, port, PIFINDER_DEV, wait=1.0)
+    mount_text = get_properties(host, port, mount_name, wait=1.0)
+    mb_text = get_properties(host, port, MOUNT_BRIDGE, wait=1.0)
+    return Sample(
+        t=time.time() - t0,
+        pifinder_ra=get_num(pf_text, "EQUATORIAL_EOD_COORD", "RA"),
+        pifinder_dec=get_num(pf_text, "EQUATORIAL_EOD_COORD", "DEC"),
+        mount_name=mount_name,
+        mount_ra=get_num(mount_text, "EQUATORIAL_EOD_COORD", "RA"),
+        mount_dec=get_num(mount_text, "EQUATORIAL_EOD_COORD", "DEC"),
+        drift_arcmin=get_num(mb_text, "DRIFT_STATUS", "DRIFT_ARCMIN"),
+        drift_state=get_switch_state(mb_text, "DRIFT_STATUS") or "?",
+        align_state=get_switch_state(mb_text, "MULTI_POINT_ALIGN") or "?",
+    )
+
+
+def fmt_sample(s: Sample) -> str:
+    def f(v):
+        return f"{v:.4f}" if v is not None else "?"
+
+    return (
+        f"t={s.t:6.1f}s  pifinder=({f(s.pifinder_ra)},{f(s.pifinder_dec)})  "
+        f"{s.mount_name}=({f(s.mount_ra)},{f(s.mount_dec)})  "
+        f"drift={f(s.drift_arcmin)}' [{s.drift_state}]  align={s.align_state}"
+    )
+
+
+def run_trace(host, port, baseline_secs, timeout_secs, poll_interval, test_abort, abort_after_secs):
+    mb_text = get_properties(host, port, MOUNT_BRIDGE, wait=1.5)
+    mount_name = get_active_mount(mb_text)
+    if not mount_name:
+        print("ERROR: could not read ACTIVE_MOUNT from PiFinder Mount Bridge - aborting.")
+        sys.exit(1)
+    print(f"ACTIVE_MOUNT = '{mount_name}'  (tracing this + '{PIFINDER_DEV}')\n")
+
+    t0 = time.time()
+    samples: list[Sample] = []
+    wire = WireCapture(host, port)
+    wire.start()
+
+    print(f"--- Phase 1: baseline trace, {baseline_secs}s, no alignment running ---")
+    deadline = time.time() + baseline_secs
+    while time.time() < deadline:
+        s = take_sample(host, port, t0, mount_name)
+        samples.append(s)
+        print(fmt_sample(s))
+        time.sleep(poll_interval)
+
+    print(f"\n--- Phase 2: MULTI_POINT_ALIGN Start ---")
+    send_switch(host, port, MOUNT_BRIDGE, "MULTI_POINT_ALIGN", "ALIGN_START")
+
+    start_t = time.time()
+    aborted_at = None
+    deadline = start_t + timeout_secs
+    while time.time() < deadline:
+        s = take_sample(host, port, t0, mount_name)
+        samples.append(s)
+        print(fmt_sample(s))
+        if test_abort and aborted_at is None and (time.time() - start_t) >= abort_after_secs:
+            print(f"\n--- Phase 3: sending ALIGN_STOP at t={time.time() - t0:.1f}s ---")
+            send_switch(host, port, MOUNT_BRIDGE, "MULTI_POINT_ALIGN", "ALIGN_STOP")
+            aborted_at = time.time() - t0
+        if s.align_state in ("Ok", "Alert") and (not test_abort or aborted_at is not None):
+            print(f"\nMULTI_POINT_ALIGN reached terminal state '{s.align_state}' - stopping trace.")
+            break
+        time.sleep(poll_interval)
+
+    wire.stop()
+    return samples, wire.events, aborted_at, mount_name
+
+
+def print_report(samples, wire_events, aborted_at, mount_name, test_abort):
+    print("\n" + "=" * 78)
+    print("REPORT")
+    print("=" * 78)
+
+    print(f"\n[1] Baseline (before Start) - PiFinder-vs-mount agreement:")
+    pre_start = [s for s in samples if s.drift_arcmin is not None]
+    if pre_start:
+        first = pre_start[0]
+        print(f"    First sample: drift={first.drift_arcmin:.1f}' [{first.drift_state}]")
+        print(
+            f"    -> Mount was {'NOT ' if first.drift_arcmin and first.drift_arcmin > 5 else ''}"
+            f"pre-synced to PiFinder's reported position at trace start."
+        )
+
+    print(f"\n[2] Raw wire events captured ({len(wire_events)} total, "
+          f"setNumberVector/setSwitchVector/message from {MOUNT_BRIDGE}/{PIFINDER_DEV}):")
+    for e in wire_events:
+        first_line = e.line.split("\n")[0][:160]
+        print(f"    t={e.t:6.1f}s  {first_line}")
+
+    print(f"\n[3] Mount position over time (from periodic samples):")
+    last_pos = None
+    for s in samples:
+        pos = (s.mount_ra, s.mount_dec)
+        if pos != last_pos:
+            print(f"    t={s.t:6.1f}s  {mount_name} -> ({s.mount_ra}, {s.mount_dec})")
+            last_pos = pos
+
+    print(f"\n[4] MULTI_POINT_ALIGN state transitions:")
+    last_state = None
+    for s in samples:
+        if s.align_state != last_state:
+            print(f"    t={s.t:6.1f}s  align_state -> {s.align_state}")
+            last_state = s.align_state
+
+    if test_abort:
+        print(f"\n[5] Abort test: ALIGN_STOP sent at t={aborted_at:.1f}s" if aborted_at else
+              "\n[5] Abort test: never triggered (sequence finished before abort_after_secs)")
+        if aborted_at is not None:
+            after = [s for s in samples if s.t >= aborted_at]
+            positions_after = {(s.mount_ra, s.mount_dec) for s in after}
+            print(f"    Distinct mount positions after abort: {len(positions_after)}")
+            print(f"    -> Mount {'DID NOT move further' if len(positions_after) <= 1 else 'KEPT MOVING'} "
+                  f"after ALIGN_STOP.")
+            states_after = {s.align_state for s in after}
+            print(f"    align_state values seen after abort: {states_after}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--host", default="localhost")
+    ap.add_argument("--port", type=int, default=7624)
+    ap.add_argument("--baseline-secs", type=float, default=15.0)
+    ap.add_argument("--timeout-secs", type=float, default=180.0)
+    ap.add_argument("--poll-interval", type=float, default=2.5)
+    ap.add_argument("--test-abort", action="store_true", help="Send ALIGN_STOP partway through instead of letting the sequence finish.")
+    ap.add_argument("--abort-after-secs", type=float, default=8.0, help="Seconds after Start to send ALIGN_STOP, if --test-abort.")
+    args = ap.parse_args()
+
+    samples, wire_events, aborted_at, mount_name = run_trace(
+        args.host, args.port, args.baseline_secs, args.timeout_secs,
+        args.poll_interval, args.test_abort, args.abort_after_secs,
+    )
+    print_report(samples, wire_events, aborted_at, mount_name, args.test_abort)
+
+
+if __name__ == "__main__":
+    main()

--- a/test_tools/test.md
+++ b/test_tools/test.md
@@ -138,6 +138,49 @@ guessing across camera/GPIO/software/menu-logic all at once.
   long-press timer, and a thread race that closed the marking menu
   immediately on release).
 
+## multipoint_alignment_trace.py
+
+- **Purpose:** repeatable, GUI-independent verification of the #191
+  Multi-Point Alignment sequence (Start/Stop, per-point Goto/Sync,
+  drift/freshness gating) straight off the INDI wire - no KStars UI, no
+  Control Center (which deliberately has no #191 GUI yet), so results can't
+  be confused with a client-side rendering/interaction issue.
+- **What it does:** opens raw sockets to `indiserver` (default
+  `localhost:7624`), does one-shot `getProperties` polls for `PiFinder
+  Mount Bridge` and `PiFinder LX200` plus a persistent background listener
+  that captures every `setNumberVector`/`setSwitchVector`/`message` XML
+  fragment from those two devices as they're pushed. Runs a baseline trace
+  (no alignment active), then sends `MULTI_POINT_ALIGN.ALIGN_START` and
+  traces until the property reaches a terminal state (`Ok`/`Alert`) or a
+  timeout. With `--test-abort`, sends `ALIGN_STOP` mid-sequence at
+  `--abort-after-secs` and checks whether the mount's position samples stop
+  changing afterward. Prints a report: baseline PiFinder/mount agreement,
+  the raw wire event log, sampled mount positions over time, and
+  `MULTI_POINT_ALIGN` state transitions.
+- **Usage:**
+  ```bash
+  python3 test_tools/multipoint_alignment_trace.py
+  python3 test_tools/multipoint_alignment_trace.py --test-abort
+  python3 test_tools/multipoint_alignment_trace.py --host localhost --port 7624 \
+      --baseline-secs 15 --timeout-secs 180 --poll-interval 2.5
+  ```
+  Requires `indiserver` running with both `PiFinder Mount Bridge` and the
+  target mount driver (e.g. Telescope Simulator) already connected -
+  `ACTIVE_DEVICES.ACTIVE_MOUNT` on the Mount Bridge determines which mount
+  device it traces.
+- **When to use:** verifying/reproducing #191 behavior without relying on
+  KStars' own INDI Control Panel rendering or a Control Center GUI that
+  doesn't exist for this feature yet. Live-tested 2026-08-10 against the
+  Telescope Simulator: confirmed `ALIGN_STOP` correctly aborts the sequence
+  and stops the mount at the INDI level (0/4 points, mount position frozen
+  after Stop) - the "can't abort" complaint traced to a missing dedicated
+  GUI affordance, not a backend fault. Also surfaced that on an indoor bench
+  rig, PiFinder's own pre-solve sleep state machine
+  (`PiFinder/python/PiFinder/main.py`'s `WARMUP`→sleep→`RETRY` cycle, no
+  real stars in view) leaves `solve_source` stuck at `"IMU"` with a stale
+  `last_solve_success`, which starves every alignment point's
+  `isPiFinderSolveFresh()` gate - see #191's TE issue for the full writeup.
+
 ## Related: the `pifinder-remote` Claude Code skill
 
 Not in this directory (it lives in the PiFinder checkout itself, under


### PR DESCRIPTION
## Summary

Implements #191 (automatic Multi-Point Alignment) end to end and closes out #217's investigation:

- **Candidate selection**: real, catalog-driven bright-star selection via a new PiFinder `/api/nearby_bright_stars` endpoint (altitude-filtered using PiFinder's own GPS/time), replacing the earlier hardcoded-points PoC.
- **Mount Bridge driver**: `MULTI_POINT_ALIGN` (Start/Stop), `AlignConfigNP` (radius/count/min altitude, now correctly persisted via `saveConfigItems()` - was silently missing), `ALIGN_PROGRESS` (poll-friendly per-point progress), and a fix so a fully-skipped sequence reports `IPS_ALERT` instead of a misleading `IPS_OK`.
- **Control Center GUI**: a full "Multi-Point Alignment" collapsible section (Start/Stop, live progress, config fields), following this project's documented status-row convention (`Readme_ControlCenter.md`) after re-reading it mid-session.
- **Simulator test tooling**: `test_tools/multipoint_alignment_trace.py` (raw-INDI tracer, no GUI dependency) and a reliable, watchdog-backed "Synthetic Solve" toggle wrapping `test_tools/pifinder_truth_injector.py`, replacing an earlier confusing dual-toggle design. Also fixed a real orphan-process bug: this service's `KillMode=process` doesn't kill subprocess children on restart, so a Truth Injector could silently survive redeploys - now cleaned up on every server start.
- **#217 investigation**: documented in issues #217/#218 - confirmed the "can't abort" report was a missing GUI affordance (backend was already correct), and the "PiFinder doesn't follow" report was an indoor-bench-testing artifact once `pifinder_truth_injector.py` is used correctly for simulator testing.

## Test plan

- [x] Live-verified end to end against `Telescope Simulator` + `pifinder_truth_injector.py`: 4/4 candidate points reached "verified - synced", final `align_state` `Ok`, drift converged to ~0.03'.
- [x] `ALIGN_STOP` verified to correctly abort an in-progress sequence and stop the mount (raw INDI trace, `--test-abort`).
- [x] `AlignConfigNP` persistence verified on disk (`~/.indi/PiFinder Mount Bridge_config.xml`) after the `saveConfigItems()` fix.
- [x] Truth Injector orphan-cleanup verified live (journal showed the orphaned process, confirmed gone after the fix).
- [ ] User's own Control Center click-through testing (in progress this session - several rounds of direct feedback already incorporated).