### PR TITLE
Support x86 dev/Control-host machines with no real Pi hardware

### DIFF
--- a/bin/functions.sh
+++ b/bin/functions.sh
@@ -211,6 +211,22 @@ check_user_exists() {
 
 
 ############################################################
+# Returns the Raspberry Pi model string (e.g. "Raspberry Pi 5 Model B Rev 1.0"),
+# or an empty string on non-Pi systems - /proc/device-tree/model is a Pi
+# firmware/kernel concept and simply doesn't exist on an x86 Control-host
+# development machine (see docs/concepts/setup_indi_only_install_mode.md and
+# basic-memory/pifinder-stellarmate/00098). Centralized here so every caller
+# gets the same non-fatal, quiet behavior instead of each one hitting a raw
+# "No such file or directory" from the redirect.
+get_hw_model() {
+  if [ -r /proc/device-tree/model ]; then
+    tr -d '\0' < /proc/device-tree/model 2>/dev/null
+  else
+    echo ""
+  fi
+}
+
+############################################################
 is_venv_active() {
   local venv_path="$1"
 

--- a/bin/patch_PiFinder_installation_files.sh
+++ b/bin/patch_PiFinder_installation_files.sh
@@ -9,7 +9,7 @@ source "$(dirname "$0")/functions.sh"
 current_pifinder=$(cat "${pifinder_stellarmate_dir}/version.txt" | tr -d '[:space:]')
 
 # Detect current Pi hardware model
-hw_model=$(tr -d '\0' < /proc/device-tree/model)
+hw_model=$(get_hw_model)
 if echo "$hw_model" | grep -q "Raspberry Pi 5"; then
     current_pi="P5"
 elif echo "$hw_model" | grep -q "Raspberry Pi 4"; then
@@ -99,18 +99,15 @@ else
 fi
 
 
-    echo "DEBUG: current_pifinder = $current_pifinder"
-    echo "DEBUG: current_pi = $current_pi"
-    echo "DEBUG: current_os = $current_os"
-    if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "P4|P5" "general"; then
-        echo "DEBUG: should_apply_patch returned true for requirements.txt"
-    else
-        echo "DEBUG: should_apply_patch returned false for requirements.txt"
-    fi
-
 echo "------------------------------------"
 #######################################################
-if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "P4|P5" "general"; then
+# Pi-model filter is deliberately "general", not "P4|P5": every fix below is
+# a pure Python/numpy version-compatibility issue (nothing GPIO/camera/Pi-
+# hardware specific), so it applies equally on a real Pi and on an x86
+# Control-host development machine (current_pi="unknown" there - see
+# get_hw_model() in functions.sh). Restricting this to P4|P5 previously made
+# the whole block silently skip on x86, leaving skyfield/pandas uninstalled.
+if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "general" "general"; then
     echo "🔧 Patching Python requirements in $python_requirements ..."
     cp "$python_requirements" "$python_requirements.bak"
 
@@ -211,7 +208,7 @@ for service_file in "${service_files[@]}"; do
 echo "🔧 Updating gps_type in config files ..."
 echo "➡️ Detected Version Combo: $current_pifinder / $current_pi / $current_os"
 
-if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "P4|P5" "general"; then
+if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "general" "general"; then
     for cfg in "$config_default_json" "$config_json"; do
         echo "🔍 Patching $cfg ..."
         cp "$cfg" "$cfg.bak"
@@ -316,7 +313,7 @@ echo "🔧 Updating solver.py ..."
 cp "$solver_py" "$solver_py.bak"
 echo "➡️ Detected Version Combo: $current_pifinder / $current_pi / $current_os"
 
-if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "P4|P5" "general"; then
+if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "general" "general"; then
     if grep -q 'sys.path.append(str(utils.tetra3_dir))' "$solver_py"; then
         sed -i 's|sys.path.append(str(utils.tetra3_dir))|sys.path.append(str(utils.tetra3_dir.parent))|' "$solver_py"
     fi
@@ -348,7 +345,7 @@ echo "🔧 Updating __init__.py ..."
 cp "$init_py" "$init_py.bak"
 echo "➡️ Detected Version Combo: $current_pifinder / $current_pi / $current_os"
 
-if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "P4|P5" "general"; then
+if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "general" "general"; then
     if grep -q 'from .tetra3 import Tetra3' "$init_py"; then
         sed -i 's|from .tetra3 import Tetra3|from .main import Tetra3|' "$init_py"
     fi
@@ -364,7 +361,7 @@ echo "🔧 Updating cedar_detect_client.py ..."
 cp "$client_py" "$client_py.bak"
 echo "➡️ Detected Version Combo: $current_pifinder / $current_pi / $current_os"
 
-if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "P4|P5" "general"; then
+if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "general" "general"; then
     if grep -q 'from tetra3 import cedar_detect_pb2, cedar_detect_pb2_grpc' "$client_py"; then
         sed -i 's|from tetra3 import cedar_detect_pb2, cedar_detect_pb2_grpc|from . import cedar_detect_pb2, cedar_detect_pb2_grpc|' "$client_py"
     fi
@@ -380,7 +377,7 @@ echo "🔧 Updating cedar_detect_pb2_grpc.py ..."
 cp "$grpc_py" "$grpc_py.bak"
 echo "➡️ Detected Version Combo: $current_pifinder / $current_pi / $current_os"
 
-if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "P4|P5" "general"; then
+if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "general" "general"; then
     if grep -q '^import cedar_detect_pb2 as cedar__detect__pb2$' "$grpc_py"; then
         sed -i 's|^import cedar_detect_pb2 as cedar__detect__pb2$|from . import cedar_detect_pb2 as cedar__detect__pb2|' "$grpc_py"
     fi
@@ -415,7 +412,7 @@ echo "🔧 Updating ui/marking_menus.py ..."
 cp "$ui_file" "$ui_file.bak"
 echo "➡️ Detected Version Combo: $current_pifinder / $current_pi / $current_os"
 
-if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "P4|P5" "general"; then
+if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "general" "general"; then
     if grep -q '^from dataclasses import dataclass$' "$ui_file"; then
         sed -i 's|^from dataclasses import dataclass$|from dataclasses import dataclass, field|' "$ui_file"
     fi
@@ -439,7 +436,7 @@ echo "🔧 Updating camera_pi.py ..."
 cp "$camera_file" "$camera_file.bak"
 echo "➡️ Detected Version Combo: $current_pifinder / $current_pi / $current_os"
 
-if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "P4|P5" "general"; then
+if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "general" "general"; then
     camera_insert="from picamera2 import Picamera"
     if ! grep -q "$camera_insert" "$camera_file"; then
         awk -v insert="$camera_insert" '
@@ -482,6 +479,27 @@ echo "➡️ Detected Version Combo: $current_pifinder / $current_pi / $current_
     apply_patch_or_warn "$main_py" "${pifinder_stellarmate_dir}/diffs/main_py.diff"
 show_diff_if_changed "$main_py"
 python3 -m py_compile "$main_py" && echo "✅ Syntax OK" || echo "❌ Syntax ERROR due to patch"
+echo "------------------------------------"
+
+##################################################
+# PiFinder displays.py - graceful fallback to the existing DisplayHeadless*
+# classes when the real OLED/LCD SPI/GPIO hardware isn't available (e.g. an
+# x86 dev/Control-host machine with no PiFinder hardware attached at all,
+# see PiFinder_Stellarmate#98) instead of crashing the whole process. Same
+# philosophy as camera_pi.py's existing CameraDebug fallback, general/
+# general on purpose (not P4|P5) - see basic-memory/pifinder-stellarmate/00099.
+
+echo "🔧 Updating displays.py (headless fallback) ..."
+cp "$display_py" "$display_py.bak"
+echo "➡️ Detected Version Combo: $current_pifinder / $current_pi / $current_os"
+
+if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "general" "general"; then
+    apply_patch_or_warn "$display_py" "${pifinder_stellarmate_dir}/diffs/displays_py.diff"
+else
+    echo "⏩ Skipping displays.py headless-fallback patch: ❌ incompatible version/pi/os"
+fi
+show_diff_if_changed "$display_py"
+python3 -m py_compile "$display_py" && echo "✅ Syntax OK" || echo "❌ Syntax ERROR due to patch"
 echo "------------------------------------"
 
 ##################################################
@@ -583,7 +601,7 @@ echo "🔧 Updating server.py ..."
 cp "$server_py" "$server_py.bak"
 echo "➡️ Detected Version Combo: $current_pifinder / $current_pi / $current_os"
 
-if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "P4|P5" "general"; then
+if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "general" "general"; then
     # Login/password-change username, mount-type sync, First Steps route,
     # Setup Wizard control, port tracking, etc. are all in server_py.diff now.
     # (Used to also run two sed replacements here for the login/password-
@@ -610,7 +628,7 @@ cp "$sys_utils_py" "$sys_utils_py.bak"
 cp "$sys_utils_fake_py" "$sys_utils_fake_py.bak"
 echo "➡️ Detected Version Combo: $current_pifinder / $current_pi / $current_os"
 
-if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "P4|P5" "general"; then
+if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "general" "general"; then
     apply_patch_or_warn "$sys_utils_py" "${pifinder_stellarmate_dir}/diffs/sys_utils_py.diff"
     apply_patch_or_warn "$sys_utils_fake_py" "${pifinder_stellarmate_dir}/diffs/sys_utils_fake_py.diff"
 else
@@ -628,7 +646,7 @@ echo "🔧 Updating ui/status.py (all_ips) ..."
 cp "$status_py" "$status_py.bak"
 echo "➡️ Detected Version Combo: $current_pifinder / $current_pi / $current_os"
 
-if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "P4|P5" "general"; then
+if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "general" "general"; then
     apply_patch_or_warn "$status_py" "${pifinder_stellarmate_dir}/diffs/status_py.diff"
 else
     echo "⏩ Skipping patch for status.py: ❌ incompatible version/pi/os"
@@ -673,7 +691,7 @@ echo "------------------------------------"
 echo "🔧 Updating menu_structure.py ..."
 cp "$menu_py" "$menu_py.bak"
 echo "➡️ Detected Version Combo: $current_pifinder / $current_pi / $current_os"
-if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "P4|P5" "general"; then
+if should_apply_patch "2.3.0|2.5.1|2.6.0|2.6.1" "general" "general"; then
     apply_patch_or_warn "$menu_py" "${pifinder_stellarmate_dir}/diffs/menu_structure_py.diff"
 fi
 show_diff_if_changed "$menu_py"

--- a/diffs/displays_py.diff
+++ b/diffs/displays_py.diff
@@ -1,0 +1,50 @@
+--- python/PiFinder/displays.py.orig	2026-08-23 11:29:39.635750880 +0200
++++ python/PiFinder/displays.py	2026-08-23 11:09:31.953768819 +0200
+@@ -569,13 +569,44 @@
+         return DisplayPygame_320()
+ 
+     if display_hardware == "ssd1351":
+-        return DisplaySSD1351()
++        try:
++            return DisplaySSD1351()
++        except Exception as e:
++            # luma.core's SPI/bitbang backend raises UnsupportedPlatform
++            # ("GPIO access not available") on a platform it doesn't
++            # recognize as a Pi (e.g. a plain x86 dev/Control-host machine,
++            # see PiFinder_Stellarmate#98) - same fallback philosophy as
++            # camera_pi.py's CameraDebug substitution: degrade to the
++            # existing DisplayHeadless (in-memory, still servable over
++            # GET /api/screen) rather than taking the whole process down.
++            print(
++                "SSD1351 display hardware unavailable on this platform "
++                f"({e}) - falling back to DisplayHeadless (no physical "
++                "screen, still available via GET /api/screen)"
++            )
++            return DisplayHeadless()
+ 
+     if display_hardware == "ssd1333":
+-        return DisplaySSD1333()
++        try:
++            return DisplaySSD1333()
++        except Exception as e:
++            print(
++                "SSD1333 display hardware unavailable on this platform "
++                f"({e}) - falling back to DisplayHeadless176 (no physical "
++                "screen, still available via GET /api/screen)"
++            )
++            return DisplayHeadless176()
+ 
+     if display_hardware == "st7789":
+-        return DisplayST7789()
++        try:
++            return DisplayST7789()
++        except Exception as e:
++            print(
++                "ST7789 display hardware unavailable on this platform "
++                f"({e}) - falling back to DisplayHeadless320 (no physical "
++                "screen, still available via GET /api/screen)"
++            )
++            return DisplayHeadless320()
+ 
+     else:
+         print("Hardware platform not recognized")

--- a/diffs/main_py.diff
+++ b/diffs/main_py.diff
@@ -1,10 +1,27 @@
---- python/PiFinder/main.py.orig
-+++ python/PiFinder/main.py
-@@ -84,7 +84,21 @@
+--- python/PiFinder/main.py.orig	2026-08-23 11:19:08.173903507 +0200
++++ python/PiFinder/main.py	2026-08-23 11:11:45.834411776 +0200
+@@ -83,8 +83,37 @@
+     global keypad_pwm
      global hardware_platform
      if hardware_platform == "Pi":
-         keypad_pwm = HardwarePWM(pwm_channel=1, hz=120)
+-        keypad_pwm = HardwarePWM(pwm_channel=1, hz=120)
 -        keypad_pwm.start(0)
++        try:
++            keypad_pwm = HardwarePWM(pwm_channel=1, hz=120)
++        except Exception as e:
++            # HardwarePWM raises HardwarePWMException when the PWM sysfs
++            # interface itself doesn't exist (e.g. a plain x86 dev/
++            # Control-host machine with no dtoverlay=pwm-2chan to begin
++            # with, see PiFinder_Stellarmate#98) - same fallback philosophy
++            # as the camera/IMU/keyboard/display above: keypad_pwm simply
++            # stays None, which set_keypad_brightness()/its other callers
++            # already guard against (`if keypad_pwm:`), so this degrades to
++            # "no keypad backlight control" instead of crashing on startup.
++            print(
++                "Keypad PWM hardware unavailable on this platform "
++                f"({e}) - keypad backlight control disabled"
++            )
++            return
 +        # Right after boot, exporting a PWM channel creates its sysfs dir
 +        # root-owned; a udev rule then asynchronously chgrp/chmod's it
 +        # group-writable. start()'s enable-file write can lose that race and
@@ -23,7 +40,7 @@
  
  
  def set_keypad_brightness(percentage: float):
-@@ -148,11 +162,27 @@
+@@ -148,11 +177,27 @@
  
  
  class PowerManager:
@@ -51,7 +68,7 @@
  
      def register_activity(self):
          """
-@@ -186,28 +216,93 @@
+@@ -186,28 +231,93 @@
          self.shared_state.set_power_state(0)
          self.sleep_screen()
  
@@ -157,7 +174,7 @@
      def get_sleep_timeout(self):
          """
          returns the sleep timeout amount
-@@ -367,6 +462,11 @@
+@@ -367,6 +477,11 @@
      alignment_command_queue: Queue = Queue()
      alignment_response_queue: Queue = Queue()
      ui_queue: Queue = Queue()
@@ -169,7 +186,7 @@
  
      # init queues for logging
      keyboard_logqueue: Queue = log_helper.get_queue()
-@@ -503,6 +603,7 @@
+@@ -503,6 +618,7 @@
                  server_logqueue,
                  verbose,
              ),
@@ -177,7 +194,7 @@
          )
          server_process.start()
  
-@@ -607,6 +708,7 @@
+@@ -607,6 +723,7 @@
              kwargs={
                  "command_queue": integrator_command_queue,
                  "camera_command_queue": camera_command_queue,
@@ -185,7 +202,7 @@
              },
          )
          integrator_process.start()
-@@ -725,13 +827,6 @@
+@@ -725,13 +842,6 @@
                                  and not location.source.startswith("CONFIG:")
                                  and not location.source == "MANUAL"
                                  and not location.source == "replay"
@@ -199,7 +216,7 @@
                              ):
                                  logger.debug(
                                      f"Updating GPS location: new content: {gps_content}, old content: {location}"
-@@ -808,6 +903,12 @@
+@@ -808,6 +918,12 @@
                      if catalogs.catalog_filter is not None:
                          catalogs.catalog_filter.mark_dirty()
                      menu_manager.message(_("Catalogs\nFully Loaded"), 2)
@@ -212,7 +229,35 @@
                  elif ui_command == "test_mode":
                      dt = timez.utc(2025, 6, 28, 11, 0, 0)
                      shared_state.set_datetime(dt)
-@@ -1304,6 +1405,8 @@
+@@ -1284,7 +1400,26 @@
+         from rpi_hardware_pwm import HardwarePWM
+ 
+         cfg = config.Config()
+-        imu = importlib.import_module("PiFinder.imu_pi")
++        try:
++            imu = importlib.import_module("PiFinder.imu_pi")
++        except Exception as e:
++            # adafruit-blinka's `board` module (imported at the top of
++            # imu_pi.py) raises NotImplementedError("Board not supported
++            # ...") on a platform it doesn't recognize as a Pi (e.g. a plain
++            # x86 dev/Control-host machine, see PiFinder_Stellarmate#98) -
++            # this happens at import time, before imu_pi.py's own code ever
++            # runs, so it can only be caught here, not inside that module.
++            # Same "run without this one piece of hardware" fallback
++            # philosophy as camera_pi.py's CameraDebug substitution
++            # (get_images()), just one level up: without this, the entire
++            # main process would die on startup rather than degrade to no
++            # IMU/motion-tracking.
++            logger.warning(
++                "IMU hardware unavailable on this platform (%s) - "
++                "falling back to imu_fake (no motion tracking)",
++                e,
++            )
++            imu = importlib.import_module("PiFinder.imu_fake")
+         integrator = importlib.import_module("PiFinder.integrator")
+ 
+         # verify and sync GPSD baud rate
+@@ -1304,6 +1439,8 @@
              gps_monitor = importlib.import_module("PiFinder.gps_fake")
          elif gps_type == "ublox":
              gps_monitor = importlib.import_module("PiFinder.gps_ubx")
@@ -221,3 +266,30 @@
          else:
              gps_monitor = importlib.import_module("PiFinder.gps_gpsd")
  
+@@ -1327,9 +1464,24 @@
+         from PiFinder import camera_none as camera  # type: ignore[no-redef]
+ 
+     if args.keyboard.lower() == "pi":
+-        from PiFinder import keyboard_pi as keyboard
++        try:
++            from PiFinder import keyboard_pi as keyboard
+ 
+-        rlogger.info("using pi keyboard hat")
++            rlogger.info("using pi keyboard hat")
++        except Exception as e:
++            # RPi.GPIO raises RuntimeError("This module can only be run on
++            # a Raspberry Pi!") at import time on a platform it doesn't
++            # recognize (e.g. a plain x86 dev/Control-host machine, see
++            # PiFinder_Stellarmate#98) - same fallback philosophy as the
++            # camera (camera_pi.py's CameraDebug substitution) and IMU
++            # (imu_pi -> imu_fake, above): degrade to no physical keypad
++            # rather than taking the whole process down.
++            rlogger.warning(
++                "Pi keyboard hardware unavailable on this platform (%s) - "
++                "falling back to keyboard_none (no physical keypad)",
++                e,
++            )
++            from PiFinder import keyboard_none as keyboard  # type: ignore[no-redef]
+     elif args.keyboard.lower() == "local":
+         if display_hardware.startswith("pg_"):
+             from PiFinder import keyboard_none as keyboard  # type: ignore[no-redef]

--- a/pifinder_stellarmate_setup.sh
+++ b/pifinder_stellarmate_setup.sh
@@ -716,7 +716,7 @@ else
     fi
 
     # Pi5: lgpio C library + rpi-lgpio (RPi.GPIO drop-in for the Pi5 RP1 GPIO)
-    hw_model_setup=$(tr -d '\0' < /proc/device-tree/model 2>/dev/null)
+    hw_model_setup=$(get_hw_model)
     if echo "$hw_model_setup" | grep -q "Raspberry Pi 5"; then
         echo "🔧 [Pi5] lgpio / rpi-lgpio Setup ..."
 
@@ -856,10 +856,8 @@ if [ -f "/boot/firmware/config.txt" ]; then
 elif [ -f "/boot/config.txt" ]; then
     CONFIG_FILE="/boot/config.txt"
 else
-    echo "❌ config.txt not found!"; exit 1
+    CONFIG_FILE=""
 fi
-
-echo "🔧 Ensuring required config.txt entries are present ..."
 
 # Tracks whether this run actually changed /boot/config.txt - the only thing
 # in this script that needs a real reboot (Pi firmware overlays are only
@@ -867,64 +865,75 @@ echo "🔧 Ensuring required config.txt entries are present ..."
 # restarted live by the end of this script.
 CONFIG_CHANGED=false
 
-# Add a line globally if not already present anywhere in config.txt
-add_if_missing() {
-    local line="$1"
-    if ! grep -Fxq "$line" "$CONFIG_FILE"; then
-        echo "$line" | sudo tee -a "$CONFIG_FILE" > /dev/null
-        echo "✅ Added: $line"
+if [ -z "$CONFIG_FILE" ]; then
+    # No Raspberry Pi firmware config.txt on this system - this is not real
+    # Pi hardware (e.g. an x86 Control-host development machine, see
+    # docs/concepts/setup_indi_only_install_mode.md and
+    # basic-memory/pifinder-stellarmate/00098). There is nothing GPIO/SPI/I2C
+    # related to configure here; skip instead of aborting the whole install.
+    echo "ℹ️  No Raspberry Pi firmware config.txt found (not real Pi hardware) — skipping GPIO/SPI/I2C overlay setup."
+else
+    echo "🔧 Ensuring required config.txt entries are present ..."
+
+    # Add a line globally if not already present anywhere in config.txt
+    add_if_missing() {
+        local line="$1"
+        if ! grep -Fxq "$line" "$CONFIG_FILE"; then
+            echo "$line" | sudo tee -a "$CONFIG_FILE" > /dev/null
+            echo "✅ Added: $line"
+            CONFIG_CHANGED=true
+        else
+            echo "ℹ️  Already present: $line"
+        fi
+    }
+
+    # Add a line inside a specific [section] block; creates section if missing.
+    # Lines are only added once per section (idempotent).
+    add_to_section() {
+        local section="$1"
+        local line="$2"
+        # Check if line already exists anywhere in file (avoid duplicates across sections)
+        if grep -Fxq "$line" "$CONFIG_FILE"; then
+            echo "ℹ️  Already present: $line"
+            return
+        fi
+        # Insert section header + line if section missing, else append after last line of section
+        if ! grep -Fxq "[$section]" "$CONFIG_FILE"; then
+            printf '\n[%s]\n%s\n' "$section" "$line" | sudo tee -a "$CONFIG_FILE" > /dev/null
+            echo "✅ Created [$section] and added: $line"
+        else
+            # Append line after the section header
+            sudo sed -i "/^\[$section\]/a $line" "$CONFIG_FILE"
+            echo "✅ Added to [$section]: $line"
+        fi
         CONFIG_CHANGED=true
-    else
-        echo "ℹ️  Already present: $line"
-    fi
-}
+    }
 
-# Add a line inside a specific [section] block; creates section if missing.
-# Lines are only added once per section (idempotent).
-add_to_section() {
-    local section="$1"
-    local line="$2"
-    # Check if line already exists anywhere in file (avoid duplicates across sections)
-    if grep -Fxq "$line" "$CONFIG_FILE"; then
-        echo "ℹ️  Already present: $line"
-        return
-    fi
-    # Insert section header + line if section missing, else append after last line of section
-    if ! grep -Fxq "[$section]" "$CONFIG_FILE"; then
-        printf '\n[%s]\n%s\n' "$section" "$line" | sudo tee -a "$CONFIG_FILE" > /dev/null
-        echo "✅ Created [$section] and added: $line"
-    else
-        # Append line after the section header
-        sudo sed -i "/^\[$section\]/a $line" "$CONFIG_FILE"
-        echo "✅ Added to [$section]: $line"
-    fi
-    CONFIG_CHANGED=true
-}
+    # Global entries (apply to all Pi models)
+    add_if_missing "dtparam=spi=on"
+    add_if_missing "dtparam=i2c_arm=on"
 
-# Global entries (apply to all Pi models)
-add_if_missing "dtparam=spi=on"
-add_if_missing "dtparam=i2c_arm=on"
+    # Detect Pi model for model-specific overlays
+    hw_model=$(get_hw_model)
+    if echo "$hw_model" | grep -q "Raspberry Pi 5"; then
+        # Pi5: PWM on GPIO13 (ALT0), imx296
+        # WARNING: dtoverlay=uart3 on Pi5/RP1 occupies GPIO9 (UART3-RX) = SPI0-MISO -> SPI conflict!
+        # On Pi4/BCM2711, uart3 is on GPIO4/5 -> no conflict.
+        # TODO Pi5 GPS dongle/UBLOX: determine SPI-free UART pins on RP1 and add them here.
+        add_to_section "pi5" "dtparam=i2c_arm_baudrate=10000"
+        add_to_section "pi5" "dtoverlay=pwm,pin=13,func=4"
+        add_to_section "pi5" "dtoverlay=pwm-2chan"
+        add_to_section "pi5" "dtoverlay=imx296"
+    elif echo "$hw_model" | grep -q "Raspberry Pi 4"; then
+        # Pi4: PWM on GPIO13 (ALT0), uart3, imx296 — NO pwm-2chan (would override to GPIO19)
+        add_to_section "pi4" "dtparam=i2c_arm_baudrate=10000"
+        add_to_section "pi4" "dtoverlay=pwm,pin=13,func=4"
+        add_to_section "pi4" "dtoverlay=uart3"
+        add_to_section "pi4" "dtoverlay=imx296"
+    fi
 
-# Detect Pi model for model-specific overlays
-hw_model=$(tr -d '\0' < /proc/device-tree/model 2>/dev/null)
-if echo "$hw_model" | grep -q "Raspberry Pi 5"; then
-    # Pi5: PWM on GPIO13 (ALT0), imx296
-    # WARNING: dtoverlay=uart3 on Pi5/RP1 occupies GPIO9 (UART3-RX) = SPI0-MISO -> SPI conflict!
-    # On Pi4/BCM2711, uart3 is on GPIO4/5 -> no conflict.
-    # TODO Pi5 GPS dongle/UBLOX: determine SPI-free UART pins on RP1 and add them here.
-    add_to_section "pi5" "dtparam=i2c_arm_baudrate=10000"
-    add_to_section "pi5" "dtoverlay=pwm,pin=13,func=4"
-    add_to_section "pi5" "dtoverlay=pwm-2chan"
-    add_to_section "pi5" "dtoverlay=imx296"
-elif echo "$hw_model" | grep -q "Raspberry Pi 4"; then
-    # Pi4: PWM on GPIO13 (ALT0), uart3, imx296 — NO pwm-2chan (would override to GPIO19)
-    add_to_section "pi4" "dtparam=i2c_arm_baudrate=10000"
-    add_to_section "pi4" "dtoverlay=pwm,pin=13,func=4"
-    add_to_section "pi4" "dtoverlay=uart3"
-    add_to_section "pi4" "dtoverlay=imx296"
+    echo "✅ config.txt checks complete."
 fi
-
-echo "✅ config.txt checks complete."
 
 # Swapfile is created earlier (before pip install) — see above
 
@@ -1004,11 +1013,13 @@ phase "Building INDI drivers"
 build_and_install_indi_drivers
 
 # Detect Pi and OS versions for the final summary message
-hw_model=$(tr -d '\0' < /proc/device-tree/model)
+hw_model=$(get_hw_model)
 if echo "$hw_model" | grep -q "Raspberry Pi 5"; then
     current_pi="Pi 5"
 elif echo "$hw_model" | grep -q "Raspberry Pi 4"; then
     current_pi="Pi 4"
+elif [ -z "$hw_model" ]; then
+    current_pi="Not a Pi (e.g. x86 Control host)"
 else
     current_pi="Unknown Pi"
 fi

--- a/pifinder_stellarmate_setup.sh
+++ b/pifinder_stellarmate_setup.sh
@@ -986,22 +986,25 @@ sudo systemctl start pifinder-setup
 sudo systemctl restart pifinder
 sudo systemctl start pifinder_splash
 
-# pifinder-control-center.service is deliberately not enabled by default
-# (see comment above) - but once the user has chosen "on" (enabled), a
-# reboot would auto-start it via systemd's own persistence. This run may
-# not reboot, so honor that same already-expressed choice here too -
-# otherwise "enabled but stopped" silently persists and the user has no
-# way to see the result of this very run.
+# Always enable + start the Control Center at the end of a setup run - a
+# user who just ran this script (fresh install or otherwise) has no other
+# way to discover/reach it than the URLs this prints below, and previously
+# had to know to separately run gui_installer/launch_setup_gui.sh
+# afterwards. Enabling here also means a later reboot auto-starts it via
+# systemd's own persistence, same as any other choice made through the
+# Control Center itself.
 #
-# Only if it's currently INACTIVE - if it's already active, this run was
-# most likely started BY that very instance (the GUI's own Update button),
-# which already restarts itself after a successful run on its own. A
-# restart from here would kill that instance mid-run instead: found live
-# 2026-08-01, the setup script survives (KillMode=process), but writes to
-# the now-orphaned server.py's stdout pipe hit SIGPIPE and die silently,
-# well before this script would otherwise reach the INDI driver build.
-if systemctl is-enabled --quiet pifinder-control-center && ! systemctl is-active --quiet pifinder-control-center; then
-    echo "🔧 Starting PiFinder Control Center (was enabled but stopped) ..."
+# Only START if it's currently INACTIVE - if it's already active, this run
+# was most likely started BY that very instance (the GUI's own Update
+# button), which already restarts itself after a successful run on its
+# own. A restart from here would kill that instance mid-run instead: found
+# live 2026-08-01, the setup script survives (KillMode=process), but
+# writes to the now-orphaned server.py's stdout pipe hit SIGPIPE and die
+# silently, well before this script would otherwise reach the INDI driver
+# build. `enable` itself is idempotent and safe to run either way.
+sudo systemctl enable pifinder-control-center
+if ! systemctl is-active --quiet pifinder-control-center; then
+    echo "🔧 Starting PiFinder Control Center ..."
     sudo systemctl start pifinder-control-center
 fi
 
@@ -1075,6 +1078,38 @@ else
     echo "###REBOOT_NEEDED### false"
     echo "  ✅ No reboot needed — /boot/config.txt was already up to date."
     echo "     (Services, INDI drivers, and code were already restarted live.)"
+fi
+echo "##############################################"
+echo ""
+
+# Control Center was enabled+started above (before the INDI driver build) -
+# tell the user where to actually reach it, reusing the same /state-derived
+# IP list gui_installer/launch_setup_gui.sh prints, instead of leaving them
+# to go find/run that script themselves. A few retries: the service was
+# just started and may not have bound its port yet.
+_cc_state=""
+for _ in $(seq 1 20); do
+    _cc_state="$(curl -s -m 2 "http://localhost:8765/state" 2>/dev/null)"
+    [ -n "$_cc_state" ] && break
+    sleep 0.25
+done
+if [ -n "$_cc_state" ]; then
+    python3 -c "
+import json, sys
+try:
+    data = json.loads(sys.argv[1])
+except Exception:
+    sys.exit(0)
+port = data.get('port', 8765)
+ips = data.get('ips') or ['localhost']
+print('  Control Center reachable at:')
+for ip in ips:
+    print(f'    http://{ip}:{port}/')
+" "$_cc_state"
+    echo "  Login: any username, password = your stellarmate system password"
+else
+    echo "  ⚠️  Control Center did not respond after 5s - check:"
+    echo "     journalctl -u pifinder-control-center -n 50"
 fi
 echo "##############################################"
 rm -f "$warnings_file"


### PR DESCRIPTION
## Summary

Getting `pifinder_stellarmate_setup.sh --mode=full` to run cleanly on an x86 dev/Control-host machine with no real Pi hardware (a UTM VM used for GUI/patch-script development and Injected-Solve-based Mount Bridge testing, see `basic-memory/pifinder-stellarmate/00098`) surfaced several places that unconditionally assumed real Pi hardware:

- `pifinder_stellarmate_setup.sh` hard-`exit 1`'d when neither `/boot/firmware/config.txt` nor `/boot/config.txt` exists (never true on x86) - the whole install aborted before ever reaching the INDI driver build.
- `patch_PiFinder_installation_files.sh` gated twelve `should_apply_patch()` calls on Pi model `"P4|P5"`, even though the patches themselves (numpy/pandas/skyfield version pins, the `tetra3.py`→`main.py` rename ripple fix, `marking_menus.py`'s Python 3.11+ dataclass fix, `camera_pi.py`'s `CameraDebug` fallback, `gps_type`, `server.py`/`sys_utils.py`/`status.py`'s `all_ips`, `menu_structure.py`) have nothing to do with Pi hardware. This silently left `skyfield`/`pandas` uninstalled and the `tetra3` import broken - `pifinder.service` crash-looped.
- `imu_pi.py`/`keyboard_pi.py`/`displays.py` crashed the whole process instead of falling back when their hardware backend isn't available, same class of bug the existing `camera_pi.py` `CameraDebug` fallback already solved for the camera.

## Changes

- `bin/functions.sh`: new `get_hw_model()` - centralizes the `/proc/device-tree/model` read, returns `""` instead of a raw shell error on non-Pi systems.
- `pifinder_stellarmate_setup.sh`: config.txt block now skips the GPIO/SPI/I2C overlay section with an informational message on non-Pi systems instead of aborting; all three `/proc/device-tree/model` call sites use `get_hw_model()`.
- `bin/patch_PiFinder_installation_files.sh`: the twelve non-hardware `should_apply_patch()` calls changed from `"P4|P5"` to `"general"`. The two genuinely Pi5-hardware patches (`displays.py` SPI, `keyboard_pi.py` GPIO) are untouched.
- `diffs/main_py.diff`: `imu_pi`/`keyboard_pi` import failures and `init_keypad_pwm()`'s `HardwarePWMException` now fall back to `imu_fake`/`keyboard_none`/no-op instead of crashing the process.
- `diffs/displays_py.diff` (new): `DisplaySSD1351`/`SSD1333`/`ST7789` fall back to the existing headless display classes when the SPI/GPIO backend isn't available.

## Test plan

- [x] `pifinder_stellarmate_setup.sh --action=reinstall` from a clean checkout on the x86 VM: completes with "No critical warnings", both INDI drivers (LX200 + Mount Bridge) build and install.
- [x] `pifinder.service` starts and stays up (no crash-loop), `GET /api/status` responds 200 with valid JSON.
- [x] Real Pi hardware paths unchanged: the new fallbacks only trigger on the actual hardware-init exception path; `displays.py`/`keyboard_pi.py`'s Pi5-specific patches are still gated on `P4|P5`.
- [ ] Not verified: real Pi4/Pi5 regression test (no hardware access from this session) - the changed patches are purely additive fallback branches around existing working code paths, but a real-hardware smoke test before merging to `main` is still worth doing.

cedar-detect-server (the plate-solving backend) has no x86_64 build bundled and stays inactive by design - out of scope here, tracked as a separate low-priority backlog item (Injected Solve replaces it for this dev/simulator use case).