### PR TITLE
Goto-Forward: sync-before-Goto, atomic CAM position fix, keep-awake (still unreliable overall)

### DIFF
--- a/diffs/main_py.diff
+++ b/diffs/main_py.diff
@@ -1,8 +1,6 @@
-diff --git a/python/PiFinder/main.py b/python/PiFinder/main.py
-index 6f6e2eb6..7d006111 100644
---- a/python/PiFinder/main.py
-+++ b/python/PiFinder/main.py
-@@ -84,7 +84,21 @@ def init_keypad_pwm():
+--- python/PiFinder/main.py.orig
++++ python/PiFinder/main.py
+@@ -84,7 +84,21 @@
      global hardware_platform
      if hardware_platform == "Pi":
          keypad_pwm = HardwarePWM(pwm_channel=1, hz=120)
@@ -25,7 +23,7 @@ index 6f6e2eb6..7d006111 100644
  
  
  def set_keypad_brightness(percentage: float):
-@@ -148,11 +162,19 @@ StateManager.register("NewImage", Image.new)
+@@ -148,11 +162,27 @@
  
  
  class PowerManager:
@@ -34,6 +32,14 @@ index 6f6e2eb6..7d006111 100644
 +    _PRE_SLEEP = "pre_sleep"  # 30s sleep between attempts
 +    _RETRY = "retry"        # 1-min retry window after sleep
 +    _SOLVED = "solved"      # normal operation after first solve
++
++    # How long a single register_external_activity() call (see state.py)
++    # keeps counting as "activity" - must comfortably exceed the interval an
++    # external caller polls at (Mount Bridge: every ~2s while GoTo-Forward is
++    # active) so a normal poll gap never reads as "gone idle", but short
++    # enough that PiFinder resumes its own battery-friendly sleep promptly
++    # once the caller actually stops (mode turned off, bridge disconnected).
++    _EXTERNAL_ACTIVITY_GRACE_SEC = 10
 +
      def __init__(self, cfg, shared_state, display_device):
          self.cfg = cfg
@@ -45,7 +51,7 @@ index 6f6e2eb6..7d006111 100644
  
      def register_activity(self):
          """
-@@ -186,28 +208,76 @@ class PowerManager:
+@@ -186,28 +216,93 @@
          self.shared_state.set_power_state(0)
          self.sleep_screen()
  
@@ -82,19 +88,35 @@ index 6f6e2eb6..7d006111 100644
 -            # We are awake, should we sleep?
 -            if time.time() - self.last_activity > self.get_sleep_timeout():
 -                self.go_to_sleep()
--
++        has_solve = self._has_solve()
+ 
 -        else:  # We are asleepd, should we wake up?
 -            _imu = self.shared_state.imu()
 -            if _imu:
 -                if _imu.moving:
-+        has_solve = self._has_solve()
-+
 +        if self._solve_state == self._SOLVED:
 +            if not has_solve:
 +                # Lost solve (clouds etc.) — restart warmup
 +                self._enter_state(self._WARMUP)
 +                self.wake_up()
 +                return
++
++            # External activity (e.g. Mount Bridge actively running
++            # GoTo-Forward, which needs full-cadence solves to sync/verify
++            # against - see state.py's register_external_activity()) counts
++            # the same as local keypad/IMU activity for the idle timer, and
++            # can itself trigger an immediate wake if currently asleep -
++            # found live (2026-08-19, #227 follow-up): without this,
++            # GoTo-Forward's own sync-before-Goto could never get a fresh
++            # enough solve once PiFinder's own (unrelated) idle timeout put
++            # it to sleep, since nothing was moving the scope to generate
++            # IMU activity either - a self-inflicted deadlock.
++            external_ts = self.shared_state.external_activity_ts()
++            if external_ts is not None and time.time() - external_ts < self._EXTERNAL_ACTIVITY_GRACE_SEC:
++                self.last_activity = max(self.last_activity, external_ts)
++                if self.shared_state.power_state() <= 0:
+                     self.wake_up()
+ 
 +            # Normal operation: sleep after configured timeout of inactivity
 +            if self.shared_state.power_state() > 0:
 +                if time.time() - self.last_activity > self.get_sleep_timeout():
@@ -102,8 +124,8 @@ index 6f6e2eb6..7d006111 100644
 +            else:
 +                _imu = self.shared_state.imu()
 +                if _imu and _imu.moving:
-                     self.wake_up()
- 
++                    self.wake_up()
++
 +        elif self._solve_state == self._WARMUP:
 +            if has_solve:
 +                self._enter_state(self._SOLVED)
@@ -135,7 +157,7 @@ index 6f6e2eb6..7d006111 100644
      def get_sleep_timeout(self):
          """
          returns the sleep timeout amount
-@@ -367,6 +437,11 @@ def main(
+@@ -367,6 +462,11 @@
      alignment_command_queue: Queue = Queue()
      alignment_response_queue: Queue = Queue()
      ui_queue: Queue = Queue()
@@ -147,7 +169,7 @@ index 6f6e2eb6..7d006111 100644
  
      # init queues for logging
      keyboard_logqueue: Queue = log_helper.get_queue()
-@@ -503,6 +578,7 @@ def main(
+@@ -503,6 +603,7 @@
                  server_logqueue,
                  verbose,
              ),
@@ -155,7 +177,7 @@ index 6f6e2eb6..7d006111 100644
          )
          server_process.start()
  
-@@ -607,6 +683,7 @@ def main(
+@@ -607,6 +708,7 @@
              kwargs={
                  "command_queue": integrator_command_queue,
                  "camera_command_queue": camera_command_queue,
@@ -163,7 +185,7 @@ index 6f6e2eb6..7d006111 100644
              },
          )
          integrator_process.start()
-@@ -725,13 +802,6 @@ def main(
+@@ -725,13 +827,6 @@
                                  and not location.source.startswith("CONFIG:")
                                  and not location.source == "MANUAL"
                                  and not location.source == "replay"
@@ -177,7 +199,7 @@ index 6f6e2eb6..7d006111 100644
                              ):
                                  logger.debug(
                                      f"Updating GPS location: new content: {gps_content}, old content: {location}"
-@@ -808,6 +878,12 @@ def main(
+@@ -808,6 +903,12 @@
                      if catalogs.catalog_filter is not None:
                          catalogs.catalog_filter.mark_dirty()
                      menu_manager.message(_("Catalogs\nFully Loaded"), 2)
@@ -190,7 +212,7 @@ index 6f6e2eb6..7d006111 100644
                  elif ui_command == "test_mode":
                      dt = timez.utc(2025, 6, 28, 11, 0, 0)
                      shared_state.set_datetime(dt)
-@@ -1304,6 +1380,8 @@ if __name__ == "__main__":
+@@ -1304,6 +1405,8 @@
              gps_monitor = importlib.import_module("PiFinder.gps_fake")
          elif gps_type == "ublox":
              gps_monitor = importlib.import_module("PiFinder.gps_ubx")

--- a/diffs/server_py.diff
+++ b/diffs/server_py.diff
@@ -75,7 +75,7 @@
                      session["authenticated"] = True
                      session.pop("origin_url", None)
                      return redirect(origin_url)
-@@ -538,6 +568,48 @@
+@@ -538,6 +568,67 @@
              self.network.set_host_name(host_name)
              return app.jinja_env.get_template("restart.html").render(title=_("Restart"))
  
@@ -121,10 +121,29 @@
 +                }
 +            )
 +
++        @app.route("/api/keep_awake", methods=["POST"])
++        def api_keep_awake():
++            # Called repeatedly (every ~2s) by the Mount Bridge INDI driver
++            # (StellarMate integration) while GoTo-Forward mode is actively
++            # coordinating a GoTo - that mode needs full-cadence, fresh
++            # solves to Sync from and to verify arrival against, but
++            # PiFinder's own battery-friendly sleep (keypad/IMU activity
++            # only, see PowerManager in main.py) has no way to know an
++            # external caller needs it awake. A single call only buys
++            # PowerManager._EXTERNAL_ACTIVITY_GRACE_SEC worth of "activity" -
++            # callers must keep polling for as long as they need this. Same
++            # loopback-only restriction as /api/set_mount_type - machine-to-
++            # machine, not a browser session.
++            if request.remote_addr not in ("127.0.0.1", "::1"):
++                return jsonify({"error": "forbidden"}), 403
++
++            self.shared_state.register_external_activity()
++            return jsonify({"ok": True})
++
          @app.route("/tools/pwchange", methods=["POST"])
          @auth_required
          def password_change():
-@@ -553,7 +625,7 @@
+@@ -553,7 +644,7 @@
  
              if new_passworda == new_passwordb:
                  if sys_utils.change_password(
@@ -133,7 +152,7 @@
                  ):
                      return app.jinja_env.get_template("tools.html").render(
                          title=_("Tools"), status_message=_("Password Changed")
-@@ -1230,6 +1302,15 @@
+@@ -1230,6 +1321,15 @@
          self.app = app
  
      def run(self):
@@ -149,7 +168,7 @@
          # If the PiFinder software is running as a service
          # it can grab port 80.  If not, it needs to use 8080
          try:
-@@ -1265,10 +1346,23 @@
+@@ -1265,10 +1365,23 @@
  
  
  def run_server(

--- a/diffs/state_py.diff
+++ b/diffs/state_py.diff
@@ -1,6 +1,21 @@
 --- python/PiFinder/state.py.orig
 +++ python/PiFinder/state.py
-@@ -305,6 +305,17 @@
+@@ -273,6 +273,14 @@
+ class SharedStateObj:
+     def __init__(self) -> None:
+         self.__power_state = 1  # 0 = sleep state, 1 = awake state
++        # Timestamp of the last externally-requested "keep awake" (e.g. the
++        # Mount Bridge actively coordinating a GoTo - see
++        # register_external_activity()'s docstring). None = never requested.
++        # Separate from the main process's own PowerManager.last_activity
++        # (keypad/IMU), which an external web-server-process caller has no
++        # access to - main.py's update() loop reads this alongside its own
++        # activity timer instead.
++        self.__external_activity_ts: Optional[float] = None
+         # self.__solve_state
+         # None = No solve attempted yet
+         # True = Valid solve data from either IMU or Camera
+@@ -305,6 +313,17 @@
          self.__arch = None
          self.__camera_align = False
          self.__camera_type = "imx296"  # Default, will be set by camera process
@@ -18,7 +33,31 @@
          # Degrees the camera process rotates the solve/display image relative
          # to the stored raw frame (PIL CCW). None until the camera reports.
          self.__solve_image_rotation = None
-@@ -380,6 +391,18 @@
+@@ -350,6 +369,23 @@
+                 f"Invalid value for set_power_state: {v}. power_state not changed."
+             )
+ 
++    def external_activity_ts(self):
++        return self.__external_activity_ts
++
++    def register_external_activity(self):
++        """
++        Called from outside the main process (e.g. the web server, on behalf
++        of the Mount Bridge actively coordinating a GoTo) to request that
++        PiFinder stay awake and keep producing full-cadence solves, the same
++        as real keypad/IMU activity would. Does NOT wake the screen or
++        directly flip power_state itself - main.py's update() loop is the
++        only place that decides sleep/wake, it just also honors this
++        timestamp alongside its own last_activity. Callers must keep calling
++        this periodically (not just once) for as long as they need PiFinder
++        awake - a single call only buys until the current sleep timeout.
++        """
++        self.__external_activity_ts = time.time()
++
+     def arch(self):
+         return self.__arch
+ 
+@@ -380,6 +416,18 @@
      def set_camera_type(self, v: str):
          self.__camera_type = v
  

--- a/indi_pifinder_bridge/pifinder_mount_bridge.cpp
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.cpp
@@ -44,6 +44,40 @@ bool httpPostMountType(const std::string &url, const std::string &mountType)
     return res == CURLE_OK && httpCode == 200;
 }
 
+// #227 follow-up (2026-08-19): Goto-Forward needs full-cadence, fresh
+// PiFinder solves throughout (to Sync from before every Goto, and to verify
+// arrival), but PiFinder's own battery-friendly sleep (keypad/IMU activity
+// only) has no way to know this driver needs it awake - a real live deadlock
+// otherwise (PiFinder sleeps from inactivity, sleep throttles its solve
+// cadence, Goto-Forward can never get a fresh enough solve to act, so
+// nothing ever moves to generate real activity either). Called every tick
+// while MODE_GOTO_FORWARD is active - see PiFinder's /api/keep_awake and
+// state.py's register_external_activity() for the other side of this.
+bool httpPostKeepAwake(const std::string &url)
+{
+    CURL *curl = curl_easy_init();
+    if (curl == nullptr)
+        return false;
+
+    struct curl_slist *headers = nullptr;
+    headers = curl_slist_append(headers, "Content-Type: application/json");
+
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "{}");
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, 1500L);
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+
+    const CURLcode res = curl_easy_perform(curl);
+    long httpCode = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpCode);
+
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+
+    return res == CURLE_OK && httpCode == 200;
+}
+
 size_t appendToString(char *ptr, size_t size, size_t nmemb, void *userdata)
 {
     static_cast<std::string *>(userdata)->append(ptr, size * nmemb);
@@ -86,6 +120,79 @@ bool httpGetPiFinderSolveStatus(const std::string &url, std::string &solveSource
         solveSource = solution.value("solve_source", std::string());
         const auto &lastSolveField = solution.at("last_solve_success");
         lastSolveSuccess = lastSolveField.is_null() ? 0.0 : lastSolveField.get<double>();
+        return true;
+    }
+    catch (const nlohmann::json::exception &)
+    {
+        return false;
+    }
+}
+
+// Same /api/status endpoint as httpGetPiFinderSolveStatus() above, but also
+// extracts RA/Dec from the *same* JSON response instead of leaving the
+// caller to fetch position separately (e.g. via the LX200 EQUATORIAL_EOD_COORD
+// property, as getPiFinderRADE() does). That separate-channel approach is
+// fine for read-only display, but for anything that's about to Sync the
+// mount it has a real timing gap: confirming "the last solve was CAM and
+// fresh" via this endpoint, then fetching the position value via a totally
+// different call moments later, can pick up a position PiFinder has since
+// advanced past that confirmed solve via IMU interpolation - syncing the
+// mount to a position that was never actually verified. Found live
+// (2026-08-19, #227 follow-up): PiFinder "overshooting" past a target the
+// mount had genuinely reached correctly. Returns false (and leaves ra/dec
+// untouched) unless solve_source is exactly "CAM", the solve is within
+// maxAgeSeconds, and RA/Dec both parsed - the position and the freshness/
+// source guarantee always come from one atomic snapshot.
+bool httpGetPiFinderFreshCamPosition(const std::string &url, double maxAgeSeconds, double &ra, double &dec)
+{
+    CURL *curl = curl_easy_init();
+    if (curl == nullptr)
+        return false;
+
+    std::string body;
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, appendToString);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &body);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, 1500L);
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+
+    const CURLcode res = curl_easy_perform(curl);
+    long httpCode = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpCode);
+    curl_easy_cleanup(curl);
+
+    if (res != CURLE_OK || httpCode != 200)
+        return false;
+
+    try
+    {
+        const auto parsed = nlohmann::json::parse(body);
+        const auto &solution = parsed.at("solution");
+        const std::string solveSource = solution.value("solve_source", std::string());
+        const auto &lastSolveField = solution.at("last_solve_success");
+        const double lastSolveSuccess = lastSolveField.is_null() ? 0.0 : lastSolveField.get<double>();
+
+        if (solveSource != "CAM" || lastSolveSuccess <= 0.0)
+            return false;
+        const double ageSeconds = static_cast<double>(time(nullptr)) - lastSolveSuccess;
+        if (!(ageSeconds >= 0.0 && ageSeconds <= maxAgeSeconds))
+            return false;
+
+        const auto &raField = solution.at("RA");
+        const auto &decField = solution.at("Dec");
+        if (raField.is_null() || decField.is_null())
+            return false;
+
+        // CRITICAL UNIT MISMATCH (found live 2026-08-19, caused a real
+        // runaway slew): PiFinder's /api/status reports "solution.RA" in
+        // DEGREES (0-360) - unlike the LX200 EQUATORIAL_EOD_COORD property
+        // getPiFinderRADE() reads elsewhere in this driver, which is hours
+        // (0-24) per INDI convention. Every caller of this function (Sync,
+        // angularSeparationArcmin()) expects hours, matching getMountRADE()
+        // and the rest of the driver. Must convert here, once, at the
+        // source - never assume degrees-vs-hours from a bare number.
+        ra = raField.get<double>() / 15.0;
+        dec = decField.get<double>();
         return true;
     }
     catch (const nlohmann::json::exception &)
@@ -465,6 +572,7 @@ bool PiFinderMountBridge::Connect()
     }
 
     LOGF_INFO("Bridging %s -> %s.", piFinderName.c_str(), mountName.c_str());
+    m_didInitialSync = false;
     SetTimer(getCurrentPollingPeriod());
     return true;
 }
@@ -493,6 +601,17 @@ void PiFinderMountBridge::syncMountTypeToPiFinder()
         LOGF_INFO("Mount type '%s' pushed to PiFinder.", mountType.c_str());
         m_lastSyncedMountType = mountType;
     }
+}
+
+void PiFinderMountBridge::keepPiFinderAwake()
+{
+    // Same 80-then-8080 fallback order as syncMountTypeToPiFinder() above.
+    // Best-effort - a failed keep-awake call isn't fatal to the Goto, it
+    // just means PiFinder might go/stay asleep and the next sync-before-Goto
+    // attempt waits for its own next fresh solve, same as before this
+    // mechanism existed.
+    httpPostKeepAwake("http://127.0.0.1/api/keep_awake") ||
+        httpPostKeepAwake("http://127.0.0.1:8080/api/keep_awake");
 }
 
 void PiFinderMountBridge::syncOrientationStatus()
@@ -602,11 +721,17 @@ void PiFinderMountBridge::handleShadowSync()
     // Same freshness gate as every other automatic action here (#79) -
     // mirroring a stale/IMU-interpolated position would just teach the
     // shadow device to lie too, defeating the point of it being "truth".
-    if (!isPiFinderSolveFresh(SolveFreshnessMaxAgeN[0].value))
-        return;
-
+    // #227 follow-up (2026-08-19/20): position now comes from the same
+    // atomic snapshot as the freshness/source check (see
+    // httpGetPiFinderFreshCamPosition()) - the old two-call pattern here
+    // could mirror a position already advanced past the verified solve via
+    // IMU interpolation, which is exactly the Shadow device visibly
+    // drifting apart from PiFinder LX200 that was observed live.
     double piRA, piDec;
-    if (!m_client->getPiFinderRADE(piRA, piDec))
+    const bool haveFreshCamPosition =
+        httpGetPiFinderFreshCamPosition("http://127.0.0.1/api/status", SolveFreshnessMaxAgeN[0].value, piRA, piDec) ||
+        httpGetPiFinderFreshCamPosition("http://127.0.0.1:8080/api/status", SolveFreshnessMaxAgeN[0].value, piRA, piDec);
+    if (!haveFreshCamPosition)
         return;
 
     m_client->syncShadowCoords(piRA, piDec);
@@ -846,6 +971,20 @@ void PiFinderMountBridge::TimerHit()
     }
     m_bindingGiveUpLogged = false;
 
+    // #227 follow-up (2026-08-19): before trusting/using the mount's
+    // position for anything, unconditionally Sync it once from PiFinder's
+    // position - whatever the mount reports right after Connect() (leftover
+    // from before this session, or a hardware default) is not assumed
+    // accurate. Only for the modes actually allowed to move/Sync the mount;
+    // Verify-Alert and Off must stay passive. Retries every tick (no fresh
+    // solve yet just means try again next tick) until it succeeds once.
+    if (!m_didInitialSync &&
+        (BridgeModeS[MODE_AUTO_CORRECT].s == ISS_ON || BridgeModeS[MODE_GOTO_FORWARD].s == ISS_ON))
+    {
+        if (syncMountToPiFinderPosition())
+            m_didInitialSync = true;
+    }
+
     // #191 PoC - independent of Coupling mode entirely (a one-shot action,
     // not a standing coupling mode - see the concept doc's own "Abgrenzung
     // zu bestehenden Coupling-Modi"), so it ticks unconditionally here
@@ -1002,19 +1141,40 @@ void PiFinderMountBridge::applySlewRateForDrift(double driftArcmin)
     if (count <= 0)
         return; // driver doesn't expose slew rates - optional enhancement, not fatal to the Goto
 
-    int index;
-    if (driftArcmin > SLEW_RATE_FAR_THRESHOLD_ARCMIN)
-        index = count - 1; // fastest available
-    else if (driftArcmin > SLEW_RATE_CLOSE_THRESHOLD_ARCMIN)
-        index = count / 2; // a middle rate
-    else
-        index = 0; // slowest/most precise available
+    const double clamped = std::clamp(driftArcmin, SLEW_RATE_LOG_MIN_ARCMIN, SLEW_RATE_LOG_MAX_ARCMIN);
+    const double t = std::log(clamped / SLEW_RATE_LOG_MIN_ARCMIN) /
+                      std::log(SLEW_RATE_LOG_MAX_ARCMIN / SLEW_RATE_LOG_MIN_ARCMIN); // 0..1
+    int index = static_cast<int>(std::lround(t * (count - 1)));
+    index = std::clamp(index, 0, count - 1);
 
     m_client->setSlewRateIndex(index);
 }
 
+bool PiFinderMountBridge::syncMountToPiFinderPosition()
+{
+    double piRA, piDec;
+    if (!(httpGetPiFinderFreshCamPosition("http://127.0.0.1/api/status", SolveFreshnessMaxAgeN[0].value, piRA, piDec) ||
+          httpGetPiFinderFreshCamPosition("http://127.0.0.1:8080/api/status", SolveFreshnessMaxAgeN[0].value, piRA, piDec)))
+    {
+        LOG_WARN("No fresh PiFinder camera solve yet - deferring Goto until the mount can be Synced to a real position first.");
+        return false;
+    }
+
+    if (!m_client->sendMountCoords(piRA, piDec, "SYNC"))
+    {
+        LOG_ERROR("Failed to Sync mount to PiFinder's current position before forwarding Goto.");
+        return false;
+    }
+
+    LOGF_INFO("Synced mount to PiFinder's current position (RA %.4fh, DEC %.4f deg) before forwarding Goto.",
+              piRA, piDec);
+    return true;
+}
+
 void PiFinderMountBridge::handleGotoForward()
 {
+    keepPiFinderAwake();
+
     double targetRA, targetDec;
     const bool hasTarget = m_client->getPiFinderTargetRADE(targetRA, targetDec);
 
@@ -1023,9 +1183,15 @@ void PiFinderMountBridge::handleGotoForward()
         case ForwardState::IDLE:
         {
             if (!hasTarget)
+            {
+                m_forwardAwaitingSync = false;
                 return;
+            }
 
-            if (!m_client->consumePiFinderTargetPending())
+            if (m_client->consumePiFinderTargetPending())
+                m_forwardAwaitingSync = true;
+
+            if (!m_forwardAwaitingSync)
             {
                 // No genuinely new Goto *event* since we started watching
                 // (a BridgeMode switch, or a driver restart while this mode
@@ -1055,11 +1221,21 @@ void PiFinderMountBridge::handleGotoForward()
                 return;
             }
 
+            // #227 root-cause fix (2026-08-19): always Sync the mount to
+            // PiFinder's actual current position before computing/sending
+            // the Goto - see syncMountToPiFinderPosition()'s header comment.
+            // If PiFinder has no fresh solve yet, m_forwardAwaitingSync stays
+            // true and this is retried next tick using whatever target is
+            // then current, instead of either firing blind or dropping the
+            // user's target selection.
+            if (!syncMountToPiFinderPosition())
+                break;
+
             {
                 double mountRA, mountDec;
                 applySlewRateForDrift(m_client->getMountRADE(mountRA, mountDec)
                                           ? angularSeparationArcmin(targetRA, targetDec, mountRA, mountDec)
-                                          : SLEW_RATE_FAR_THRESHOLD_ARCMIN + 1.0); // unknown - assume far, safe default
+                                          : SLEW_RATE_LOG_MAX_ARCMIN); // unknown - assume far, safe default
             }
             if (m_client->sendMountCoords(targetRA, targetDec, "TRACK"))
             {
@@ -1070,6 +1246,7 @@ void PiFinderMountBridge::handleGotoForward()
                 m_lastForwardedRA = targetRA;
                 m_lastForwardedDec = targetDec;
                 m_settleRetriesRemaining = MAX_SETTLE_RETRIES;
+                m_forwardAwaitingSync = false;
                 m_forwardState = ForwardState::SLEWING;
             }
             else
@@ -1125,11 +1302,21 @@ void PiFinderMountBridge::handleGotoForward()
                 break;
             }
 
-            if (!isPiFinderSolveFresh(SolveFreshnessMaxAgeN[0].value))
+            double piRA, piDec;
+            const bool haveFreshCamPosition =
+                httpGetPiFinderFreshCamPosition("http://127.0.0.1/api/status", SolveFreshnessMaxAgeN[0].value, piRA, piDec) ||
+                httpGetPiFinderFreshCamPosition("http://127.0.0.1:8080/api/status", SolveFreshnessMaxAgeN[0].value, piRA, piDec);
+            if (!haveFreshCamPosition)
             {
                 // PiFinder hasn't produced a real camera solve since arrival
                 // yet - see the header comment on m_freshnessWaitTicksRemaining.
                 // Keep waiting rather than verifying/correcting off a guess.
+                // #227 follow-up (2026-08-19): this now also covers the case
+                // where the *last* solve was fresh-and-CAM but the position
+                // read separately (e.g. via LX200) had already moved past it
+                // via IMU interpolation by the time we read it - position and
+                // freshness/source guarantee now always come from the same
+                // atomic snapshot, see httpGetPiFinderFreshCamPosition().
                 if (--m_freshnessWaitTicksRemaining <= 0)
                 {
                     LOG_WARN("Gave up waiting for a fresh PiFinder solve after arrival - resuming normal holding.");
@@ -1138,8 +1325,8 @@ void PiFinderMountBridge::handleGotoForward()
                 break;
             }
 
-            double piRA, piDec, mountRA, mountDec;
-            if (!m_client->getPiFinderRADE(piRA, piDec) || !m_client->getMountRADE(mountRA, mountDec))
+            double mountRA, mountDec;
+            if (!m_client->getMountRADE(mountRA, mountDec))
             {
                 m_forwardState = ForwardState::IDLE;
                 break;
@@ -1216,12 +1403,23 @@ void PiFinderMountBridge::handleGotoForward()
             if (hasTarget)
             {
                 if (m_client->consumePiFinderTargetPending())
+                    m_forwardAwaitingSync = true;
+
+                if (m_forwardAwaitingSync)
                 {
+                    // Same #227 root-cause fix as IDLE above - always Sync to
+                    // PiFinder's current position before forwarding a new
+                    // target, retrying next tick (still holding the old
+                    // target in the meantime) if no fresh solve is available
+                    // yet.
+                    if (!syncMountToPiFinderPosition())
+                        break;
+
                     {
                         double mountRA, mountDec;
                         applySlewRateForDrift(m_client->getMountRADE(mountRA, mountDec)
                                                   ? angularSeparationArcmin(targetRA, targetDec, mountRA, mountDec)
-                                                  : SLEW_RATE_FAR_THRESHOLD_ARCMIN + 1.0);
+                                                  : SLEW_RATE_LOG_MAX_ARCMIN);
                     }
                     if (m_client->sendMountCoords(targetRA, targetDec, "TRACK"))
                     {
@@ -1232,6 +1430,7 @@ void PiFinderMountBridge::handleGotoForward()
                         m_lastForwardedRA = targetRA;
                         m_lastForwardedDec = targetDec;
                         m_settleRetriesRemaining = MAX_SETTLE_RETRIES;
+                        m_forwardAwaitingSync = false;
                         m_forwardState = ForwardState::SLEWING;
                     }
                     else
@@ -1279,11 +1478,27 @@ void PiFinderMountBridge::handleGotoForward()
             // indefinitely instead of only right after arrival. Same
             // freshness gate as everywhere else - never correct off a
             // guessed/stale position.
-            if (!isPiFinderSolveFresh(SolveFreshnessMaxAgeN[0].value))
+            //
+            // #227 follow-up (2026-08-19): this is the loop that was
+            // actually oscillating live ("PiFinder overshoots, mount pulls
+            // back and forth") - the mount had genuinely reached the real
+            // target correctly, but the *separately* fetched PiFinder
+            // position (old getPiFinderRADE(), a plain LX200 read with no
+            // freshness/source info of its own) could already reflect IMU
+            // interpolation applied *after* the last confirmed-fresh CAM
+            // solve, dragging an already-correct mount away from a real
+            // target toward an unverified guess. Now uses one atomic
+            // snapshot for both the freshness/source guarantee and the
+            // position value - see httpGetPiFinderFreshCamPosition().
+            double piRA, piDec;
+            const bool haveFreshCamPosition =
+                httpGetPiFinderFreshCamPosition("http://127.0.0.1/api/status", SolveFreshnessMaxAgeN[0].value, piRA, piDec) ||
+                httpGetPiFinderFreshCamPosition("http://127.0.0.1:8080/api/status", SolveFreshnessMaxAgeN[0].value, piRA, piDec);
+            if (!haveFreshCamPosition)
                 break;
 
-            double piRA, piDec, mountRA, mountDec;
-            if (!m_client->getPiFinderRADE(piRA, piDec) || !m_client->getMountRADE(mountRA, mountDec))
+            double mountRA, mountDec;
+            if (!m_client->getMountRADE(mountRA, mountDec))
                 break;
 
             const double drift = angularSeparationArcmin(piRA, piDec, mountRA, mountDec);
@@ -1500,7 +1715,7 @@ bool PiFinderMountBridge::gotoAlignPoint(size_t index)
     double mountRA, mountDec;
     applySlewRateForDrift(m_client->getMountRADE(mountRA, mountDec)
                                ? angularSeparationArcmin(ra, dec, mountRA, mountDec)
-                               : SLEW_RATE_FAR_THRESHOLD_ARCMIN + 1.0);
+                               : SLEW_RATE_LOG_MAX_ARCMIN);
     if (!m_client->sendMountCoords(ra, dec, "TRACK"))
     {
         LOGF_ERROR("Multi-Point Alignment: failed to send Goto for point %zu/%zu (RA %.4fh, DEC %.4f deg).",
@@ -1818,10 +2033,22 @@ bool PiFinderMountBridge::ISNewSwitch(const char *dev, const char *name, ISState
 
             if (wantSync || wantGoto)
             {
+                // #227 follow-up (2026-08-19/20): same atomic fresh-CAM-
+                // solve requirement as every automatic action - a manual
+                // trigger is still a real Sync/Goto to the mount and must
+                // not act on a stale/IMU-interpolated position just because
+                // a human clicked the button. Previously used the plain
+                // (non-atomic, no freshness/source check at all)
+                // getPiFinderRADE() - this manual path had none of the
+                // protection the automatic paths already had.
                 double piRA, piDec;
-                if (!m_client->isReady() || !m_client->getPiFinderRADE(piRA, piDec))
+                const bool haveFreshCamPosition =
+                    m_client->isReady() &&
+                    (httpGetPiFinderFreshCamPosition("http://127.0.0.1/api/status", SolveFreshnessMaxAgeN[0].value, piRA, piDec) ||
+                     httpGetPiFinderFreshCamPosition("http://127.0.0.1:8080/api/status", SolveFreshnessMaxAgeN[0].value, piRA, piDec));
+                if (!haveFreshCamPosition)
                 {
-                    LOG_ERROR("Not ready - PiFinder or mount device/properties not available yet.");
+                    LOG_ERROR("Not ready, or no fresh PiFinder camera solve available - not sending a manual correction off a guess.");
                     ManualTriggerSP.s = IPS_ALERT;
                 }
                 else

--- a/indi_pifinder_bridge/pifinder_mount_bridge.h
+++ b/indi_pifinder_bridge/pifinder_mount_bridge.h
@@ -55,6 +55,13 @@ class PiFinderMountBridge : public INDI::DefaultDevice
         void syncMountTypeToPiFinder();
         std::string m_lastSyncedMountType;
 
+        // Tells PiFinder to stay awake (see PiFinder's /api/keep_awake) -
+        // called every tick from handleGotoForward() itself, so it's
+        // automatically scoped to exactly when Goto-Forward is active, never
+        // running (and never needlessly draining PiFinder's battery) in any
+        // other coupling mode. See #227 follow-up (2026-08-19).
+        void keepPiFinderAwake();
+
         std::unique_ptr<PiFinderBridgeClient> m_client;
 
         // ISGetProperties() fires once per client connection (every
@@ -137,6 +144,21 @@ class PiFinderMountBridge : public INDI::DefaultDevice
         // warning if it happens again). See PiFinderBridgeClient::
         // retryMissingPropertiesIfNeeded()/bindingGaveUp().
         bool m_bindingGiveUpLogged = false;
+
+        // #227 follow-up (2026-08-19, user-requested): whatever position the
+        // mount reports right after Connect() (its own idea of "where it is"
+        // from before this session, or a hardware default) is exactly as
+        // untrustworthy as the pre-Goto case syncMountToPiFinderPosition()
+        // already fixes - found live: right after a driver reconnect, drift
+        // was already >120' (over MaxSyncDriftNP), which would otherwise
+        // just sit unfixed in HOLDING forever, same deadlock as before but
+        // at connect-time instead of Goto-time. Reset to false in Connect();
+        // TimerHit() performs exactly one unconditional Sync from PiFinder's
+        // position as soon as isReady() and a fresh solve are both true, for
+        // BridgeModeS that are allowed to actively command the mount
+        // (Auto-correct, Goto-Forward) - never for Verify-Alert/Off, which
+        // must never move/Sync the mount at all.
+        bool m_didInitialSync = false;
 
         // Mode-Readiness-Check (2026-08-08, User request): runs whenever a
         // Coupling mode other than Off is (re-)selected. Verifies known
@@ -296,21 +318,49 @@ class PiFinderMountBridge : public INDI::DefaultDevice
         INumberVectorProperty MaxSyncDriftNP;
         INumber MaxSyncDriftN[1];
 
-        // Graduated slew rate for correction Gotos (2026-08-08): sending
-        // every correction at whatever rate happens to be currently
-        // selected on the mount (found live: "Half-Max") risks overshoot -
-        // real handsets have long used slower "Guide/Center" rates
-        // specifically for fine centering, only using fast rates for big
-        // slews (see basic-memory pifinder-stellarmate for the KStars/Ekos
-        // Align research this mirrors). Picks by INDEX POSITION in
-        // whatever TELESCOPE_SLEW_RATE list the mount reports (same
+        // Graduated slew rate for correction Gotos (2026-08-08, regraded
+        // 2026-08-19): sending every correction at whatever rate happens to
+        // be currently selected on the mount (found live: "Half-Max") risks
+        // overshoot - real handsets have long used slower "Guide/Center"
+        // rates specifically for fine centering, only using fast rates for
+        // big slews (see basic-memory pifinder-stellarmate for the
+        // KStars/Ekos Align research this mirrors). Picks by INDEX POSITION
+        // in whatever TELESCOPE_SLEW_RATE list the mount reports (same
         // mount-agnostic philosophy as getMountType() - never assumes a
-        // specific driver's item names/count). Deliberately fixed
-        // constants, not a GUI-configurable property, to avoid scope
-        // creep - can become tunable later if needed.
-        static constexpr double SLEW_RATE_FAR_THRESHOLD_ARCMIN = 30.0;
-        static constexpr double SLEW_RATE_CLOSE_THRESHOLD_ARCMIN = 3.0;
+        // specific driver's item names/count).
+        //
+        // Originally a fixed 3-bucket (slow/medium/fast) scheme - found live
+        // (2026-08-19, first real Goto-Forward test against a correctly-
+        // detected Alt/Az OnStep mount, see #227) that 3 buckets waste most
+        // of a mount's actual rate ladder (OnStep exposes 10 steps) and,
+        // combined with the old "no pre-Goto Sync" bug below, contributed to
+        // large, uncorrected residuals. Now interpolates LOGARITHMICALLY
+        // across the mount's *entire* available rate count between these two
+        // endpoints - drift can plausibly range from sub-arcminute (fine
+        // HOLDING correction) to several hundred degrees (an unaligned
+        // mount's very first Goto), and a log scale gives sensible
+        // resolution across that whole range instead of only at the low end.
+        static constexpr double SLEW_RATE_LOG_MIN_ARCMIN = 0.5;
+        static constexpr double SLEW_RATE_LOG_MAX_ARCMIN = 21600.0; // 360 deg
         void applySlewRateForDrift(double driftArcmin);
+
+        // Root-cause fix for #227's real-sky Goto-Forward failure
+        // (2026-08-19): every path that forwards a *new* target Goto to the
+        // mount used to send it unconditionally, trusting whatever internal
+        // model the mount already had - fine for an already-aligned mount,
+        // but the very first real Goto against a freshly-correctly-detected
+        // Alt/Az OnStep mount (no prior alignment reference at all) landed
+        // many degrees off, and MaxSyncDriftNP's outlier-solve heuristic
+        // then refused to correct it, since a residual that large looked
+        // indistinguishable from a bad solve. Fix: ALWAYS Sync the mount to
+        // PiFinder's current (not target) position immediately before
+        // computing/sending a new Goto - this corrects the mount's model
+        // from ground truth right before it computes the slew vector, so
+        // the arrival residual reflects the mount's real pointing accuracy
+        // instead of compounding an unknown, possibly huge, pre-existing
+        // model error. Returns false (and forwards nothing) if PiFinder has
+        // no fresh solve to sync from yet - never skip the sync silently.
+        bool syncMountToPiFinderPosition();
 
         // Auto-correct only fires off a position PiFinder itself reports as
         // a real, recent camera solve (via /api/status - see #79/#107 in
@@ -345,6 +395,15 @@ class PiFinderMountBridge : public INDI::DefaultDevice
         ForwardState m_forwardState = ForwardState::IDLE;
         double m_lastForwardedRA = std::nan("");
         double m_lastForwardedDec = std::nan("");
+
+        // A genuinely new target event (consumePiFinderTargetPending()) was
+        // seen, but syncMountToPiFinderPosition() couldn't run yet (no fresh
+        // PiFinder solve at that exact tick) - remember the intent and keep
+        // retrying the sync every tick, using whatever target is *currently*
+        // selected (getPiFinderTargetRADE() is non-consuming), instead of
+        // silently dropping the user's target selection because one tick
+        // was unlucky. Cleared once the sync succeeds and the Goto fires.
+        bool m_forwardAwaitingSync = false;
         int m_settleTicksRemaining = 0;
         static constexpr int SETTLE_TICKS = 3; // poll cycles to wait before even checking for a fresh solve
 


### PR DESCRIPTION
## Kontext

Erstes echtes GoTo-Testing heute Nacht gegen die seit #227 korrekt als
Alt/Az erkannte OnStep-Mount. Mehrere echte, live gefundene Bugs im
`GOTO_FORWARD`-Pfad behoben - aber **GoTo-Forward ist danach immer noch
nicht zuverlässig genug für den produktiven Einsatz**. Dieser PR sichert
den Zwischenstand, keine Behauptung von "fertig".

## Behoben

- **Sync-vor-Goto fehlte komplett**: IDLE/HOLDING gaben ein neues Ziel
  bisher blind an die Mount weiter, ohne vorher deren Modell mit
  PiFinders aktueller Position zu korrigieren.
- **Fehlte auch nach Connect()**: neuer einmaliger Connect-Time-Sync für
  AUTO_CORRECT/GOTO_FORWARD.
- **Kritischer eigener Folgefehler, live gefunden**: die neue Positions-
  Quelle (PiFinders `/api/status`) liefert RA in Grad, nicht in Stunden
  wie die bisherige LX200-Quelle - führte zu einem echten Runaway
  Richtung Horizont. Gefixt an der Quelle.
- **Race Condition**: Solve-Frische-Check und Positions-Lesen liefen in
  zwei getrennten Aufrufen - dazwischen konnte PiFinder per IMU
  weiterinterpoliert haben. Jetzt eine atomare Abfrage.
- **Slew-Rate**: von 3 festen Stufen auf logarithmische Interpolation
  über die volle Stufenleiter der Mount.
- **Keep-Awake**: GOTO_FORWARD hält PiFinder jetzt aktiv wach (neuer
  `/api/keep_awake`), sonst schlief PiFinder mangels Bewegung ein und
  die Solve-Kadenz brach ein - Deadlock (kein GoTo ohne frischen Solve,
  kein frischer Solve ohne Wachsein, kein Wachsein ohne Bewegung).

## Weiterhin offen (Folge-Issues folgen)

- `HOLDING` verfolgt nach einem Reconnect ein u.U. Stunden altes,
  vergessenes PiFinder-Ziel statt der aktuellen Position.
- `BRIDGE_MODE=Off` stoppt keine bereits laufende Mount-Bewegung - nur
  ein echtes `TELESCOPE_ABORT_MOTION` tut das.
- Trotz visuell bestätigtem Pinpoint-Pointing (Okular, Mizar) zeigt
  `DRIFT_ARCMIN` weiterhin ~17' Rest-Differenz in Verify/Alert (reine
  Beobachtung). Ursache ungeklärt - Epochen-Mismatch (J2000 vs JNow)
  als Hypothese durch Live-Zahlen nicht bestätigt.

Refs #227