### PR TITLE
Fix upstream OnStep mount-type misdetection (Alt/Az reported as GEM)

### DIFF
--- a/bin/build_indi_onstep_fix.sh
+++ b/bin/build_indi_onstep_fix.sh
@@ -1,0 +1,84 @@
+#! /usr/bin/bash
+set -euo pipefail
+
+# Builds and installs a patched "indi_lx200generic" binary (the shared
+# binary behind "indi_lx200_OnStep" - a symlink, see below) that fixes the
+# OnStep/OnStepX mount-type misdetection from issue #227: :GXEM# returns the
+# raw numeric OnStep web-interface mount-select value ("1 GEM, 2 EQ Fork, or
+# 3 Alt/Azm") on this firmware, but the upstream driver's switch statement
+# only recognizes letter codes (A/K/k/E) and silently defaults anything else
+# - including '3' - to GEM. See diffs/indi_lx200_OnStep_v2.2.2.diff and
+# indi_onstep_fix/CMakeLists.txt for details.
+#
+# This binary is owned by the system "libindi" package, so a plain package
+# reinstall/upgrade will overwrite it with the stock (bugged) version again
+# - rerun this script afterwards to reapply the fix.
+
+source "$(dirname "$0")/functions.sh"
+
+INDI_VERSION="v2.2.2"          # must match the installed libindi package version
+FIX_DIR="${pifinder_stellarmate_dir}/indi_onstep_fix"
+SRC_CACHE_DIR="${FIX_DIR}/build/indi-src"
+BUILD_DIR="${FIX_DIR}/build/out"
+DIFF_FILE="${pifinder_stellarmate_dir}/diffs/indi_lx200_OnStep_v2.2.2.diff"
+BACKUP_SUFFIX="orig-backup-$(date +%Y-%m-%d)"
+
+installed_version="$(pacman -Q libindi 2>/dev/null | awk '{print $2}' | cut -d- -f1)"
+if [[ -n "${installed_version}" && "${installed_version}" != "${INDI_VERSION#v}" ]]; then
+    echo "WARNING: installed libindi is ${installed_version}, this fix is pinned to ${INDI_VERSION}."
+    echo "         Proceeding anyway, but verify the fix still applies/builds cleanly."
+fi
+
+if [[ "${1:-}" == "--clean-build" ]]; then
+    echo "-> Removing existing source cache and build directory..."
+    rm -rf "${SRC_CACHE_DIR}" "${BUILD_DIR}"
+fi
+
+if [[ ! -d "${SRC_CACHE_DIR}/.git" ]]; then
+    echo "-> Cloning indilib/indi ${INDI_VERSION} (shallow)..."
+    rm -rf "${SRC_CACHE_DIR}"
+    git clone --depth 1 --branch "${INDI_VERSION}" https://github.com/indilib/indi.git "${SRC_CACHE_DIR}"
+fi
+
+echo "-> Applying mount-type fix diff..."
+if ! (cd "${SRC_CACHE_DIR}" && patch -p1 --dry-run -N < "${DIFF_FILE}" >/dev/null 2>&1); then
+    echo "   Already applied or checkout is dirty - checking if it's already applied cleanly..."
+    if ! (cd "${SRC_CACHE_DIR}" && patch -p1 --dry-run -R < "${DIFF_FILE}" >/dev/null 2>&1); then
+        echo "ERROR: diff does not apply cleanly (forward or reverse). Investigate ${SRC_CACHE_DIR} manually."
+        exit 1
+    fi
+    echo "   Diff already applied, continuing."
+else
+    (cd "${SRC_CACHE_DIR}" && patch -p1 -N < "${DIFF_FILE}")
+fi
+
+echo "-> Configuring..."
+mkdir -p "${BUILD_DIR}"
+cmake -S "${FIX_DIR}" -B "${BUILD_DIR}" -DCMAKE_BUILD_TYPE=Release -DINDI_SRC_DIR="${SRC_CACHE_DIR}"
+
+echo "-> Building..."
+cmake --build "${BUILD_DIR}"
+
+echo "-> Stopping INDI server (if running) to avoid 'Text file busy'..."
+active_profile="$(curl -s http://localhost:8624/api/server/status 2>/dev/null | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d[0].get("active_profile",""))' 2>/dev/null || true)"
+curl -s -X POST http://localhost:8624/api/server/stop >/dev/null 2>&1 || true
+sleep 1
+
+echo "-> Backing up and installing driver executable..."
+if [[ -f /usr/bin/indi_lx200generic && ! -f "/usr/bin/indi_lx200generic.${BACKUP_SUFFIX}" ]]; then
+    sudo cp /usr/bin/indi_lx200generic "/usr/bin/indi_lx200generic.${BACKUP_SUFFIX}"
+fi
+sudo cp "${BUILD_DIR}/indi_lx200generic" /usr/bin/indi_lx200generic
+sudo chmod +x /usr/bin/indi_lx200generic
+
+if [[ -n "${active_profile}" ]]; then
+    echo "-> Restarting INDI server with profile '${active_profile}'..."
+    curl -s -X POST "http://localhost:8624/api/server/start/${active_profile// /%20}" >/dev/null 2>&1 || true
+fi
+
+echo ""
+echo "Done. indi_lx200_OnStep (symlink to indi_lx200generic) now includes the"
+echo "mount-type fix. Verify after reconnecting the mount driver:"
+echo "  indi_getprop -h localhost -p 7624 -t 5 \"LX200 OnStep.TELESCOPE_MOUNT_TYPE.*\""
+echo ""
+echo "To roll back: sudo cp /usr/bin/indi_lx200generic.${BACKUP_SUFFIX} /usr/bin/indi_lx200generic"

--- a/diffs/indi_lx200_OnStep_v2.2.2.diff
+++ b/diffs/indi_lx200_OnStep_v2.2.2.diff
@@ -1,0 +1,192 @@
+diff --git a/drivers/telescope/lx200_OnStep.cpp b/drivers/telescope/lx200_OnStep.cpp
+index 4d4f93f..220cd95 100644
+--- a/drivers/telescope/lx200_OnStep.cpp
++++ b/drivers/telescope/lx200_OnStep.cpp
+@@ -2001,11 +2001,16 @@ void LX200_OnStep::getBasicData()
+             switch (mountTypeResponse[0])
+             {
+                 case 'A':
++                // OnStepX's :GXEM# returns the raw numeric web-interface mount select value
++                // ("1 GEM, 2 EQ Fork, or 3 Alt/Azm") on this firmware, not the letter codes
++                // used by older/other OnStep builds. '3' must be treated the same as 'A'.
++                case '3':
+                     OSMountType = MOUNTTYPE_ALTAZ;
+                     MountTypeSP[MOUNT_ALTAZ].setState(ISS_ON);
+                     LOG_INFO("Mount type detected: AltAz");
+                     break;
+                 case 'K':
++                case '2':
+                     OSMountType = MOUNTTYPE_FORK;
+                     MountTypeSP[MOUNT_EQ_FORK].setState(ISS_ON);
+                     LOG_INFO("Mount type detected: Fork (Equatorial)");
+@@ -2016,6 +2021,7 @@ void LX200_OnStep::getBasicData()
+                     LOG_INFO("Mount type detected: Fork Alt (AltAz)");
+                     break;
+                 case 'E':
++                case '1':
+                 default:
+                     OSMountType = MOUNTTYPE_GEM;
+                     MountTypeSP[MOUNT_EQ_GEM].setState(ISS_ON);
+@@ -2660,15 +2666,15 @@ bool LX200_OnStep::ReadScopeStatus()
+             //Ignored for now.
+         }
+         //Byte 0: Current Status
+-        if (OSStat[0] & 0b10000001 == 0b10000001)
++        if ((OSStat[0] & 0b10000001) == 0b10000001)
+         {
+             //Not tracking
+         }
+-        if (OSStat[0] & 0b10000010 == 0b10000010)
++        if ((OSStat[0] & 0b10000010) == 0b10000010)
+         {
+             //No goto
+         }
+-        if (OSStat[0] & 0b10000100 == 0b10000100)
++        if ((OSStat[0] & 0b10000100) == 0b10000100)
+         {
+             // PPS sync
+             OnstepStatTP[5].setText("PPS / GPS Sync Ok");
+@@ -2677,7 +2683,7 @@ bool LX200_OnStep::ReadScopeStatus()
+         {
+             OnstepStatTP[5].setText("N/A");
+         }
+-        if (OSStat[0] & 0b10001000 == 0b10001000)
++        if ((OSStat[0] & 0b10001000) == 0b10001000)
+         {
+             // Guide active
+         }
+@@ -2686,18 +2692,18 @@ bool LX200_OnStep::ReadScopeStatus()
+         // reply[0]|=0b10010000;                       // Refr enabled
+         // reply[0]|=0b11100000;                       // OnTrack enabled Single axis
+         // reply[0]|=0b10100000;                       // OnTrack enabled
+-        if ((OSStat[0] & 0b10010000 == 0b10010000
+-                || OSStat[0] & 0b10100000 == 0b10100000)) //On, either refractory only (r) or full (t)
++        if (((OSStat[0] & 0b10010000) == 0b10010000
++                || (OSStat[0] & 0b10100000) == 0b10100000)) //On, either refractory only (r) or full (t)
+         {
+-            if (OSStat[0] & 0b10100000 == 0b10100000)
++            if ((OSStat[0] & 0b10100000) == 0b10100000)
+             {
+                 OnstepStatTP[2].setText("Full Comp");
+             }
+-            if (OSStat[0] & 0b10010000 == 0b10010000)
++            if ((OSStat[0] & 0b10010000) == 0b10010000)
+             {
+                 OnstepStatTP[2].setText("Refractory Comp");
+             }
+-            if (OSStat[0] & 0b11000000 == 0b11000000)
++            if ((OSStat[0] & 0b11000000) == 0b11000000)
+             {
+                 OnstepStatTP[8].setText("Single Axis");
+             }
+@@ -2712,29 +2718,29 @@ bool LX200_OnStep::ReadScopeStatus()
+             OnstepStatTP[8].setText("N/A");
+         }
+         //Byte 1: Standard tracking rates
+-        if (OSStat[1] & 0b10000001 == 0b10000001)
++        if ((OSStat[1] & 0b10000001) == 0b10000001)
+         {
+             // Lunar rate selected
+         }
+-        if (OSStat[1] & 0b10000010 == 0b10000010)
++        if ((OSStat[1] & 0b10000010) == 0b10000010)
+         {
+             // Solar rate selected
+         }
+-        if (OSStat[1] & 0b10000011 == 0b10000011)
++        if ((OSStat[1] & 0b10000011) == 0b10000011)
+         {
+             // King rate selected
+         }
+         //Byte 2: Flags
+-        if (OSStat[2] & 0b10000001 == 0b10000001)
++        if ((OSStat[2] & 0b10000001) == 0b10000001)
+         {
+             // At home
+         }
+-        if (OSStat[2] & 0b10000010 == 0b10000010)
++        if ((OSStat[2] & 0b10000010) == 0b10000010)
+         {
+             // Waiting at home
+             OnstepStatTP[3].setText("Waiting at Home");
+         }
+-        if (OSStat[2] & 0b10000100 == 0b10000100)
++        if ((OSStat[2] & 0b10000100) == 0b10000100)
+         {
+             // Pause at home enabled?
+             //AutoPauseAtHome
+@@ -2748,11 +2754,11 @@ bool LX200_OnStep::ReadScopeStatus()
+             HomePauseSP.setState(IPS_OK);
+             HomePauseSP.apply();
+         }
+-        if (OSStat[2] & 0b10001000 == 0b10001000)
++        if ((OSStat[2] & 0b10001000) == 0b10001000)
+         {
+             // Buzzer enabled?
+         }
+-        if (OSStat[2] & 0b10010000 == 0b10010000)
++        if ((OSStat[2] & 0b10010000) == 0b10010000)
+         {
+             // Auto meridian flip
+             AutoFlipSP[0].setState(ISS_OFF);
+@@ -2767,7 +2773,7 @@ bool LX200_OnStep::ReadScopeStatus()
+             AutoFlipSP.setState(IPS_OK);
+             AutoFlipSP.apply();
+         }
+-        if (OSStat[2] & 0b10100000 == 0b10100000)
++        if ((OSStat[2] & 0b10100000) == 0b10100000)
+         {
+             // PEC data has been recorded
+         }
+@@ -2776,25 +2782,25 @@ bool LX200_OnStep::ReadScopeStatus()
+ 
+ 
+         //Byte 3: Mount type and info
+-        if (OSStat[3] & 0b10000001 == 0b10000001)
++        if ((OSStat[3] & 0b10000001) == 0b10000001)
+         {
+             // GEM
+             OnstepStatTP[6].setText("German Mount");
+             OSMountType = MOUNTTYPE_GEM;
+         }
+-        if (OSStat[3] & 0b10000010 == 0b10000010)
++        if ((OSStat[3] & 0b10000010) == 0b10000010)
+         {
+             // FORK
+             OnstepStatTP[6].setText("Fork Mount");
+             OSMountType = MOUNTTYPE_FORK;
+         }
+-        if (OSStat[3] & 0b10000100 == 0b10000100)   //Seems depreciated/subsumed into  FORK
++        if ((OSStat[3] & 0b10000100) == 0b10000100)   //Seems depreciated/subsumed into  FORK
+         {
+             // Fork Alt
+             OnstepStatTP[6].setText("Fork Alt Mount");
+             OSMountType = MOUNTTYPE_FORK_ALT;
+         }
+-        if (OSStat[3] & 0b10001000 == 0b10001000)
++        if ((OSStat[3] & 0b10001000) == 0b10001000)
+         {
+             // ALTAZM
+             OnstepStatTP[6].setText("AltAZ Mount");
+@@ -2803,18 +2809,18 @@ bool LX200_OnStep::ReadScopeStatus()
+ 
+ 
+         setPierSide(PIER_UNKNOWN);
+-        if (OSStat[3] & 0b10010000 == 0b10010000)
++        if ((OSStat[3] & 0b10010000) == 0b10010000)
+         {
+             // Pier side none
+             setPierSide(PIER_UNKNOWN);
+             // INDI doesn't account for 'None'
+         }
+-        if (OSStat[3] & 0b10100000 == 0b10100000)
++        if ((OSStat[3] & 0b10100000) == 0b10100000)
+         {
+             // Pier side east
+             setPierSide(PIER_EAST);
+         }
+-        if (OSStat[3] & 0b11000000 == 0b11000000)
++        if ((OSStat[3] & 0b11000000) == 0b11000000)
+         {
+             // Pier side west
+             setPierSide(PIER_WEST);

--- a/indi_onstep_fix/CMakeLists.txt
+++ b/indi_onstep_fix/CMakeLists.txt
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 3.10)
+project(indi_lx200generic_fixed)
+
+# ################################################################################
+# Standalone build of the upstream indilib/indi "indi_lx200generic" binary
+# (which the "indi_lx200_OnStep" driver is a symlink to - all LX200-family
+# drivers share one binary, dispatching on argv[0]), including the mount-type
+# detection fix for issue #227 (see diffs/indi_lx200_OnStep_v2.2.2.diff).
+#
+# Links against the system-installed libindi, same rationale as
+# indi_pifinder_bridge/CMakeLists.txt - no full indi monorepo build needed.
+# Source file list mirrors upstream's drivers/telescope/CMakeLists.txt
+# add_executable(indi_lx200generic ...) target for v2.2.2.
+#
+# Not built/run by this script directly - see bin/build_indi_onstep_fix.sh,
+# which clones the pinned upstream tag, applies the diff, then configures
+# this CMakeLists.txt against that checkout.
+# ################################################################################
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(INDI REQUIRED libindi)
+
+if(NOT DEFINED INDI_SRC_DIR)
+    message(FATAL_ERROR "INDI_SRC_DIR must be set to the indilib/indi checkout root (see bin/build_indi_onstep_fix.sh)")
+endif()
+
+set(SRC_DIR "${INDI_SRC_DIR}/drivers/telescope")
+
+add_executable(indi_lx200generic
+    ${SRC_DIR}/lx200driver.cpp
+    ${SRC_DIR}/lx200autostar.cpp
+    ${SRC_DIR}/lx200_16.cpp
+    ${SRC_DIR}/lx200gps.cpp
+    ${SRC_DIR}/lx200generic.cpp
+    ${SRC_DIR}/lx200telescope.cpp
+    ${SRC_DIR}/lx200classic.cpp
+    ${SRC_DIR}/lx200gemini.cpp
+    ${SRC_DIR}/lx200zeq25.cpp
+    ${SRC_DIR}/lx200am5.cpp
+    ${SRC_DIR}/lx200gotonova.cpp
+    ${SRC_DIR}/lx200pulsar2.cpp
+    ${SRC_DIR}/lx200apdriver.cpp
+    ${SRC_DIR}/lx200ap_v2.cpp
+    ${SRC_DIR}/lx200ap_gtocp2.cpp
+    ${SRC_DIR}/lx200fs2.cpp
+    ${SRC_DIR}/lx200ss2000pc.cpp
+    ${SRC_DIR}/lx200_OnStep.cpp
+    ${SRC_DIR}/lx200_OpenAstroTech.cpp
+    ${SRC_DIR}/lx200_pegasus_nyx101.cpp
+    ${SRC_DIR}/lx200_10micron.cpp
+    ${SRC_DIR}/ioptronHC8406.cpp
+    ${SRC_DIR}/eq500x.cpp
+    ${SRC_DIR}/lx200_esp32go.cpp
+)
+
+target_include_directories(indi_lx200generic PRIVATE ${INDI_INCLUDE_DIRS})
+target_compile_definitions(indi_lx200generic PRIVATE _XOPEN_SOURCE=600 _POSIX_C_SOURCE=200809L HAVE_LIBNOVA)
+target_link_libraries(indi_lx200generic indidriver nova pthread)


### PR DESCRIPTION
## Was

Fügt einen reproduzierbaren Fix für den in #227 dokumentierten Bug im
upstream-Treiber `indilib/indi` (`lx200_OnStep.cpp`) hinzu: `:GXEM#` liefert
auf dieser Firmware die rohe Ziffer des OnStep-Webinterface-Settings
("1 GEM, 2 EQ Fork, or 3 Alt/Azm"), der Treiber erwartet aber Buchstaben-Codes
(A/K/k/E) und wertet alles andere - inklusive '3' - fälschlich als GEM.

Live verifiziert (siehe #227 für den vollständigen Trace):
- `LX200 OnStep.TELESCOPE_MOUNT_TYPE.ALTAZ=On` nach dem Fix (vorher `EQ_GEM=On`)
- `PiFinder Mount Bridge.PIFINDER_ORIENTATION.MOUNT_TYPE=Alt/Az` (Downstream-Konsument liest korrekt durch)

## Warum als Diff + Build-Script, nicht nur installierte Binary

`indi_lx200generic`/`indi_lx200_OnStep` gehört zum System-Paket `libindi` -
ein Paket-Reinstall/-Upgrade würde den Fix sonst kommentarlos wieder
überschreiben. `bin/build_indi_onstep_fix.sh` klont den gepinnten
`indilib/indi`-Tag (`v2.2.2`, passend zur installierten `libindi`-Version),
wendet `diffs/indi_lx200_OnStep_v2.2.2.diff` an und baut isoliert gegen die
System-`libindi` (gleiches Muster wie `indi_pifinder_bridge/CMakeLists.txt`,
kein voller Monorepo-Build nötig). Backup der Original-Binary wird beim
Installieren automatisch angelegt.

## Nicht enthalten

Kein echter GoTo/Slew-Test am realen Teleskop - bewusst nicht autonom
ausgeführt (unbeaufsichtigte Mount-Bewegung ist ein Sicherheitsrisiko).
Steht noch aus, #227 bleibt bis dahin offen.

Refs #227